### PR TITLE
Fix mouse wheel on slide

### DIFF
--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -437,6 +437,12 @@ begin
               mouseDown   := (Event.wheel.y <> 0);
               mouseBtn    := SDL_BUTTON_WHEELDOWN;
               if (Event.wheel.y > 0) then mouseBtn := SDL_BUTTON_WHEELUP;
+
+              // some menu buttons require proper mouse location for trying to
+              // react to mouse wheel navigation simulation (see UMenu.ParseMouse)
+              SDL_GetMouseState(@mouseX, @mouseY);
+              Event.button.x := longint(mouseX);
+              Event.button.y := longint(mouseY);
             end;
           end;
 

--- a/src/screens/UScreenJukebox.pas
+++ b/src/screens/UScreenJukebox.pas
@@ -825,173 +825,173 @@ begin
       else
       begin
         //song scrolling with mousewheel
-      if (MouseButton = SDL_BUTTON_WHEELDOWN) then
-        Result := ParseInput(SDLK_PAGEDOWN, 0, true);
+        if (MouseButton = SDL_BUTTON_WHEELDOWN) then
+          Result := ParseInput(SDLK_PAGEDOWN, 0, true)
 
-      if (MouseButton = SDL_BUTTON_WHEELUP) then
-        Result := ParseInput(SDLK_PAGEUP, 0, true)
+        else if (MouseButton = SDL_BUTTON_WHEELUP) then
+          Result := ParseInput(SDLK_PAGEUP, 0, true)
 
-      else
-      begin
-        // up/down songlist
-        if InRegion(X, Y, Button[JukeboxSongListUp].GetMouseOverArea) then
+        else
         begin
-          PageUp(10);
-        end;
-
-        if InRegion(X, Y, Button[JukeboxSongListDown].GetMouseOverArea) then
-        begin
-          PageDown(10);
-        end;
-
-        // change time
-        if InRegion(X, Y, Text[JukeboxTextTimeText].GetMouseOverArea) then
-        begin
-          if (fTimebarMode = High(TTimebarMode)) then
-            fTimebarMode := Low(TTimebarMode)
-          else
-            Inc(fTimebarMode);
-
-          Ini.JukeboxTimebarMode := Ord(fTimebarMode);
-          Ini.SaveJukeboxTimebarMode();
-        end;
-
-        // play or move song
-        for I := 0 to Max do
-        begin
-          if InRegion(X, Y, Button[SongDescription[I]].GetMouseOverArea) then
+          // up/down songlist
+          if InRegion(X, Y, Button[JukeboxSongListUp].GetMouseOverArea) then
           begin
+            PageUp(10);
+          end;
 
-            // start move song
-            if not InRegion(X, Y, Button[SongDescription[Interaction]].GetMouseOverArea) then
+          if InRegion(X, Y, Button[JukeboxSongListDown].GetMouseOverArea) then
+          begin
+            PageDown(10);
+          end;
+
+          // change time
+          if InRegion(X, Y, Text[JukeboxTextTimeText].GetMouseOverArea) then
+          begin
+            if (fTimebarMode = High(TTimebarMode)) then
+              fTimebarMode := Low(TTimebarMode)
+            else
+              Inc(fTimebarMode);
+
+            Ini.JukeboxTimebarMode := Ord(fTimebarMode);
+            Ini.SaveJukeboxTimebarMode();
+          end;
+
+          // play or move song
+          for I := 0 to Max do
+          begin
+            if InRegion(X, Y, Button[SongDescription[I]].GetMouseOverArea) then
             begin
