### PR TITLE
Re-usable template names hotkeys. Compatibility to Fullscreen switch

### DIFF
--- a/src/menu/UDisplay.pas
+++ b/src/menu/UDisplay.pas
@@ -102,6 +102,10 @@ type
 
       function  Draw: boolean;
 
+      // TODO rewrite ParseInput to include handling/suppressing input as return, use KeepGoing as by-reference
+      { checks if display is handling the passed key in ParseInput. calls HandleInput of cur or next Screen if assigned }
+      function ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown : boolean; out SuppressKey: boolean): boolean;
+
       { calls ParseInput of cur or next Screen if assigned }
       function ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown : boolean): boolean;
 
@@ -603,6 +607,16 @@ begin
       glDisable(GL_TEXTURE_2D);
     end;
   end;
+end;
+
+function TDisplay.ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown : boolean; out SuppressKey: boolean): boolean;
+begin
+  if (assigned(NextScreen)) then
+    Result := NextScreen^.ShouldHandleInput(PressedKey, CharCode, PressedDown, SuppressKey)
+  else if (assigned(CurrentScreen)) then
+    Result := CurrentScreen^.ShouldHandleInput(PressedKey, CharCode, PressedDown, SuppressKey)
+  else
+    Result := True;
 end;
 
 function TDisplay.ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown : boolean): boolean;

--- a/src/menu/UMenu.pas
+++ b/src/menu/UMenu.pas
@@ -149,6 +149,7 @@ type
       function DrawBG: boolean; virtual;
       function DrawFG: boolean; virtual;
       function Draw: boolean; virtual;
+      function ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown : boolean; out SuppressKey: boolean): boolean; virtual;
       function ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown : boolean): boolean; virtual;
       function ParseMouse(MouseButton: integer; BtnDown: boolean; X, Y: integer): boolean; virtual;
       function InRegion(X, Y: real; A: TMouseOverRect): boolean;
@@ -1712,6 +1713,12 @@ procedure TMenu.OnHide;
 begin
   // nothing
   Background.OnFinish;
+end;
+
+function TMenu.ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean; out SuppressKey: boolean): boolean;
+begin
+  // nothing
+  Result := true;
 end;
 
 function TMenu.ParseInput(PressedKey: Cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean;

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -234,6 +234,7 @@ var
   I: integer;
   SDL_ModState: word;
   Col: TRGB;
+  isAlternate: boolean;
 begin
   Result := true;
   if (PressedDown) then
@@ -253,10 +254,12 @@ begin
     end;
 
     // check special keys
+    isAlternate := (SDL_ModState = KMOD_LSHIFT) or (SDL_ModState = KMOD_RSHIFT);
+    isAlternate := isAlternate or (SDL_ModState = KMOD_LALT); // legacy key combination
     case PressedKey of
       // Templates for Names Mod
       SDLK_F1:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[0] := Button[PlayerName].Text[0].Text;
          end
@@ -266,7 +269,7 @@ begin
            PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
          end;
       SDLK_F2:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[1] := Button[PlayerName].Text[0].Text;
          end
@@ -276,7 +279,7 @@ begin
            PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
          end;
       SDLK_F3:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[2] := Button[PlayerName].Text[0].Text;
          end
@@ -286,7 +289,7 @@ begin
            PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
          end;
       SDLK_F4:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[3] := Button[PlayerName].Text[0].Text;
          end
@@ -296,7 +299,7 @@ begin
            PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
          end;
       SDLK_F5:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[4] := Button[PlayerName].Text[0].Text;
          end
@@ -306,7 +309,7 @@ begin
            PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
          end;
       SDLK_F6:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[5] := Button[PlayerName].Text[0].Text;
          end
@@ -316,7 +319,7 @@ begin
            PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
          end;
       SDLK_F7:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[6] := Button[PlayerName].Text[0].Text;
          end
@@ -326,7 +329,7 @@ begin
            PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
          end;
       SDLK_F8:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[7] := Button[PlayerName].Text[0].Text;
          end
@@ -336,7 +339,7 @@ begin
            PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
          end;
       SDLK_F9:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[8] := Button[PlayerName].Text[0].Text;
          end
@@ -346,7 +349,7 @@ begin
            PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
          end;
       SDLK_F10:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[9] := Button[PlayerName].Text[0].Text;
          end
@@ -356,7 +359,7 @@ begin
            PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
          end;
       SDLK_F11:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[10] := Button[PlayerName].Text[0].Text;
          end
@@ -366,7 +369,7 @@ begin
            PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
          end;
       SDLK_F12:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[11] := Button[PlayerName].Text[0].Text;
          end

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -91,6 +91,7 @@ type
       Goto_SingScreen: boolean; //If true then next Screen in SingScreen
       
       constructor Create; override;
+      function ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean; out SuppressKey: boolean): boolean; override;
       function ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean; override;
       function ParseMouse(MouseButton: integer; BtnDown: boolean; X, Y: integer): boolean; override;
 
