### PR TITLE
Update cursor on screen change

### DIFF
--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -40,7 +40,6 @@ uses
 var
   CheckMouseButton: boolean; // for checking mouse motion
   MAX_FPS: Byte; // 0 to 255 is enough
-  LastMouseX, LastMouseY: integer;
 
 
 procedure Main;
@@ -384,6 +383,7 @@ var
   s1: UTF8String;
   mouseDown: boolean;
   mouseBtn:  integer;
+  mouseX, mouseY: PInt;
   KeepGoing: boolean;
   SuppressKey: boolean;
 begin
@@ -428,8 +428,6 @@ begin
               else
                 mouseDown := false;
               mouseBtn  := 0;
-              LastMouseX := Event.button.X;
-              LastMouseY := Event.button.Y;
             end;
           end;
 
@@ -586,11 +584,14 @@ begin
 
   if Display.NeedsCursorUpdate() then
   begin
+
+
     // push a generated event onto the queue in order to simulate a mouse movement
     // the next tick will poll the motion event and handle it just like a real input
+    SDL_GetMouseState(@mouseX, @mouseY);
     SimEvent.user.type_ := SDL_MOUSEMOTION;
-    SimEvent.button.x := LastMouseX;
-    SimEvent.button.y := LastMouseY;
+    SimEvent.button.x := longint(mouseX);
+    SimEvent.button.y := longint(mouseY);
     SDL_PushEvent(@SimEvent);
   end;
 end;

--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -40,6 +40,7 @@ uses
 var
   CheckMouseButton: boolean; // for checking mouse motion
   MAX_FPS: Byte; // 0 to 255 is enough
+  LastMouseX, LastMouseY: integer;
 
 
 procedure Main;
@@ -378,6 +379,7 @@ end;
 procedure CheckEvents;
 var
   Event:     TSDL_event;
+  SimEvent:  TSDL_event;
   KeyCharUnicode: UCS4Char;
   s1: UTF8String;
   mouseDown: boolean;
@@ -426,6 +428,8 @@ begin
               else
                 mouseDown := false;
               mouseBtn  := 0;
+              LastMouseX := Event.button.X;
+              LastMouseY := Event.button.Y;
             end;
           end;
 
@@ -579,6 +583,16 @@ begin
         end;
     end; // case
   end; // while
+
+  if Display.NeedsCursorUpdate() then
+  begin
+    // push a generated event onto the queue in order to simulate a mouse movement
+    // the next tick will poll the motion event and handle it just like a real input
+    SimEvent.user.type_ := SDL_MOUSEMOTION;
+    SimEvent.button.x := LastMouseX;
+    SimEvent.button.y := LastMouseY;
+    SDL_PushEvent(@SimEvent);
+  end;
 end;
 
 procedure MainThreadExec(Proc: TMainThreadExecProc; Data: Pointer);

--- a/src/menu/UDisplay.pas
+++ b/src/menu/UDisplay.pas
@@ -76,6 +76,8 @@ type
       Cursor_LastMove:     cardinal;
       Cursor_Fade:         boolean;
 
+      Cursor_Update:       boolean;
+
       procedure DrawDebugInformation;
 
       { called by MoveCursor and OnMouseButton to update last move and start fade in }
@@ -125,6 +127,10 @@ type
 
       { draws software cursor }
       procedure DrawCursor;
+
+      { returns whether this display is requesting an cursor update }
+      function NeedsCursorUpdate(): boolean;
+
   end;
 
 var
@@ -193,6 +199,7 @@ begin
   Cursor_Y        := -1;
   Cursor_Fade     := false;
   Cursor_HiddenByScreen := true;
+  Cursor_Update   := false;
 end;
 
 destructor TDisplay.Destroy;
@@ -418,6 +425,7 @@ begin
         begin
           CurrentScreen.OnShowFinish;
           CurrentScreen.ShowFinish := true;
+          Cursor_Update := true;
         end
         else
         begin
@@ -666,6 +674,12 @@ begin
     else
       Result.FadeTo(Screen);
   end;
+end;
+
+function TDisplay.NeedsCursorUpdate: boolean;
+begin
+  Result := Cursor_Update;
+  Cursor_Update := false;
 end;
 
 procedure TDisplay.SaveScreenShot;

--- a/src/menu/UDisplay.pas
+++ b/src/menu/UDisplay.pas
@@ -678,7 +678,7 @@ end;
 
 function TDisplay.NeedsCursorUpdate: boolean;
 begin
-  Result := Cursor_Update;
+  Result := Cursor_Update and Cursor_Visible and not Cursor_Fade;
   Cursor_Update := false;
 end;
 


### PR DESCRIPTION
Enforces mouse-over selection without the need to move the mouse.

By using the mouse to navigate through the menus, returning back to the previous screen wouldn't update the mouse-over selection once the new screen is faded in. In case you open a menu and immediately switch back and already adjusting your mouse location in order to push on another button from the original screen, it won't select the button unless you move the mouse. With this change, once the old screen is fully faded out, the mouse-over selection will adjust where the current/last position is located.

There is a slight lag due to the fading process taking place (and preventing any input). Without screen fading enabled, the selection is updated directly (with a small noticable delay though).

Original (cursor needs to move in order to select the button)
![original](https://cloud.githubusercontent.com/assets/6833006/16717372/66120fa2-4715-11e6-9b25-f049254330bc.gif)

With cursor update (button selection updates without moving)
![withcursorupdate](https://cloud.githubusercontent.com/assets/6833006/16717383/a1f1b144-4715-11e6-9e4a-40f3b90ebe63.gif)


Due to private accessibility of the current/last cursor position, it is stored from the last polled event and used to simulate the _same_ mouse movement. A proper solution could be using an API call to receive the mouse position (or slightly change the existing code).