-              Button[SongDescriptionClone].X := X;
-              Button[SongDescriptionClone].Y := Y;
-              Button[SongDescriptionClone].Text[0].X := X + Button[SongDescription[I]].Text[0].X - Button[SongDescription[I]].X;
-              Button[SongDescriptionClone].Text[0].Y := Y + Button[SongDescription[I]].Text[0].Y - Button[SongDescription[I]].Y;
-              Button[SongDescriptionClone].Text[0].Text := CatSongs.Song[JukeboxVisibleSongs[Interaction + ListMin]].Artist + ' - ' + CatSongs.Song[JukeboxVisibleSongs[Interaction + ListMin]].Title;
 
-              MoveX := Button[SongDescription[I]].Texture.X;
-              MoveY := Button[SongDescription[I]].Texture.Y;
-              MoveInicial := ListMin + Interaction;
+              // start move song
+              if not InRegion(X, Y, Button[SongDescription[Interaction]].GetMouseOverArea) then
+              begin
+                Button[SongDescriptionClone].X := X;
+                Button[SongDescriptionClone].Y := Y;
+                Button[SongDescriptionClone].Text[0].X := X + Button[SongDescription[I]].Text[0].X - Button[SongDescription[I]].X;
+                Button[SongDescriptionClone].Text[0].Y := Y + Button[SongDescription[I]].Text[0].Y - Button[SongDescription[I]].Y;
+                Button[SongDescriptionClone].Text[0].Text := CatSongs.Song[JukeboxVisibleSongs[Interaction + ListMin]].Artist + ' - ' + CatSongs.Song[JukeboxVisibleSongs[Interaction + ListMin]].Title;
 
-              Button[SongDescriptionClone].Visible := true;
-              Button[SongDescription[Interaction]].SetSelect(false);
+                MoveX := Button[SongDescription[I]].Texture.X;
+                MoveY := Button[SongDescription[I]].Texture.Y;
+                MoveInicial := ListMin + Interaction;
+
+                Button[SongDescriptionClone].Visible := true;
+                Button[SongDescription[Interaction]].SetSelect(false);
+              end
+              else
+              begin
+
+                if (MouseButton = SDL_BUTTON_LEFT) then
+                begin
+                  if (SDL_GetTicks() - DoubleClickTime <= 500) then
+                    Result := ParseInput(SDLK_RETURN, 0, true);
+
+                  DoubleClickTime := SDL_GetTicks();
+                end;
+
+              end;
+            end;
+          end;
+
+          // close songlist
+          if InRegion(X, Y, Button[JukeboxSongListClose].GetMouseOverArea)then
+          begin
+            Result := ParseInput(SDLK_ESCAPE, 0, true);
+            CloseClickTime := SDL_GetTicks();
+            Button[JukeboxSongListClose].SetSelect(false);
+          end;
+
+          // fix songlist
+          if InRegion(X, Y, Button[JukeboxSongListFixPin].GetMouseOverArea)then
+          begin
+            SongListVisibleFix := not SongListVisibleFix;
+
+            if (SongListVisibleFix) then
+              Ini.JukeboxSongMenu := 0
+            else
+              Ini.JukeboxSongMenu := 1;
+
+            Ini.SaveJukeboxSongMenu;
+
+            Button[JukeboxSongListFixPin].SetSelect(SongListVisibleFix);
+          end;
+
+          if InRegion(X, Y, Statics[JukeboxStaticTimeProgress].GetMouseOverArea) then
+          begin
+            Time := ((X - Statics[JukeboxStaticTimeProgress].Texture.X) * LyricsState.TotalTime)/(Statics[JukeboxStaticTimeProgress].Texture.W);
+
+            ChangeTime(Time);
+          end;
+
+          if InRegion(X, Y, Button[JukeboxRepeatSongList].GetMouseOverArea) then
+          begin
+            RepeatSongList := not RepeatSongList;
+            Button[JukeboxRepeatSongList].SetSelect(RepeatSongList);
+          end;
+
+          if InRegion(X, Y, Button[JukeboxSongListOrder].GetMouseOverArea) then
+          begin
+            ChangeOrderList();
+          end;
+
+          if InRegion(X, Y, Button[JukeboxRandomSongList].GetMouseOverArea) then
+          begin
+            RandomList();
+          end;
+
+          if InRegion(X, Y, Button[JukeboxLyric].GetMouseOverArea) then
+          begin
+            ShowLyrics := not ShowLyrics;
+            Button[JukeboxLyric].SetSelect(ShowLyrics);
+          end;
+
+          if InRegion(X, Y, Button[JukeboxPlayPause].GetMouseOverArea) then
+          begin
+            Pause;
+            Button[JukeboxPlayPause].SetSelect(Paused);
+          end;
+
+          if InRegion(X, Y, Button[JukeboxFindSong].GetMouseOverArea) then
+          begin
+            FindSongList := not FindSongList;
+
+            if (Filter = '') then
+            begin
+              if (FindSongList) then
+                Button[JukeboxFindSong].Text[0].Text := ''
+            end;
+
+            Button[JukeboxFindSong].SetSelect(FindSongList);
+
+            if not (FindSongList) and (Length(JukeboxSongsList) <> Length(JukeboxVisibleSongs)) then
+            begin
+              FilterSongList('');
             end
             else
             begin