@@ -228,6 +229,23 @@ begin
 
 end;
 
+function TScreenName.ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean; out SuppressKey: boolean): boolean;
+begin
+  Result := inherited;
+  // only suppress special keys for now
+  case PressedKey of
+    // Templates for Names Mod
+    SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F7, SDLK_F8, SDLK_F9, SDLK_F10, SDLK_F11, SDLK_F12:
+     if (Button[PlayerName].Selected) then
+     begin
+       SuppressKey := true;
+     end
+     else
+     begin
+       Result := false;
+     end;
+  end;
+end;
 
 function TScreenName.ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean;
 var
@@ -243,9 +261,20 @@ begin
     SDL_ModState := SDL_GetModState and (KMOD_LSHIFT + KMOD_RSHIFT
     + KMOD_LCTRL + KMOD_RCTRL + KMOD_LALT  + KMOD_RALT);
 
-    // check normal keys
-    if (Interaction = 3) and (IsPrintableChar(CharCode)) then
+    if (not Button[PlayerName].Selected) then
     begin
+      // check normal keys
+      case UCS4UpperCase(CharCode) of
+        Ord('Q'):
+          begin
+            Result := false;
+            Exit;
+          end;
+      end;
+    end
+    else if (Interaction = 3) and (IsPrintableChar(CharCode)) then
+    begin
+      // pass printable chars to button
       Button[PlayerName].Text[0].Text := Button[PlayerName].Text[0].Text +
                                           UCS4ToUTF8String(CharCode);
 

--- a/src/screens/UScreenPartyPlayer.pas
+++ b/src/screens/UScreenPartyPlayer.pas
@@ -79,6 +79,7 @@ type
       Player12Name: cardinal;
 
       constructor Create; override;
+      function ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean; out SuppressKey: boolean): boolean; override;
       function ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean; override;
       procedure OnShow; override;
       
@@ -210,6 +211,24 @@ begin
     // no mode available for current player setup
     ScreenPopupError.ShowPopup(Language.Translate('ERROR_NO_MODES_FOR_CURRENT_SETUP'));
     Party.Clear;
+  end;
+end;
+
+function TScreenPartyPlayer.ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean; out SuppressKey: boolean): boolean;
+begin
+  Result := inherited;
+  // only suppress special keys for now
+  case PressedKey of
+    // Templates for Names Mod
+    SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F7, SDLK_F8, SDLK_F9, SDLK_F10, SDLK_F11, SDLK_F12:
+     if (Button[Interactions[Interaction].Num].Selected) then
+     begin
+       SuppressKey := true;
+     end
+     else
+     begin
+       Result := false;
+     end;
   end;
 end;
 

--- a/src/screens/UScreenPartyPlayer.pas
+++ b/src/screens/UScreenPartyPlayer.pas
@@ -218,6 +218,7 @@ var
   SDL_ModState:  word;
   Team: integer;
   I: integer;
+  isAlternate: boolean;
   procedure IntNext;
   begin
     repeat
@@ -257,10 +258,12 @@ begin
     end;
 
     // check special keys
+    isAlternate := (SDL_ModState = KMOD_LSHIFT) or (SDL_ModState = KMOD_RSHIFT);
+    isAlternate := isAlternate or (SDL_ModState = KMOD_LALT); // legacy key combination
     case PressedKey of
       // Templates for Names Mod
       SDLK_F1:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[0] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -269,7 +272,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[0];
          end;
       SDLK_F2:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[1] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -278,7 +281,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[1];
          end;
       SDLK_F3:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[2] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -287,7 +290,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[2];
          end;
       SDLK_F4:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[3] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -296,7 +299,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[3];
          end;
       SDLK_F5:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[4] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -305,7 +308,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[4];
          end;
       SDLK_F6:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[5] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -314,7 +317,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[5];
          end;
       SDLK_F7:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[6] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -323,7 +326,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[6];
          end;
       SDLK_F8:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[7] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -332,7 +335,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[7];
          end;
       SDLK_F9:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[8] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -341,7 +344,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[8];
          end;
       SDLK_F10:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[9] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -350,7 +353,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[9];
          end;
       SDLK_F11:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[10] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -359,7 +362,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[10];
          end;
       SDLK_F12:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[11] := Button[Interactions[Interaction].Num].Text[0].Text;
          end

--- a/src/screens/UScreenPartyPlayer.pas
+++ b/src/screens/UScreenPartyPlayer.pas
@@ -395,6 +395,17 @@ begin
           Button[Interactions[Interaction].Num].Text[0].DeleteLastLetter;
         end;
     end;
+  end
+  else
+  begin
+    // check normal keys
+    case UCS4UpperCase(CharCode) of
+      Ord('Q'):
+        begin
+          Result := false;
+          Exit;
+        end;
+    end;
   end;
 
   case PressedKey of

