### PR TITLE
Quickfix for #6

### DIFF
--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -110,6 +110,14 @@ begin
     WindowTitle := USDXVersionStr;
 
     Platform.Init;
+    
+    // Commandline Parameter Parser
+    Params := TCMDParams.Create;
+
+    // Log + Benchmark
+    Log := TLog.Create;
+    Log.Title := WindowTitle;
+    //Log.FileOutputEnabled := not Params.NoLog;
 
     if Platform.TerminateIfAlreadyRunning(WindowTitle) then
       Exit;
@@ -139,14 +147,6 @@ begin
 
     USTime := TTime.Create;
     VideoBGTimer := TRelativeTimer.Create;
-
-    // Commandline Parameter Parser
-    Params := TCMDParams.Create;
-
-    // Log + Benchmark
-    Log := TLog.Create;
-    Log.Title := WindowTitle;
-    //Log.FileOutputEnabled := not Params.NoLog;
 
     // Language
     Log.LogStatus('Initialize Paths', 'Initialization');


### PR DESCRIPTION
It looks like when we exit the application if it is already running, we enter the finally block which contains logging. We should initialize logging before that.

Care full **untested**!