### PR TITLE
Re-implemented MouseWheel scrolling

### DIFF
--- a/src/base/UCommon.pas
+++ b/src/base/UCommon.pas
@@ -51,6 +51,9 @@ type
 const
   SepWhitespace = [#9, #10, #13, ' ']; // tab, lf, cr, space
 
+  SDL_BUTTON_WHEELUP = 1001; // emulated MouseButton ID for mouse wheel up. @Note some high number to prevent conflict. @see sdl_mouse.inc
+  SDL_BUTTON_WHEELDOWN = 1002; // emulated MouseButton ID for mouse wheel down. @Note some high number to prevent conflict. @see sdl_mouse.inc
+
 {**
  * Splits a string into pieces separated by Separators.
  * MaxCount specifies the max. number of pieces. If it is <= 0 the number is

--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -384,6 +384,7 @@ var
   mouseBtn:  integer;
   KeepGoing: boolean;
   SuppressKey: boolean;
+  UpdateMouse: boolean;
 begin
   KeyCharUnicode:=0;
   KeepGoing := true;
@@ -398,10 +399,11 @@ begin
         Display.CheckOK := true;
       end;
 
-      SDL_MOUSEMOTION, SDL_MOUSEBUTTONDOWN, SDL_MOUSEBUTTONUP:
+      SDL_MOUSEMOTION, SDL_MOUSEBUTTONDOWN, SDL_MOUSEBUTTONUP, SDL_MOUSEWHEEL:
       begin
         if (Ini.Mouse > 0) then
         begin
+          UpdateMouse := true;
           case Event.type_ of
             SDL_MOUSEBUTTONDOWN:
             begin
@@ -427,10 +429,18 @@ begin
                 mouseDown := false;
               mouseBtn  := 0;
             end;
+            SDL_MOUSEWHEEL:
+            begin
+              UpdateMouse := false;
+              mouseDown   := (Event.wheel.y <> 0);
+              mouseBtn    := SDL_BUTTON_WHEELDOWN;
+              if (Event.wheel.y > 0) then mouseBtn := SDL_BUTTON_WHEELUP;
+            end;
           end;
 
-          Display.MoveCursor(Event.button.X * 800 * Screens / ScreenW,
-                             Event.button.Y * 600 / ScreenH);
+          if UpdateMouse then
+            Display.MoveCursor(Event.button.X * 800 * Screens / ScreenW,
+                               Event.button.Y * 600 / ScreenH);
 
           if not Assigned(Display.NextScreen) then
           begin //drop input when changing screens

--- a/src/menu/UMenu.pas
+++ b/src/menu/UMenu.pas
@@ -1776,7 +1776,7 @@ begin
           else
             Action := maReturn;
         end
-        {else if (MouseButton = SDL_BUTTON_WHEELDOWN) then
+        else if (MouseButton = SDL_BUTTON_WHEELDOWN) then
         begin //forward on select slide with mousewheel
           if (Interactions[nBut].Typ = iSelectS) then
             Action := maRight;
@@ -1785,7 +1785,7 @@ begin
         begin //backward on select slide with mousewheel
           if (Interactions[nBut].Typ = iSelectS) then
             Action := maLeft;
-        end};
+        end;
       end;
 
         // do the action we have to do ;)

--- a/src/screens/UScreenJukebox.pas
+++ b/src/screens/UScreenJukebox.pas
@@ -825,14 +825,14 @@ begin
       else
       begin
         //song scrolling with mousewheel
-      {if (MouseButton = SDL_BUTTON_WHEELDOWN) then
+      if (MouseButton = SDL_BUTTON_WHEELDOWN) then
         Result := ParseInput(SDLK_PAGEDOWN, 0, true);
 
       if (MouseButton = SDL_BUTTON_WHEELUP) then
         Result := ParseInput(SDLK_PAGEUP, 0, true)
 
       else
-      begin}
+      begin
         // up/down songlist
         if InRegion(X, Y, Button[JukeboxSongListUp].GetMouseOverArea) then
         begin
@@ -991,7 +991,7 @@ begin
           LastSongOptionsTick := SDL_GetTicks();
         end;
 
-      {end;}
+      end;
       end;
     end
     else

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -153,13 +153,13 @@ begin
     if RightMbESC and (MouseButton = SDL_BUTTON_RIGHT) then
       Result:=ParseInput(SDLK_ESCAPE, 0, true);
 
-    {//scrolling avatars with mousewheel
+    //scrolling avatars with mousewheel
     if (MouseButton = SDL_BUTTON_WHEELDOWN) then
       ParseInput(SDLK_RIGHT, 0, true)
     else if (MouseButton = SDL_BUTTON_WHEELUP) then
-      ParseInput(SDLK_LEFT, 0, true)}
-    {else
-    begin}
+      ParseInput(SDLK_LEFT, 0, true)
+    else
+    begin
       // click avatars
       // 1st left
       Btn := AvatarTarget - 2;
@@ -224,7 +224,7 @@ begin
           AvatarTarget := PlayerAvatars[PlayerIndex];
         end;
       end;
-    {end;}
+    end;
   end;
 
 end;

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -1345,12 +1345,12 @@ begin
     if RightMbESC and (MouseButton = SDL_BUTTON_RIGHT) then
       Result:=ParseInput(SDLK_ESCAPE, 0, true)
 
-    {//song scrolling with mousewheel
+    //song scrolling with mousewheel
     else if (MouseButton = SDL_BUTTON_WHEELDOWN) then
       ParseInput(SDLK_DOWN, 0, true)
 
     else if (MouseButton = SDL_BUTTON_WHEELUP) then
-      ParseInput(SDLK_UP, 0, true)}
+      ParseInput(SDLK_UP, 0, true)
 
     else
     begin
@@ -1409,12 +1409,12 @@ begin
     if RightMbESC and (MouseButton = SDL_BUTTON_RIGHT) then
       Result:=ParseInput(SDLK_ESCAPE, 0, true)
 
-    {//song scrolling with mousewheel
+    //song scrolling with mousewheel
     else if (MouseButton = SDL_BUTTON_WHEELDOWN) then
       ParseInput(SDLK_RIGHT, 0, true)
 
     else if (MouseButton = SDL_BUTTON_WHEELUP) then
-      ParseInput(SDLK_LEFT, 0, true)}
+      ParseInput(SDLK_LEFT, 0, true)
 
     //LMB anywhere starts
     else if (MouseButton = SDL_BUTTON_LEFT) then


### PR DESCRIPTION
Using SDL2 _SDL_MouseWheelEvent_ and calling legacy code with emulated events.

Not the best solution to re-define the old constants of SDL but it seemed to be the most adaptable code. Otherwise `ParseInput` would require to be re-designed to support fields given by the _SDL_MOUSEWHEEL_ event.

Not sure how well touch control works with this solution. Judging from the lib's doc, it could work just fine out of the box.