--- a/src/screens/UScreenPartyTournamentPlayer.pas
+++ b/src/screens/UScreenPartyTournamentPlayer.pas
@@ -153,6 +153,7 @@ function TScreenPartyTournamentPlayer.ParseInput(PressedKey: cardinal; CharCode:
 var
   SDL_ModState:  word;
   I:  integer;
+  isAlternate: boolean;
   procedure IntNext;
   begin
     repeat
@@ -192,10 +193,12 @@ begin
     end;
 
     // check special keys
+    isAlternate := (SDL_ModState = KMOD_LSHIFT) or (SDL_ModState = KMOD_RSHIFT);
+    isAlternate := isAlternate or (SDL_ModState = KMOD_LALT); // legacy key combination
     case PressedKey of
       // Templates for Names Mod
       SDLK_F1:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[0] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -204,7 +207,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[0];
          end;
       SDLK_F2:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[1] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -213,7 +216,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[1];
          end;
       SDLK_F3:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[2] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -222,7 +225,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[2];
          end;
       SDLK_F4:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[3] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -231,7 +234,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[3];
          end;
       SDLK_F5:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[4] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -240,7 +243,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[4];
          end;
       SDLK_F6:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[5] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -249,7 +252,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[5];
          end;
       SDLK_F7:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[6] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -258,7 +261,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[6];
          end;
       SDLK_F8:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[7] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -267,7 +270,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[7];
          end;
       SDLK_F9:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[8] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -276,7 +279,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[8];
          end;
       SDLK_F10:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[9] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -285,7 +288,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[9];
          end;
       SDLK_F11:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[10] := Button[Interactions[Interaction].Num].Text[0].Text;
          end
@@ -294,7 +297,7 @@ begin
            Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[10];
          end;
       SDLK_F12:
-       if (SDL_ModState = KMOD_LALT) then
+       if isAlternate then
          begin
            Ini.NameTemplate[11] := Button[Interactions[Interaction].Num].Text[0].Text;
          end

--- a/src/screens/UScreenPartyTournamentPlayer.pas
+++ b/src/screens/UScreenPartyTournamentPlayer.pas
@@ -73,6 +73,7 @@ type
       Player16Name: cardinal;
 
       constructor Create; override;
+      function ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean; out SuppressKey: boolean): boolean; override;
       function ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean; override;
       procedure OnShow; override;
       procedure SetAnimationProgress(Progress: real); override;
@@ -148,6 +149,23 @@ begin
 
 end;
 
+function TScreenPartyTournamentPlayer.ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean; out SuppressKey: boolean): boolean;
+begin
+  Result := inherited;
+  // only suppress special keys for now
+  case PressedKey of
+    // Templates for Names Mod
+    SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F7, SDLK_F8, SDLK_F9, SDLK_F10, SDLK_F11, SDLK_F12:
+     if (Button[Interactions[Interaction].Num].Selected) then
+     begin
+       SuppressKey := true;
+     end
+     else
+     begin
+       Result := false;
+     end;
+  end;
+end;
 
 function TScreenPartyTournamentPlayer.ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean;
 var

--- a/src/screens/UScreenPartyTournamentPlayer.pas
+++ b/src/screens/UScreenPartyTournamentPlayer.pas
@@ -329,6 +329,17 @@ begin
           Button[Interactions[Interaction].Num].Text[0].DeleteLastLetter;
         end;
     end;
+  end
+  else
+  begin
+    // check normal keys
+    case UCS4UpperCase(CharCode) of
+      Ord('Q'):
+        begin
+          Result := false;
+          Exit;
+        end;
+    end;
   end;
 
   case PressedKey of


### PR DESCRIPTION
The hotkey combination of storing names into the template slots is configured to be `Alt`+_`F-key`_. A combination of `Alt`+`F4` results into closing the program on several OS. The hotkey is now switched to be `Shift`+_`F-key`_ (although the old hotkey is kept for legacy support, fow now).

The _switch to fullscreen_ hotkey is setup to be `F11`. The F-keys are also used for restoring a template name in the name input field. F11-hotkey was overriding the template hotkey for F11. This resulted into an unusable 11th slot.

Additional to that, name templates can now only be re-/stored if a Button is selected/active. This might be the only downside. `Q` (for quit) is also now possible in _ScreenNames_.

Tech note:
A method is added which is called in order to query if the current _Display_ should handle input and thus will get `ParseInput` being called. Otherwise, the code will continue without processing ParseInput for such _Display_. The `ShouldHandleInput` method does return whether the given input should be parsed **but** also if it should be suppressed (meaning it shouldn't be processed by the following code such as the global switch-to-fullscreen hotkey).

In general, ShouldHandleInput and ParseInput can be combined. But in order to keep the change at minimum and working on top of what is given, I've added that method. By default, a Menu/Display inheriting class should parse input.