-
-              if (MouseButton = SDL_BUTTON_LEFT) then
-              begin
-                if (SDL_GetTicks() - DoubleClickTime <= 500) then
-                  Result := ParseInput(SDLK_RETURN, 0, true);
-
-                DoubleClickTime := SDL_GetTicks();
-              end;
-
+              if (Filter <> '') then
+                FilterSongList(Filter);
             end;
-          end;
-        end;
 
-        // close songlist
-        if InRegion(X, Y, Button[JukeboxSongListClose].GetMouseOverArea)then
-        begin
-          Result := ParseInput(SDLK_ESCAPE, 0, true);
-          CloseClickTime := SDL_GetTicks();
-          Button[JukeboxSongListClose].SetSelect(false);
-        end;
-
-        // fix songlist
-        if InRegion(X, Y, Button[JukeboxSongListFixPin].GetMouseOverArea)then
-        begin
-          SongListVisibleFix := not SongListVisibleFix;
-
-          if (SongListVisibleFix) then
-            Ini.JukeboxSongMenu := 0
-          else
-            Ini.JukeboxSongMenu := 1;
-
-          Ini.SaveJukeboxSongMenu;
-
-          Button[JukeboxSongListFixPin].SetSelect(SongListVisibleFix);
-        end;
-
-        if InRegion(X, Y, Statics[JukeboxStaticTimeProgress].GetMouseOverArea) then
-        begin
-          Time := ((X - Statics[JukeboxStaticTimeProgress].Texture.X) * LyricsState.TotalTime)/(Statics[JukeboxStaticTimeProgress].Texture.W);
-
-          ChangeTime(Time);
-        end;
-
-        if InRegion(X, Y, Button[JukeboxRepeatSongList].GetMouseOverArea) then
-        begin
-          RepeatSongList := not RepeatSongList;
-          Button[JukeboxRepeatSongList].SetSelect(RepeatSongList);
-        end;
-
-        if InRegion(X, Y, Button[JukeboxSongListOrder].GetMouseOverArea) then
-        begin
-          ChangeOrderList();
-        end;
-
-        if InRegion(X, Y, Button[JukeboxRandomSongList].GetMouseOverArea) then
-        begin
-          RandomList();
-        end;
-
-        if InRegion(X, Y, Button[JukeboxLyric].GetMouseOverArea) then
-        begin
-          ShowLyrics := not ShowLyrics;
-          Button[JukeboxLyric].SetSelect(ShowLyrics);
-        end;
-
-        if InRegion(X, Y, Button[JukeboxPlayPause].GetMouseOverArea) then
-        begin
-          Pause;
-          Button[JukeboxPlayPause].SetSelect(Paused);
-        end;
-
-        if InRegion(X, Y, Button[JukeboxFindSong].GetMouseOverArea) then
-        begin
-          FindSongList := not FindSongList;
-
-          if (Filter = '') then
-          begin
             if (FindSongList) then
