### PR TITLE
Added Gaelic translation back

### DIFF
--- a/game/languages/Gaelic.ini
+++ b/game/languages/Gaelic.ini
@@ -1,0 +1,446 @@
+﻿[Text]
+OPTION_VALUE_CATALAN=Catalanais
+OPTION_VALUE_CHINESE=Sìnis
+OPTION_VALUE_CROATIAN=Cròthaisis
+OPTION_VALUE_CZECH=Seicis
+OPTION_VALUE_DANISH=Danmhairgis
+OPTION_VALUE_DUTCH=Duitsis
+OPTION_VALUE_ENGLISH=Beurla
+OPTION_VALUE_EUSKARA=Basgais
+OPTION_VALUE_FINNISH=Fionnlannais
+OPTION_VALUE_FRENCH=Fraingis
+;TODO: OPTION_VALUE_GAELIC=Gaelic
+OPTION_VALUE_GERMAN=Gearmailtis
+OPTION_VALUE_GREEK=Greugais
+OPTION_VALUE_HUNGARIAN=Ungairis
+OPTION_VALUE_ICELANDIC=Innis Tìlis
+OPTION_VALUE_ITALIAN=Eadailtis
+OPTION_VALUE_JAPANESE=Seapanais
+OPTION_VALUE_LUXEMBOURGISH=Lugsamburgais
+OPTION_VALUE_NORWEGIAN=Nirribhis
+OPTION_VALUE_POLISH=Pòlainnis
+OPTION_VALUE_PORTUGUESE=Portagailis
+OPTION_VALUE_ROMANIAN=Romàinis
+OPTION_VALUE_RUSSIAN=Ruisis
+OPTION_VALUE_SERBIAN=Sèirbis
+OPTION_VALUE_SLOVAK=Slòbhacais
+OPTION_VALUE_SLOVENIAN=Slòbhainis
+OPTION_VALUE_SPANISH=Spàinntis
+OPTION_VALUE_SWEDISH=Suainis
+
+OPTION_VALUE_EASY=Furasta
+OPTION_VALUE_MEDIUM=Meadhanach
+OPTION_VALUE_HARD=Doirbh
+
+OPTION_VALUE_ON=Air
+OPTION_VALUE_OFF=Dheth
+
+OPTION_VALUE_EDITION=Deasachadh
+OPTION_VALUE_GENRE=Gnè
+OPTION_VALUE_LANGUAGE=Cànan
+OPTION_VALUE_FOLDER=Pasgan
+OPTION_VALUE_TITLE=Tiotal
+OPTION_VALUE_ARTIST=Ceòladair
+OPTION_VALUE_TITLE2=Tiotal 2
+OPTION_VALUE_ARTIST2=Ceòladair 2
+
+OPTION_VALUE_WHENNOVIDEO=Nuair nach eil video ann
+
+OPTION_VALUE_SMALL=Beag
+OPTION_VALUE_BIG=Mòr
+
+OPTION_VALUE_HALF=Leth mheud
+OPTION_VALUE_FULL_VID=Làn-sgrìn (video)
+OPTION_VALUE_FULL_VID_BG=Làn-sgrìn (cùlaibh & video)
+
+OPTION_VALUE_AUTO=Fèin-obrachail
+OPTION_VALUE_SEC=Diog
+OPTION_VALUE_SECS=Diogan
+
+OPTION_VALUE_PLAIN=Lom
+OPTION_VALUE_OLINE1=Oir-loidhne 1
+OPTION_VALUE_OLINE2=Oir-loidhne 2
+
+OPTION_VALUE_SIMPLE=Simplidh
+OPTION_VALUE_ZOOM=Sùm
+OPTION_VALUE_SLIDE=Lìonadh
+OPTION_VALUE_BALL=Bàla
+OPTION_VALUE_SHIFT=Leum
+
+OPTION_VALUE_EURO=Eòrpach
+OPTION_VALUE_JAPAN=Seapanach
+OPTION_VALUE_AMERICAN=Aimeireaganach
+
+OPTION_VALUE_BLUE=Gorm
+OPTION_VALUE_GREEN=Uaine
+OPTION_VALUE_PINK=Pinc
+OPTION_VALUE_RED=Dearg
+OPTION_VALUE_VIOLET=Purpaidh
+OPTION_VALUE_ORANGE=Orainds
+OPTION_VALUE_YELLOW=Buidhe
+OPTION_VALUE_BROWN=Donn
+OPTION_VALUE_BLACK=Dubh
+
+OPTION_VALUE_SING=Seinn
+OPTION_VALUE_SELECT_PLAYERS=Tagh cluicheadairean
+OPTION_VALUE_OPEN_MENU=Fosgail an clàr-taice
+
+OPTION_VALUE_HARDWARE_CURSOR=Cùrsair bathair-chruaidh
+OPTION_VALUE_SOFTWARE_CURSOR=Cùrsair bathair-bhuig
+
+SING_LOADING=Ga luchdadh...
+
+SING_CHOOSE_MODE=tagh am modh
+SING_SING=seinn
+SING_SING_DESC=geama luath: seinn nad aonar no ann an dithis
+
+SING_MULTI=cèilidh
+SING_MULTI_DESC=seinn sa mhodh chèilidh
+
+SING_TOOLS=innealan
+
+SING_STATS=stadastaireachd
+SING_STATS_DESC=Seall an stadastaireachd
+
+SING_EDITOR=deasaiche
+SING_EDITOR_DESC=cruthaich an t-òran agad fhèin
+
+SING_GAME_OPTIONS=roghainnean a' gheama
+SING_GAME_OPTIONS_DESC=atharraich roghainnean a' gheama
+
+SING_EXIT=fàg an-seo
+SING_EXIT_DESC=fàg an geama
+
+SING_OPTIONS=roghainnean
+SING_OPTIONS_DESC=atharraich na roghainnean
+SING_OPTIONS_WHEREAMI=Roghainnean
+
+SING_OPTIONS_GAME=geama
+SING_OPTIONS_GRAPHICS=grafaigeachd
+SING_OPTIONS_SOUND=fuaim
+SING_OPTIONS_LYRICS=faclan
+SING_OPTIONS_THEMES=ùrlaran
+SING_OPTIONS_RECORD=clàradh
+SING_OPTIONS_ADVANCED=adhartach
+SING_OPTIONS_EXIT=air ais
+
+SING_OPTIONS_GAME_WHEREAMI=Roghainnean a' gheama
+SING_OPTIONS_GAME_DESC=roghainnean coitcheann a' gheama
+SING_OPTIONS_GAME_PLAYERS=Cluicheadairean
+SING_OPTIONS_GAME_DIFFICULTY=Duilgheadas
+SING_OPTIONS_GAME_LANGUAGE=Cànan
+SING_OPTIONS_GAME_TABS=Tabaichean
+SING_OPTIONS_GAME_SORTING=Seòrsachadh
+SING_OPTIONS_GAME_DEBUG=Dì-bhugachadh
+
+SING_OPTIONS_GRAPHICS_WHEREAMI=Roghainnean na grafaigeachd
+SING_OPTIONS_GRAPHICS_DESC=roghainnean na grafaigeachd
+SING_OPTIONS_GRAPHICS_RESOLUTION=Breacadh-sgrìn
+SING_OPTIONS_GRAPHICS_FULLSCREEN=Làn-sgrìn
+SING_OPTIONS_GRAPHICS_DEPTH=Doimhne
+SING_OPTIONS_GRAPHICS_VISUALIZER=Fir chlis
+;TODO: SING_OPTIONS_GRAPHICS_OSCILLOSCOPE=Oscilloscope
+SING_OPTIONS_GRAPHICS_LINEBONUS=Duais loidhne
+SING_OPTIONS_GRAPHICS_MOVIE_SIZE=Meud an fhilm
+
+SING_OPTIONS_SOUND_WHEREAMI=Roghainnean na fuaime
+SING_OPTIONS_SOUND_DESC=roghainnean na fuaime
+SING_OPTIONS_SOUND_VOICEPASSTHROUGH=Ath-chluich a' mhic
+SING_OPTIONS_SOUND_BACKGROUNDMUSIC=Ceòl a' chùlaibh
+SING_OPTIONS_RECORD_MIC_BOOST=Neartachadh a' mhic
+SING_OPTIONS_SOUND_CLICK_ASSIST=Cuidiche gliog
+SING_OPTIONS_SOUND_BEAT_CLICK=Gliog nam buillean
+SING_OPTIONS_RECORD_THRESHOLD=Stairsneach
+SING_OPTIONS_SOUND_TWO_PLAYERS_MODE=Modh dà-chluicheadair
+SING_OPTIONS_SOUND_PREVIEWVOLUME=Ro-sheall an àirde
+SING_OPTIONS_SOUND_PREVIEWFADING=Ro-sheall an crìonadh
+
+SING_OPTIONS_LYRICS_WHEREAMI=Roghainnean nam faclan
+SING_OPTIONS_LYRICS_DESC=roghainnean nam faclan
+SING_OPTIONS_LYRICS_FONT=Cruth-clò
+SING_OPTIONS_LYRICS_EFFECT=Èifeachd
+SING_OPTIONS_LYRICS_SOLMIZATION=Canntaireachd
+SING_OPTIONS_LYRICS_NOTELINES=Clàran
+
+SING_OPTIONS_THEMES_WHEREAMI=Roghainnean nan ùrlaran
+SING_OPTIONS_THEMES_DESC=roghainnean nan ùrlaran is nan craicnean
+SING_OPTIONS_THEMES_THEME=Ùrlar
+SING_OPTIONS_THEMES_SKIN=Craiceann
+SING_OPTIONS_THEMES_COLOR=Dath
+
+SING_OPTIONS_RECORD_WHEREAMI=Roghainnean a' chlàraidh
+SING_OPTIONS_RECORD_DESC=roghainnean a' mhicreofon
+SING_OPTIONS_RECORD_CARD=Cairt fuaime
+SING_OPTIONS_RECORD_INPUT=Ion-chur
+SING_OPTIONS_RECORD_CHANNEL=Seanail 
+
+SING_OPTIONS_ADVANCED_WHEREAMI=Roghainnean adhartach
+SING_OPTIONS_ADVANCED_DESC=roghainnean adhartach
+SING_OPTIONS_ADVANCED_EFFECTSING=Èifeachdan seinne
+SING_OPTIONS_ADVANCED_SCREENFADE=Crìonadh na sgrìn
+SING_OPTIONS_ADVANCED_LOADANIMATION=Luchdaich beòthachadh
+SING_OPTIONS_ADVANCED_ASKBEFOREDEL=Ceistean dìonaidh
+SING_OPTIONS_ADVANCED_LINEBONUS=Duais loidhne
+SING_OPTIONS_ADVANCED_ONSONGCLICK=Tagh òran is ...
+SING_OPTIONS_ADVANCED_PARTYPOPUP=Fèin-chlàr-cèilidh
+
+SING_EDIT=Deasaiche
+SING_EDIT_MENU_DESCRIPTION=cruthaich an t-òran agad fhèin
+
+SING_EDIT_BUTTON_DESCRIPTION_CONVERT=Ion-phortaich teacsa o fhaidhle MIDI
+SING_EDIT_BUTTON_DESCRIPTION_EXIT=air ais
+SING_EDIT_BUTTON_CONVERT=Ion-phortaich
+SING_EDIT_BUTTON_EXIT=air ais
+
+SING_EDIT_NAVIGATE=seòl
+SING_EDIT_SELECT=tagh
+SING_EDIT_EXIT=air ais
+
+SING_LEGEND_SELECT=tagh
+SING_LEGEND_NAVIGATE=seòl
+SING_LEGEND_CONTINUE=air adhart
+SING_LEGEND_ESC=air ais
+
+SING_PLAYER_DESC=cuir a-steach ainmean nan cluicheadairean
+SING_PLAYER_WHEREAMI=Ainmean nan cluicheadairean
+SING_PLAYER_ENTER_NAME=cuir a-steach ainm
+
+SING_DIFFICULTY_DESC=tagh an duilgheadas
+SING_DIFFICULTY_WHEREAMI=Duilgheadas
+SING_DIFFICULTY_CONTINUE=gu taghadh an òrain
+SING_EASY=Furasta
+SING_MEDIUM=Meadhanach
+SING_HARD=Doirbh
+
+SING_SONG_SELECTION_DESC=tagh an t-òran agad
+SING_SONG_SELECTION_WHEREAMI=Taghadh an òrain
+SING_SONG_SELECTION_GOTO=rach gu ...
+SING_SONG_SELECTION=taghadh an òrain
+SING_SONG_SELECTION_MENU=clàr-taice
+SING_SONG_SELECTION_PLAYLIST=liosta cluiche
+SING_SONGS_IN_CAT=Òra(i)n
+PLAYLIST_CATTEXT=Liosta cluiche: %s
+
+SING_TIME=Ùine
+SING_TOTAL=iomlan
+SING_MODE=seinn nad aonar
+SING_NOTES=nòtaichean
+SING_GOLDEN_NOTES=nòtaichean òir
+SING_PHRASE_BONUS=duais loidhne
+
+SING_MENU=Am prìomh chlàr-taice
+
+SONG_SCORE=sgòr an òrain
+SONG_SCORE_WHEREAMI=Sgòr
+
+SING_SCORE_TONE_DEAF=Bodhar
+SING_SCORE_AMATEUR=Neach tòiseachaidh
+SING_SCORE_WANNABE=Suarach
+SING_SCORE_HOPEFUL=Dòchasach
+SING_SCORE_RISING_STAR=Reultag
+SING_SCORE_LEAD_SINGER=Prìomh sheinneadair
+SING_SCORE_SUPERSTAR=Rionnag mhòr
+SING_SCORE_ULTRASTAR=Sàr-rionnag
+
+SING_TOP_5_CHARTS=na 5 cluicheadairean as fhearr
+SING_TOP_5_CHARTS_WHEREAMI=na 5 as fhearr
+SING_TOP_5_CHARTS_CONTINUE=gu taghadh an òrain
+SING_TOP_5_CHARTS_SWITCH_DIFFICULTY=atharraich an duilgheadas
+
+POPUP_PERFECT=foirfe!
+POPUP_AWESOME=sgoinneil!
+POPUP_GREAT=glè mhath!
+POPUP_GOOD=math!
+POPUP_NOTBAD=ceart gu leòr!
+POPUP_BAD=dona!
+POPUP_POOR=sgriosail!
+POPUP_AWFUL=uabhasach!
+
+IMPLODE_GLUE1=,
+IMPLODE_GLUE2=is
+
+SONG_MENU_NAME_MAIN=Clàr-taice
+SONG_MENU_PLAY=Seinn
+SONG_MENU_CHANGEPLAYERS=Cluicheadairean eile
+SONG_MENU_EDIT=Deasaich
+SONG_MENU_MODI=Seinn modh
+SONG_MENU_CANCEL=Sguir dheth
+
+SONG_MENU_NAME_PLAYLIST=Clàr-taice
+SONG_MENU_PLAYLIST_ADD=Cuir òran ris
+SONG_MENU_PLAYLIST_DEL=Sguab òran às
+
+SONG_MENU_NAME_PLAYLIST_ADD=Cuir òran ris
+SONG_MENU_PLAYLIST_ADD_NEW=gu liosta nan òran ùr
+SONG_MENU_PLAYLIST_ADD_EXISTING=gu liosta nan òran ùr a tha ann
+SONG_MENU_PLAYLIST_NOEXISTING=Gun liosta nan òran ri làimh
+
+SONG_MENU_NAME_PLAYLIST_NEW=Liosta nan òran ùr
+SONG_MENU_PLAYLIST_NEW_CREATE=Cruthaich
+SONG_MENU_PLAYLIST_NEW_UNNAMED=Gun ainm
+
+SONG_MENU_NAME_PLAYLIST_DELITEM=A bheil thu airson a sguabadh às?
+SONG_MENU_YES=Tha
+SONG_MENU_NO=Chan eil
+
+SONG_MENU_NAME_PLAYLIST_LOAD=Fosgail liosta nan òran
+SONG_MENU_PLAYLIST_LOAD=fosgail
+SONG_MENU_PLAYLIST_DELCURRENT=sguab às dha liosta nan òran seo
+
+SONG_MENU_NAME_PLAYLIST_DEL=A bheil thu airson liosta nan òran a sguabadh às?
+
+SONG_MENU_NAME_PARTY_MAIN=Clàr-taice
+SONG_MENU_JOKER=Joker
+
+SONG_MENU_NAME_PARTY_JOKER=gabh joker
+
+SONG_JUMPTO_DESC=lorg òran
+SONG_JUMPTO_TYPE_DESC=Lorg:
+SONG_JUMPTO_TYPE1=Na h-uile
+SONG_JUMPTO_TYPE2=Tiotal
+SONG_JUMPTO_TYPE3=Ceòladair
+SONG_JUMPTO_SONGSFOUND=Chaidh %d òra(i)n a lorg
+SONG_JUMPTO_NOSONGSFOUND=Cha deach òran a lorg
+SONG_JUMPTO_HELP=sgrìobh teacsa airson lorg
+SONG_JUMPTO_CATTEXT=Lorg: %s
+
+PARTY_MODE=modh cèilidh
+PARTY_DIFFICULTY=Duilgheadas
+PARTY_PLAYLIST=Liosta nan òran
+PARTY_PLAYLIST_ALL=Na h-uile òran
+PARTY_PLAYLIST_CATEGORY=Pasgan
+PARTY_PLAYLIST_PLAYLIST=Liosta nan òran
+PARTY_TEAMS=sgiobaidhean
+PARTY_TEAMS_PLAYER1=seinneadairean
+PARTY_TEAMS_PLAYER2=seinneadairean
+PARTY_TEAMS_PLAYER3=seinneadairean
+
+PARTY_LEGEND_CONTINUE=air adhart
+
+PARTY_OPTIONS_DESC=roghainnean aig a' gheama chèilidh
+PARTY_OPTIONS_WHEREAMI=Roghainnean cèilidh
+
+PARTY_PLAYER_DESC=cuir a-steach ainmean nan cluicheadairean is nan sgiobaidhean!
+PARTY_PLAYER_WHEREAMI=Ainmean na cèilidh
+PARTY_PLAYER_ENTER_NAME=sgrìobh ainmean
+
+
+PARTY_ROUNDS_DESC=tagh na modhan a tha thu airson cluich
+PARTY_ROUNDS_WHEREAMI=Cuairtean na cèilidh
+PARTY_ROUNDS_LEGEND_CONTINUE=tòisich air geama cèilidh
+PARTY_ROUNDCOUNT=cuairtean
+PARTY_SELECTMODE1=modh cuairt 1
+PARTY_SELECTMODE2=modh cuairt 2
+PARTY_SELECTMODE3=modh cuairt 3
+PARTY_SELECTMODE4=modh cuairt 4
+PARTY_SELECTMODE5=modh cuairt 5
+PARTY_SELECTMODE6=modh cuairt 6
+PARTY_SELECTMODE7=modh cuairt 7
+
+PARTY_ROUND_DESC=na h-ath-chluicheadairean dhan mhicreofon
+PARTY_ROUND_WHEREAMI=Ath-chuairt na cèilidh
+PARTY_ROUND_LEGEND_CONTINUE=tòisich a' chuairt
+
+PARTY_SONG_WHEREAMI=Tagh òrain na cèilidh
+PARTY_SONG_LEGEND_CONTINUE=seinn
+PARTY_SONG_MENU=clàr-taice
+
+PARTY_SCORE_DESC=sgòr na cuairte mu dheireadh
+PARTY_SCORE_WHEREAMI=Puingean na cèilidh
+
+PARTY_WIN_DESC=Buannaiche a' gheama chèilidh
+PARTY_WIN_WHEREAMI=Buannaiche na cèilidh
+PARTY_WIN_LEGEND_CONTINUE=till dhan phrìomh chlàr-taice
+
+PARTY_ROUND=Cuairt
+PARTY_ROUND_WINNER=Buannaiche
+PARTY_NOTPLAYEDYET=ri teachd
+PARTY_NOBODY=gun neach sam bith
+NEXT_ROUND=An ath-chuairt:
+
+PARTY_DISMISSED=Faodaidh sibh falbh!
+PARTY_SCORE_WINS=%s
+PARTY_SCORE_WINS2=air buannachd!
+
+MODE_RANDOM_NAME=Modh air thuaiream
+MODE_RANDOM_DESC=Thèid modh a thaghadh air thuaiream
+
+MODE_HOLDTHELINE_NAME=Cùm air an loidhne
+MODE_HOLDTHELINE_DESC=Na fàs nas miosa na sheallas an tomhaire air bàr an rangachaidh dhut.
+
+MODE_5000POINTS_NAME=Gu 5000
+MODE_5000POINTS_DESC=Buannaichidh an cluicheadair a gheibh 5000 puing an toiseach.
+
+MODE_DUEL_NAME=Còmhrag-dhithis
+MODE_DUEL_DESC=Seinn còmhrag-dhithis gu 10000 puing.
+
+MODE_TEAMDUEL_NAME=Còmhrag eadar dà sgioba
+MODE_TEAMDUEL_DESC=Thoir a-null am micreofon!
+
+MODE_BLIND_NAME=Modh dall
+MODE_BLIND_DESC=Còmhrag-dhithis gun nòtaichean.
+
+STAT_MAIN=Stadastaireachd
+STAT_MAIN_DESC=Coitcheann
+STAT_MAIN_WHEREAMI=Stadastaireachd
+
+STAT_OVERVIEW_INTRO=Stadastaireachd %0:s.  \n Ath-shuidheachadh mu dheireadh %2:.2d.%1:.2d.%3:d
+STAT_OVERVIEW_SONG=%0:d òrain (%3:d le video), %1:d dhiubh air an cluich roimhe is %2:d gun chluich roimhe.\n Is %5:s o %4:s an t-òran as mòr-chòrdte.
+STAT_OVERVIEW_PLAYER=Bha %0:d c(h)luicheadair(ean) ann on ath-shuidheachadh mu dheireadh.\n Is %1:s an cluicheadair as fhearr le sgòr cuibheasach dhe %2:d p(h)uing(ean) aige/aice.\n Ràinig %3:s an sgòr as àirde le %4:d p(h)uing(ean).
+
+STAT_FORMAT_DATE=%1:.2d.%0:.2d.%2:d
+
+STAT_DETAIL=Stadastaireachd
+STAT_DETAIL_WHEREAMI=Stadastaireachd
+
+STAT_NEXT=An ath dhuilleag
+STAT_PREV=An duilleag roimhe
+STAT_REVERSE=Òrdugh contrarra
+STAT_PAGE=duilleag %0:d à %1:d\n (innteart %2:d à %3:d)
+
+STAT_DESC_SCORES=Sgòran àrda
+STAT_DESC_SCORES_REVERSED=Sgòran ìosal
+STAT_FORMAT_SCORES=%0:s - %1:d  [%2:s]  %5:s \n (%3:s - %4:s)
+
+STAT_DESC_SINGERS=Air seinn as fhearr
+STAT_DESC_SINGERS_REVERSED=Air seinn as miosa
+STAT_FORMAT_SINGERS=%0:s \n Sgòr cuibheasach: %1:d
+
+STAT_DESC_SONGS=Òrain mòr-chòrdte
+STAT_DESC_SONGS_REVERSED=Òrain nach do chòrd
+STAT_FORMAT_SONGS=%0:s - %1:s \n Chaidh a sheinn %2:d turas/tursan
+
+STAT_DESC_BANDS=Còmhlanan mòr-chòrdte
+STAT_DESC_BANDS_REVERSED=Còmhlanan nach do chòrd
+STAT_FORMAT_BANDS=%0:s \n Chaidh a sheinn %1:d turas/tursan
+
+SCREENSHOT_SAVED=Chaidh an glacadh-sgrìn a shàbhaladh
+SCREENSHOT_FAILED=Cha b' urrainn dhuinn an glacadh-sgrìn a shàbhaladh
+
+INFO_FILE_SAVED=Chaidh am faidhle a shàbhaladh
+ERROR_SAVE_FILE_FAILED=Cha b' urrainn dhuinn am faidhle a shàbhaladh
+ERROR_FILE_NOT_FOUND=Cha deach am faidhle a lorg
+
+ENCODING_ERROR_ASK_FOR_UTF8=Cha ghabh na h-atharraichean a shàbhaladh leis a' chòdachadh seo. Iompachadh gu UTF-8?
+EDITOR_ERROR_NO_TRACK_SELECTED=Cha deach trac a thaghadh
+
+MSG_ERROR_TITLE=Mearachd
+MSG_INFO_TITLE=Fiosrachadh
+MSG_QUESTION_TITLE=Ceist
+MSG_QUIT_USDX=A bheil thu airson UltraStar fhàgail?
+MSG_END_PARTY=A bheil thu airson am modh cèilidh fhàgail?
+
+ERROR_NO_SONGS=Cha deach òran sam bith a luchdadh
+ERROR_NO_PLUGINS=Cha deach plugan sam bith a luchdadh
+ERROR_NO_MODES_FOR_CURRENT_SETUP=chan eil modh ri làimh airson an roghainn dhe cluicheadair/sgioba seo
+ERROR_CAN_NOT_START_PARTY=thachair mearachd le tòiseachadh a' gheama chèilidh
+ERROR_CORRUPT_SONG=Cha b' urrainn dhuinn an t-òran a luchdadh.
+ERROR_CORRUPT_SONG_FILE_NOT_FOUND=Cha b' urrainn dhuinn an t-òran a luchdadh: Cha deach am faidhle a lorg
+ERROR_CORRUPT_SONG_NO_NOTES=Cha b' urrainn dhuinn an t-òran a luchdadh: Cha deach nòtaichean a lorg
+ERROR_CORRUPT_SONG_NO_BREAKS=Cha b' urrainn dhuinn an t-òran a luchdadh: Cha deach brisidhean loidhne a lorg
+ERROR_CORRUPT_SONG_UNKNOWN_IN_LINE=Cha b' urrainn dhuinn an t-òran a luchdadh: Mearachd e parsadh an loidhne %0:d
+ERROR_NO_EDITOR=Chan eil am feart seo ri làimh air Linux/Mac
+ERROR_PLAYER_DEVICE_ASSIGNMENT=Chaidh iomadh micreofon a shònrachadh dha chluicheadair %d. Feuch an toir thu sùil air na roghainnean clàraidh agad
+;TODO: ERROR_PLAYER_NO_DEVICE_ASSIGNMENT=Player %d is not assigned to a microphone. Please check your record options
+;UNUSED: OPTION_VALUE_GAELIC=Gàidhlig na h-Alba
+#;SING_OPTIONS_ADVANCED_COUNT_HOW_OFTEN_SUNG =


### PR DESCRIPTION
Not sure if it was a political reason it got removed, but from what I see, the Gaelic language was replaced by the Galician language (similar to spansih) by the USDX WP mod creaw, which I think misconceived the language and thought it was a wrongly translate galician version. From what I see, the Gaelic file looks good.

Having this as a pull request instead of a direct commit to get votes on it (or a opinion).

n.b. 1: Language file is not updated.
n.b. 2: Reverted from changes done in c4fc4aaf35a1c6469f747f50afcbac10be9e3342