### PR TITLE
Fix Bass version decoding

### DIFF
--- a/src/media/UAudioCore_Bass.pas
+++ b/src/media/UAudioCore_Bass.pas
@@ -87,7 +87,7 @@ begin
   Version[1] := (VersionHex shr 16) and $FF;
   Version[2] := (VersionHex shr 8) and $FF;
   Version[3] := (VersionHex shr 0) and $FF;
-  Result := Format('%x.%x.%x.%x', [Version[0], Version[1], Version[2], Version[3]]);
+  Result := Format('%d.%d.%d.%d', [Version[0], Version[1], Version[2], Version[3]]);
 end;
 
 function TAudioCore_Bass.CheckVersion(): boolean;


### PR DESCRIPTION
The version number is converted from hex to decimal back to hex (in `Format`). This results into a version like `2.4.11.2` (in original hex value) being decoded from the according hex value to the string `2.4.B.2`.