-              Button[JukeboxFindSong].Text[0].Text := ''
+              Button[JukeboxFindSong].Text[0].Selected := true
+            else
+              Button[JukeboxFindSong].Text[0].Selected := false;
+
           end;
 
-          Button[JukeboxFindSong].SetSelect(FindSongList);
+          if InRegion(X, Y, Button[JukeboxOptions].GetMouseOverArea) then
+          begin
+            SongMenuVisible := false;
+            SongListVisible := false;
 
-          if not (FindSongList) and (Length(JukeboxSongsList) <> Length(JukeboxVisibleSongs)) then
-          begin
-            FilterSongList('');
-          end
-          else
-          begin
-            if (Filter <> '') then
-              FilterSongList(Filter);
+            Button[JukeboxOptions].SetSelect(false);
+            ScreenJukeboxOptions.Visible := true;
+
+            LastSongOptionsTick := SDL_GetTicks();
           end;
 
-          if (FindSongList) then
-            Button[JukeboxFindSong].Text[0].Selected := true
-          else
-            Button[JukeboxFindSong].Text[0].Selected := false;
-
         end;
-
-        if InRegion(X, Y, Button[JukeboxOptions].GetMouseOverArea) then
-        begin
-          SongMenuVisible := false;
-          SongListVisible := false;
-
-          Button[JukeboxOptions].SetSelect(false);
-          ScreenJukeboxOptions.Visible := true;
-
-          LastSongOptionsTick := SDL_GetTicks();
-        end;
-
-      end;
       end;
     end
     else

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -67,6 +67,8 @@ type
       ColorIndex:   integer;
       LevelIndex:   integer;
 
+      PlayerAvatarIID: integer; // interaction ID
+
       AvatarCurrent: real;
       AvatarTarget:  integer;
 
@@ -155,9 +157,15 @@ begin
 
     //scrolling avatars with mousewheel
     if (MouseButton = SDL_BUTTON_WHEELDOWN) then
-      ParseInput(SDLK_RIGHT, 0, true)
+    begin
+      if (Interaction = PlayerAvatarIID) then
+        ParseInput(SDLK_RIGHT, 0, true);
+    end
     else if (MouseButton = SDL_BUTTON_WHEELUP) then
-      ParseInput(SDLK_LEFT, 0, true)
+    begin
+      if (Interaction = PlayerAvatarIID) then
+        ParseInput(SDLK_LEFT, 0, true);
+    end
     else
     begin
       // click avatars
@@ -226,7 +234,6 @@ begin
       end;
     end;
   end;
-
 end;
 
 function TScreenName.ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean; out SuppressKey: boolean): boolean;
@@ -880,6 +887,7 @@ begin
   PlayerSelect := AddButton(Theme.Name.PlayerSelectCurrent);
 
   PlayerAvatar := AddButton(Theme.Name.PlayerButtonAvatar);
+  PlayerAvatarIID := High(Interactions);
 
   PlayerName := AddButton(Theme.Name.PlayerButtonName);
   Button[PlayerName].Text[0].Writable := true;


### PR DESCRIPTION
Selection Slide menu element didn't work with mouse wheel due to improper/offset given mouse location on MouseWheel event. On mouse wheel event, this change does provide the current mouse location for a proper `InterActAt` call in UMenu (as example).

By having this fixed, the player name/count/avatar screen does react twice when _scrolling_ the player count slide. This is additionally fixed in this change by checking the `Interaction` selection and only scroll the avatar roulette if the player avator button is selected.

Jukebox was also affected by having a proper mouse location which resulted in switching to move/re-order mode when the list is at the end and the mouse wheel down is sent.

PS: Append `?w=1` to this URL for a proper diff of UScreenJukebox.pas.