### PR TITLE
Added Romanian translation back

### DIFF
--- a/game/languages/Romanian.ini
+++ b/game/languages/Romanian.ini
@@ -1,0 +1,452 @@
+﻿[Text]
+OPTION_VALUE_CATALAN=Catalană
+;TODO: OPTION_VALUE_CHINESE=Chinese
+OPTION_VALUE_CROATIAN=Croată
+OPTION_VALUE_CZECH=Cehă
+OPTION_VALUE_DANISH=Daneză
+OPTION_VALUE_DUTCH=Olandeză
+OPTION_VALUE_ENGLISH=Engleză
+OPTION_VALUE_EUSKARA=Euskera
+OPTION_VALUE_FINNISH=Finlandeză
+OPTION_VALUE_FRENCH=Franceză
+;TODO: OPTION_VALUE_GAELIC=Gaelic
+OPTION_VALUE_GERMAN=Germană
+OPTION_VALUE_GREEK=Greacă
+OPTION_VALUE_HUNGARIAN=Maghiară
+OPTION_VALUE_ICELANDIC=Islandeză
+OPTION_VALUE_ITALIAN=Italiană
+OPTION_VALUE_JAPANESE=Japoneză
+OPTION_VALUE_LUXEMBOURGISH=Luxemburgheză
+OPTION_VALUE_NORWEGIAN=Norvegiană
+OPTION_VALUE_POLISH=Poloneză
+OPTION_VALUE_PORTUGUESE=Portugheză
+OPTION_VALUE_ROMANIAN=Română
+;TODO: OPTION_VALUE_RUSSIAN=Russian
+OPTION_VALUE_SERBIAN=Sârbă
+OPTION_VALUE_SLOVAK=Slovacă
+OPTION_VALUE_SLOVENIAN=Slovenă
+OPTION_VALUE_SPANISH=Spaniolă
+OPTION_VALUE_SWEDISH=Suedeză
+
+OPTION_VALUE_EASY=Uşor
+OPTION_VALUE_MEDIUM=Mediu
+OPTION_VALUE_HARD=Greu
+
+OPTION_VALUE_ON=Da
+OPTION_VALUE_OFF=Nu
+
+OPTION_VALUE_EDITION=Ediție
+OPTION_VALUE_GENRE=Gen
+OPTION_VALUE_LANGUAGE=Limbă
+OPTION_VALUE_FOLDER=Dosar
+OPTION_VALUE_TITLE=Titlu
+OPTION_VALUE_ARTIST=Artist
+OPTION_VALUE_TITLE2=Titlu2
+OPTION_VALUE_ARTIST2=Artist2
+
+OPTION_VALUE_WHENNOVIDEO=În cazul în care nu există video
+
+OPTION_VALUE_SMALL=Mic
+OPTION_VALUE_BIG=Mare
+
+OPTION_VALUE_HALF=Jumătate
+OPTION_VALUE_FULL_VID=Complet (Video)
+OPTION_VALUE_FULL_VID_BG=Complet(Fond şi Video)
+
+OPTION_VALUE_AUTO=Automat
+OPTION_VALUE_SEC=Al doilea
+OPTION_VALUE_SECS=Secunde
+
+OPTION_VALUE_PLAIN=Simplu
+OPTION_VALUE_OLINE1=OLine1
+OPTION_VALUE_OLINE2=OLine2
+
+OPTION_VALUE_SIMPLE=Simplu
+OPTION_VALUE_ZOOM=Apropiere
+OPTION_VALUE_SLIDE=Alunecare
+OPTION_VALUE_BALL=Minge
+OPTION_VALUE_SHIFT=Săritură
+
+OPTION_VALUE_EURO=European
+OPTION_VALUE_JAPAN=Japonez
+OPTION_VALUE_AMERICAN=American
+
+OPTION_VALUE_BLUE=Albastru
+OPTION_VALUE_GREEN=Verde
+OPTION_VALUE_PINK=Roz
+OPTION_VALUE_RED=Roșu
+OPTION_VALUE_VIOLET=Violet
+OPTION_VALUE_ORANGE=Orange
+OPTION_VALUE_YELLOW=Galben
+OPTION_VALUE_BROWN=Maro
+OPTION_VALUE_BLACK=Negru
+
+OPTION_VALUE_SING=Cântă
+OPTION_VALUE_SELECT_PLAYERS=Alege Jucători
+OPTION_VALUE_OPEN_MENU=Deschide Meniu
+
+OPTION_VALUE_HARDWARE_CURSOR=Cursor hardware
+OPTION_VALUE_SOFTWARE_CURSOR=Cursor software
+
+SING_LOADING=Încărcând ...
+
+SING_CHOOSE_MODE=Alege modul
+SING_SING=Cântă!
+SING_SING_DESC=joc rapid: cântă singur sau în duet
+
+SING_MULTI=Party
+SING_MULTI_DESC=cântă în grup
+
+SING_TOOLS=Unelte
+
+SING_STATS=Statistici
+SING_STATS_DESC=vezi statistici
+
+SING_EDITOR=Editor
+SING_EDITOR_DESC=creează melodia ta
+
+SING_GAME_OPTIONS=Opţiuni de joc
+SING_GAME_OPTIONS_DESC=modifică opţiunile de joc
+
+SING_EXIT=Ieşire
+SING_EXIT_DESC=ieşi din joc
+
+SING_OPTIONS=Opţiuni
+SING_OPTIONS_DESC=modifică opţiunile
+SING_OPTIONS_WHEREAMI=Opţiuni
+
+SING_OPTIONS_GAME=Joc
+SING_OPTIONS_GRAPHICS=Grafică
+SING_OPTIONS_SOUND=Sunet
+SING_OPTIONS_LYRICS=Versuri
+SING_OPTIONS_THEMES=Aspect
+SING_OPTIONS_RECORD=Microfoane
+SING_OPTIONS_ADVANCED=Avansat
+SING_OPTIONS_EXIT=Înapoi
+
+SING_OPTIONS_GAME_WHEREAMI=Opţiuni de joc
+SING_OPTIONS_GAME_DESC=opţiuni de joc generale
+SING_OPTIONS_GAME_PLAYERS=Jucători
+SING_OPTIONS_GAME_DIFFICULTY=Dificultate
+SING_OPTIONS_GAME_LANGUAGE=Limbă
+SING_OPTIONS_GAME_TABS=Etichete
+SING_OPTIONS_GAME_SORTING=Sortează după
+SING_OPTIONS_GAME_DEBUG=Mod de depanare
+
+SING_OPTIONS_GRAPHICS_WHEREAMI=Opţiuni grafice
+SING_OPTIONS_GRAPHICS_DESC=modifică configurația video
+SING_OPTIONS_GRAPHICS_RESOLUTION=Rezoluție
+SING_OPTIONS_GRAPHICS_FULLSCREEN=Ecran complet
+SING_OPTIONS_GRAPHICS_DEPTH=Adâncime de culoare
+SING_OPTIONS_GRAPHICS_VISUALIZER=Vizualizare
+SING_OPTIONS_GRAPHICS_OSCILLOSCOPE=Osciloscop
+SING_OPTIONS_GRAPHICS_LINEBONUS=Bonus de linie
+SING_OPTIONS_GRAPHICS_MOVIE_SIZE=Mărime video
+
+SING_OPTIONS_SOUND_WHEREAMI=Opţiuni sunet
+SING_OPTIONS_SOUND_DESC=modifică configurația audio
+SING_OPTIONS_SOUND_VOICEPASSTHROUGH=Ascultă microfon
+SING_OPTIONS_SOUND_BACKGROUNDMUSIC=Muzică de fundal
+SING_OPTIONS_RECORD_MIC_BOOST=Amplifică Microfon
+SING_OPTIONS_SOUND_CLICK_ASSIST=Ajutor note
+SING_OPTIONS_SOUND_BEAT_CLICK=Clic ritm 
+SING_OPTIONS_RECORD_THRESHOLD=Prag microfon
+SING_OPTIONS_SOUND_TWO_PLAYERS_MODE=Mod 2 jucători
+SING_OPTIONS_SOUND_PREVIEWVOLUME=Vezi volum
+SING_OPTIONS_SOUND_PREVIEWFADING=Vezi atenuare
+
+SING_OPTIONS_LYRICS_WHEREAMI=Opţiuni versuri
+SING_OPTIONS_LYRICS_DESC=schimbă modul de afișare a versurilor
+SING_OPTIONS_LYRICS_FONT=Set de caractere
+SING_OPTIONS_LYRICS_EFFECT=Efect
+SING_OPTIONS_LYRICS_SOLMIZATION=Solfegiu
+SING_OPTIONS_LYRICS_NOTELINES=Partitură
+
+SING_OPTIONS_THEMES_WHEREAMI=Opţiuni aspect
+SING_OPTIONS_THEMES_DESC=schimbă culori şi aspect
+SING_OPTIONS_THEMES_THEME=Temă 
+SING_OPTIONS_THEMES_SKIN=Skin
+SING_OPTIONS_THEMES_COLOR=Culoare
+
+SING_OPTIONS_RECORD_WHEREAMI=Opţiuni înregistrare 
+SING_OPTIONS_RECORD_DESC=configurează microfon
+SING_OPTIONS_RECORD_CARD=Placă de sunet
+SING_OPTIONS_RECORD_INPUT=Intrare
+SING_OPTIONS_RECORD_CHANNEL=Canal
+
+SING_OPTIONS_ADVANCED_WHEREAMI=Opțiuni avansate
+SING_OPTIONS_ADVANCED_DESC=opțiuni avansate
+SING_OPTIONS_ADVANCED_EFFECTSING=Efecte cântând 
+SING_OPTIONS_ADVANCED_SCREENFADE=Atenuare ecran
+SING_OPTIONS_ADVANCED_LOADANIMATION=Încarcă animaţie
+SING_OPTIONS_ADVANCED_ASKBEFOREDEL=Confirmă ştergere 
+SING_OPTIONS_ADVANCED_LINEBONUS=Bonus de linie 
+SING_OPTIONS_ADVANCED_ONSONGCLICK=După alegere cântec..
+SING_OPTIONS_ADVANCED_PARTYPOPUP=Meniu party automat
+
+SING_EDIT=Editor
+SING_EDIT_MENU_DESCRIPTION=creează cântecul tău
+
+SING_EDIT_BUTTON_DESCRIPTION_CONVERT=Încarcă text din fişier MIDI
+SING_EDIT_BUTTON_DESCRIPTION_EXIT=Înapoi
+SING_EDIT_BUTTON_CONVERT=Încarcă
+SING_EDIT_BUTTON_EXIT=Înapoi
+
+SING_EDIT_NAVIGATE=Navighează
+SING_EDIT_SELECT=Alege
+SING_EDIT_EXIT=Înapoi
+
+SING_LEGEND_SELECT=Alege
+SING_LEGEND_NAVIGATE=Navighează
+SING_LEGEND_CONTINUE=Continuă
+SING_LEGEND_ESC=Înapoi
+
+SING_PLAYER_DESC=scrie nume jucător(i) 
+SING_PLAYER_WHEREAMI=Nume jucători 
+SING_PLAYER_ENTER_NAME=Introduce nume
+
+SING_DIFFICULTY_DESC=selectează dificultatea 
+SING_DIFFICULTY_WHEREAMI=Dificultate
+SING_DIFFICULTY_CONTINUE=Alege cântec
+SING_EASY=Uşor
+SING_MEDIUM=Mediu
+SING_HARD=Greu
+
+SING_SONG_SELECTION_DESC=alege-ți cântecul
+SING_SONG_SELECTION_WHEREAMI=Alege cântec
+SING_SONG_SELECTION_GOTO=Du-te la ...
+SING_SONG_SELECTION=Alege cântec
+SING_SONG_SELECTION_MENU=Meniu
+SING_SONG_SELECTION_PLAYLIST=Lista
+SING_SONGS_IN_CAT=Cântece
+PLAYLIST_CATTEXT=Lista: %s
+
+SING_TIME=Timp
+SING_TOTAL=Total
+SING_MODE=Cântă singur
+SING_NOTES=Note
+SING_GOLDEN_NOTES=Note de aur
+SING_PHRASE_BONUS=Bonus de linie 
+
+SING_MENU=Meniu principal
+
+SONG_SCORE=Punctaj cântec
+SONG_SCORE_WHEREAMI=Punctaj
+
+SING_SCORE_TONE_DEAF=Afon
+SING_SCORE_AMATEUR=Amator
+SING_SCORE_WANNABE=Începător
+SING_SCORE_HOPEFUL=Promițător
+SING_SCORE_RISING_STAR=Cântareț
+SING_SCORE_LEAD_SINGER=Mare Cântareț
+SING_SCORE_SUPERSTAR=Superstar
+SING_SCORE_ULTRASTAR=Ultrastar
+
+SING_TOP_5_CHARTS=Primii 5 jucători
+SING_TOP_5_CHARTS_WHEREAMI=primii 5
+SING_TOP_5_CHARTS_CONTINUE=la alegerea cântecului
+SING_TOP_5_CHARTS_SWITCH_DIFFICULTY=Schimbă dificultatea
+
+POPUP_PERFECT=perfect!
+POPUP_AWESOME=uimitor!
+POPUP_GREAT=grozav!
+POPUP_GOOD=bine!
+POPUP_NOTBAD=nu-i rău!
+POPUP_BAD=rău!
+POPUP_POOR=groaznic!
+POPUP_AWFUL=oribil!
+
+IMPLODE_GLUE1=,
+IMPLODE_GLUE2=și
+
+SONG_MENU_NAME_MAIN=Meniu cântece
+SONG_MENU_PLAY=Cântă
+SONG_MENU_CHANGEPLAYERS=Schimbă jucători
+SONG_MENU_EDIT=Editează
+SONG_MENU_MODI=Cântă un Modi
+SONG_MENU_CANCEL=Renunță
+
+SONG_MENU_NAME_PLAYLIST=Meniu cântece
+SONG_MENU_PLAYLIST_ADD=Adaugă cântec
+SONG_MENU_PLAYLIST_DEL=Şterge cântec
+
+SONG_MENU_NAME_PLAYLIST_ADD=Adaugă cântec
+SONG_MENU_PLAYLIST_ADD_NEW=la o listă nouă
+SONG_MENU_PLAYLIST_ADD_EXISTING=la o listă existentă
+SONG_MENU_PLAYLIST_NOEXISTING=nu sunt liste
+
+SONG_MENU_NAME_PLAYLIST_NEW=listă nouă de cântece
+SONG_MENU_PLAYLIST_NEW_CREATE=Creează
+SONG_MENU_PLAYLIST_NEW_UNNAMED=Nedenumit
+
+SONG_MENU_NAME_PLAYLIST_DELITEM=Chiar ștergi?
+SONG_MENU_YES=Da
+SONG_MENU_NO=Nu
+
+SONG_MENU_NAME_PLAYLIST_LOAD=Deschide lista
+SONG_MENU_PLAYLIST_LOAD=Deschide
+SONG_MENU_PLAYLIST_DELCURRENT=Ştergi lista actuală
+
+SONG_MENU_NAME_PLAYLIST_DEL=Ştergi listă?
+
+SONG_MENU_NAME_PARTY_MAIN=Meniu Party
+SONG_MENU_JOKER=Cântă unul la întâmplare
+
+SONG_MENU_NAME_PARTY_JOKER=la întâmplare
+
+SONG_JUMPTO_DESC=Caută cântec
+SONG_JUMPTO_TYPE_DESC=Caută după:
+SONG_JUMPTO_TYPE1=Toate
+SONG_JUMPTO_TYPE2=Titlu
+SONG_JUMPTO_TYPE3=Artist
+SONG_JUMPTO_SONGSFOUND=%d cântec(e) găsite
+SONG_JUMPTO_NOSONGSFOUND=nu s-au găsit cântece
+SONG_JUMPTO_HELP=Introduce textul de căutat
+SONG_JUMPTO_CATTEXT=Caută: %s
+
+PARTY_MODE=Modul party
+PARTY_DIFFICULTY=Dificultate
+PARTY_PLAYLIST=Mod listă 
+PARTY_PLAYLIST_ALL=Toate
+PARTY_PLAYLIST_CATEGORY=Dosar
+PARTY_PLAYLIST_PLAYLIST=Liste
+PARTY_TEAMS=Numărul echipelor
+PARTY_TEAMS_PLAYER1=Număr membri:
+PARTY_TEAMS_PLAYER2=Număr membri:
+PARTY_TEAMS_PLAYER3=Număr membri:
+
+PARTY_LEGEND_CONTINUE=Continuă
+
+PARTY_OPTIONS_DESC=opţiuni mod party
+PARTY_OPTIONS_WHEREAMI=Opţiuni mod party
+
+PARTY_PLAYER_DESC=introduce numele jucătorilor şi al echipelor
+PARTY_PLAYER_WHEREAMI=Numele echipei
+PARTY_PLAYER_ENTER_NAME=_Introduce nume
+
+
+PARTY_ROUNDS_DESC=alege ce mod vrei să joci
+PARTY_ROUNDS_WHEREAMI=Runde party
+PARTY_ROUNDS_LEGEND_CONTINUE=Pornește joc party
+PARTY_ROUNDCOUNT=Numărul de runde
+PARTY_SELECTMODE1=Modul 1 rundă
+PARTY_SELECTMODE2=Modul 2 runde
+PARTY_SELECTMODE3=Modul 3 runde
+PARTY_SELECTMODE4=Modul 4 runde
+PARTY_SELECTMODE5=Modul 5 runde
+PARTY_SELECTMODE6=Modul 6 runde
+PARTY_SELECTMODE7=Modul 7 runde
+
+PARTY_ROUND_DESC=următorii jucători la microfoane
+PARTY_ROUND_WHEREAMI=Urmatoarea rundă
+PARTY_ROUND_LEGEND_CONTINUE=Pornește runda
+
+PARTY_SONG_WHEREAMI=Alege cântec party
+PARTY_SONG_LEGEND_CONTINUE=Cântă
+PARTY_SONG_MENU=Meniu party
+
+PARTY_SCORE_DESC=scorul ultimei runde
+PARTY_SCORE_WHEREAMI=Puncte party
+
+PARTY_WIN_DESC=Echipa câştigătoare
+PARTY_WIN_WHEREAMI=Câştigător party
+PARTY_WIN_LEGEND_CONTINUE=înapoi la meniul principal
+
+PARTY_ROUND=Runda
+PARTY_ROUND_WINNER=Câştigător
+PARTY_NOTPLAYEDYET=nejucat încă
+PARTY_NOBODY=Nimeni
+NEXT_ROUND=Urmatoarea rundă:
+
+PARTY_DISMISSED=Eliminat!
+PARTY_SCORE_WINS=%s
+PARTY_SCORE_WINS2=Câștigă!
+
+MODE_RANDOM_NAME=Mod aleatoriu
+MODE_RANDOM_DESC=un mod va fi ales aleatoriu
+
+MODE_HOLDTHELINE_NAME=Păstrează linia 
+MODE_HOLDTHELINE_DESC=menține punctajul mai mare decât cel afişat pe ecran
+
+MODE_5000POINTS_NAME=Până la 5000
+MODE_5000POINTS_DESC=câștigă cel care obţine primul 5000 de puncte.
+
+MODE_DUEL_NAME=Duel
+MODE_DUEL_DESC=cântă un duel la 10000 de puncte.
+
+MODE_TEAMDUEL_NAME=Duel de echipe
+MODE_TEAMDUEL_DESC=dă mai departe microfonul!
+
+MODE_BLIND_NAME=Mod Orb
+MODE_BLIND_DESC=duel fără să vadă notele.
+
+STAT_MAIN=Statistici
+STAT_MAIN_DESC=general
+STAT_MAIN_WHEREAMI=Statistici
+
+STAT_OVERVIEW_INTRO=%0:s \nStatistici \nUltima reinițiere pe %1:.2d.%2:.2d.%3:d
+STAT_OVERVIEW_SONG=%0:d Cântece(%3:d cu video), dintre care %1:d deja au fost cântate și %2:d nu au fost cântate încă.\n Cântecul preferat este %4:s de %5:s.
+STAT_OVERVIEW_PLAYER=De la ultima reinițiere s-au înregistrat %0:d jucător(i) diferiți.\n Cel mai bun jucător este %1:s cu un punctaj mediu de %2:d puncte.\n %3:s a realizat cel mai bun punctaj cu %4:d puncte.
+
+STAT_FORMAT_DATE=%0:.2d.%1:.2d.%2:d
+
+STAT_DETAIL=Statistici
+STAT_DETAIL_WHEREAMI=Statistici detaliate
+
+STAT_NEXT=Următoarele
+STAT_PREV=Anterioare
+STAT_REVERSE=Schimbă ordinea
+STAT_PAGE=pagina %0:d din %1:d pagini\n (%2:d din %3:d elemente)
+
+STAT_DESC_SCORES=Top punctaje
+STAT_DESC_SCORES_REVERSED=Cele mai mici punctaje
+STAT_FORMAT_SCORES=%0:s - %1:d  [%2:s]  %5:s \n (%3:s - %4:s)
+
+STAT_DESC_SINGERS=Top cântăreți
+STAT_DESC_SINGERS_REVERSED=Cei mai slabi cântăreți
+STAT_FORMAT_SINGERS=%0:s \n Punctaj mediu: %1:d
+
+STAT_DESC_SONGS=Cele mai cântate
+STAT_DESC_SONGS_REVERSED=Cele mai puțin cântate
+STAT_FORMAT_SONGS=%0:s - %1:s \n cântat de %2:d ori
+
+STAT_DESC_BANDS=Top formații
+STAT_DESC_BANDS_REVERSED=Formații preferate
+STAT_FORMAT_BANDS=%0:s \n %1:dx cântat
+
+SCREENSHOT_SAVED=Captură ecran salvată
+SCREENSHOT_FAILED=Nu s-a putut salva captura ecran
+
+INFO_FILE_SAVED=Fişier salvat
+ERROR_SAVE_FILE_FAILED=Nu s-a putut salva fișierul
+ERROR_FILE_NOT_FOUND=Fişierul nu a fost găsit
+
+ENCODING_ERROR_ASK_FOR_UTF8=Nu se pot salva modificările în codificarea actuală. Convertesc la UTF-8?
+EDITOR_ERROR_NO_TRACK_SELECTED=nici o pistă aleasă
+
+MSG_ERROR_TITLE=Eroare
+MSG_INFO_TITLE=Informaţii
+MSG_QUESTION_TITLE=Întrebare
+MSG_QUIT_USDX=Chiar ieşi?
+MSG_END_PARTY=Chiar ieşi din modul party?
+
+ERROR_NO_SONGS=Nu există cântece
+ERROR_NO_PLUGINS=Nu există plugin-uri
+ERROR_NO_MODES_FOR_CURRENT_SETUP=Nu există moduri disponibile pentru jucătorul și echipele actuale
+ERROR_CAN_NOT_START_PARTY=O eroare a avut loc la pornirea jocului in mod party
+ERROR_CORRUPT_SONG=Imposibil de încărcat cântecul.
+ERROR_CORRUPT_SONG_FILE_NOT_FOUND=Imposibil de încărcat cântecul: Fişierul nu a fost găsit
+ERROR_CORRUPT_SONG_NO_NOTES=Nu pot încărca cântecul: Nu există note
+ERROR_CORRUPT_SONG_NO_BREAKS=Nu pot încărca cântecul: Nu sunt pauze de linie
+ERROR_CORRUPT_SONG_UNKNOWN_IN_LINE=Imposibil de încărcat cântecul: Eroare în analiza liniei %0:d
+ERROR_NO_EDITOR=Această caracteristică nu este disponibilă în Linux/Mac
+ERROR_PLAYER_DEVICE_ASSIGNMENT=Jucătorului %d i s-au atribuit mai multe microfoane. Verifică opţiunile de microfon.
+ERROR_PLAYER_NO_DEVICE_ASSIGNMENT=Jucătorului %d nu i s-a atribuit nici un microfon. Verifică opţiunile de microfon.
+;UNUSED: OPTION_VALUE_CHINESE=Chineză
+;UNUSED: OPTION_VALUE_RUSSIAN=Rusă
+;i translated "preview"="vezi" (not "previzualizare" because it's too long)
+;"Top" instead of "Cele mai mari" and "Cei mai buni" 
+;"_Introduce" instead of " Introduce" because apparently the program ignore the initial blank space 
+;needed to separate the text from its button (bug?)
+;PARTY_PLAYER_ENTER_NAME =_Introduce nume
+;TRANSLATOR: Teodor Sandu relu902(a)yahoo.es


### PR DESCRIPTION
Not sure if it was a political reason it got removed, but I haven't seen any other reason. The language file itself does look good from my point of view (not being able to speak romanian).

Having this as a pull request instead of a direct commit to get votes on it (or a opinion).


n.b. 1: Language file is not updated.
n.b. 2: Reverted from changes done in c4fc4aaf35a1c6469f747f50afcbac10be9e3342