### PR TITLE
Party mode selection screen

### DIFF
--- a/game/themes/Deluxe.ini
+++ b/game/themes/Deluxe.ini
@@ -6877,6 +6877,277 @@ SBGColor = PlayerLight
 STColor = White
 STDColor = GrayDark
 
+[PartyMain]
+Texts = 5
+
+[PartyMainBackground]
+Tex = PartyBG
+
+# main icon
+[PartyMainStatic1]
+X = 65
+Y = 150
+W = 25
+H = 25
+Color = White
+Tex = PartyIcon
+Type = Transparent
+# Type = Colorized
+
+# main icon title
+[PartyMainText1]
+X = 95
+Y = 115
+Color = White
+Font = 0
+Size = 54
+Align = 0
+Text = SING_MULTI
+
+# main icon subtitle
+[PartyMainText2]
+X = 95
+Y = 165
+Color = ColorLightest
+Font = 0
+Size = 30
+Align = 0
+Text = SING_MULTI_DESC
+
+[PartyMainTextDescription]
+X = 95
+Y = 195
+Color = White
+Font = 0
+Size = 30
+Align = 0
+Text = SING_MULTI_TEXT_DESC
+
+# Navigate button text
+[PartyMainText3]
+X = 300
+Y = 548
+Color = Black
+Font = 0
+Size = 24
+Align = 0
+Text = SING_LEGEND_NAVIGATE
+Reflection = 1
+ReflectionSpacing = 13
+
+# Select button text
+[PartyMainText4]
+X = 440
+Y = 548
+Color = Black
+Font = 0
+Size = 24
+Align = 0
+Text = SING_LEGEND_SELECT
+Reflection=1
+ReflectionSpacing=13
+
+# Esc button text
+[PartyMainText5]
+X = 590
+Y = 548
+Color = Black
+Font = 0
+Size = 24
+Align = 0
+Text = SING_LEGEND_ESC
+Reflection=1
+ReflectionSpacing=13
+
+[PartyMainStatic2]
+X = 0
+Y = 545
+W = 250
+H = 30
+Z = 0.4
+Tex = Leiste1
+Color = ColorLight
+Type = Colorized
+Reflection = 1
+ReflectionSpacing = 2
+
+[PartyMainStatic3]
+X = 250
+Y = 545
+W = 550
+H = 30
+Z = 0.4
+Tex = Leiste2
+Color = White
+Type = Transparent
+Reflection = 1
+ReflectionSpacing = 2
+
+[PartyMainStatic4]
+X = 260
+Y = 545
+W = 32
+H = 30
+Z = 0.5
+Tex = ButtonNavi
+Color = White
+Type = Transparent
+Reflection = 1
+ReflectionSpacing = 2
+
+[PartyMainStatic5]
+X = 400
+Y = 545
+W = 32
+H = 30
+Z = 0.5
+Tex = ButtonEnter
+Color = White
+Type = Transparent
+Reflection = 1
+ReflectionSpacing = 2
+
+[PartyMainStatic6]
+X = 550
+Y = 545
+W = 32
+H = 30
+Z = 0.952
+Tex = ButtonEsc
+Color = White
+Type = Transparent
+Reflection = 1
+ReflectionSpacing = 2
+
+[PartyMainButtonCollection1]
+X = 180
+Y = 270
+W = 150
+H = 50
+Tex = Button
+Color = ColorLight
+DColor = ColorDark
+Type = Transparent
+Texts = 1
+Reflection = 1
+ReflectionSpacing = 15
+DeSelectReflectionSpacing = 280
+Fade = 1
+FadeText = 0
+SelectH = 150
+FadeTex = ButtonFade
+FadeTexPos = 0
+FirstChild = 1
+
+[PartyMainButtonCollection1Text1]
+X = 75
+Y = 10
+Font = 0
+Size = 30
+Align = 1
+Text = SING_MULTI
+Color = White
+
+[PartyMainButtonClassic]
+X = 185
+Y = 310
+W = 140
+H = 30
+Tex = Button
+Color = ColorDark
+DColor = ColorLight
+Type = Transparent
+Texts = 1
+Reflection = 0
+Parent = 1
+
+[PartyMainButtonClassicText1]
+X = 70
+Y = 5
+Font = 0
+Size = 20
+Align = 1
+Text = PARTY_MODE_CLASSIC
+Color = White
+
+[PartyMainButtonClassicFree]
+X = 185
+Y = 345
+W = 140
+H = 30
+Tex = Button
+Color = ColorDark
+DColor = ColorLight
+Type = Transparent
+Texts = 1
+Reflection = 0
+Parent = 1
+
+[PartyMainButtonClassicFreeText1]
+X = 70
+Y = 5
+Font = 0
+Size = 20
+Align = 1
+Text = PARTY_MODE_CLASSIC_FREE
+Color = White
+
+[PartyMainButtonChallenge]
+X = 335
+Y = 270
+W = 150
+H = 50
+Tex = Button
+Color = ColorLight
+DColor = ColorDark
+Type = Transparent
+Texts = 1
+Reflection = 1
+ReflectionSpacing = 15
+DeSelectReflectionSpacing = 280
+Fade = 1
+FadeText = 1
+SelectH = 150
+FadeTex = ButtonFade
+FadeTexPos = 0
+
+[PartyMainButtonChallengeText1]
+X = 75
+Y = 10
+Font = 0
+Size = 30
+Align = 1
+Text = PARTY_MODE_CHALLENGE
+Color = White
+
+[PartyMainButtonTournament]
+X = 490
+Y = 270
+W = 150
+H = 50
+Tex = Button
+Color = ColorLight
+DColor = ColorDark
+Type = Transparent
+Texts = 1
+Reflection = 1
+ReflectionSpacing = 15
+DeSelectReflectionSpacing = 280
+Fade = 1
+FadeText = 1
+SelectH = 150
+FadeTex = ButtonFade
+FadeTexPos = 0
+
+[PartyMainButtonTournamentText1]
+X = 75
+Y = 10
+Font = 0
+Size = 30
+Align = 1
+Text = PARTY_MODE_TOURNAMENT
+Color = White
+
 [PartyNewRound]
 Texts = 7
 

--- a/game/themes/Modern.ini
+++ b/game/themes/Modern.ini
@@ -6878,6 +6878,277 @@ SBGColor = PlayerLight
 STColor = White
 STDColor = GrayDark
 
+[PartyMain]
+Texts = 5
+
+[PartyMainBackground]
+Tex = PartyBG
+
+# main icon
+[PartyMainStatic1]
+X = 65
+Y = 150
+W = 25
+H = 25
+Color = White
+Tex = PartyIcon
+Type = Transparent
+# Type = Colorized
+
+# main icon title
+[PartyMainText1]
+X = 95
+Y = 115
+Color = White
+Font = 0
+Size = 54
+Align = 0
+Text = SING_MULTI
+
+# main icon subtitle
+[PartyMainText2]
+X = 95
+Y = 165
+Color = ColorLightest
+Font = 0
+Size = 30
+Align = 0
+Text = SING_MULTI_DESC
+
+[PartyMainTextDescription]
+X = 95
+Y = 195
+Color = White
+Font = 0
+Size = 30
+Align = 0
+Text = SING_MULTI_TEXT_DESC
+
+# Navigate button text
+[PartyMainText3]
+X = 300
+Y = 548
+Color = Black
+Font = 0
+Size = 24
+Align = 0
+Text = SING_LEGEND_NAVIGATE
+Reflection = 1
+ReflectionSpacing = 13
+
+# Select button text
+[PartyMainText4]
+X = 440
+Y = 548
+Color = Black
+Font = 0
+Size = 24
+Align = 0
+Text = SING_LEGEND_SELECT
+Reflection=1
+ReflectionSpacing=13
+
+# Esc button text
+[PartyMainText5]
+X = 590
+Y = 548
+Color = Black
+Font = 0
+Size = 24
+Align = 0
+Text = SING_LEGEND_ESC
+Reflection=1
+ReflectionSpacing=13
+
+[PartyMainStatic2]
+X = 0
+Y = 545
+W = 250
+H = 30
+Z = 0.4
+Tex = Leiste1
+Color = ColorLight
+Type = Colorized
+Reflection = 1
+ReflectionSpacing = 2
+
+[PartyMainStatic3]
+X = 250
+Y = 545
+W = 550
+H = 30
+Z = 0.4
+Tex = Leiste2
+Color = White
+Type = Transparent
+Reflection = 1
+ReflectionSpacing = 2
+
+[PartyMainStatic4]
+X = 260
+Y = 545
+W = 32
+H = 30
+Z = 0.5
+Tex = ButtonNavi
+Color = White
+Type = Transparent
+Reflection = 1
+ReflectionSpacing = 2
+
+[PartyMainStatic5]
+X = 400
+Y = 545
+W = 32
+H = 30
+Z = 0.5
+Tex = ButtonEnter
+Color = White
+Type = Transparent
+Reflection = 1
+ReflectionSpacing = 2
+
+[PartyMainStatic6]
+X = 550
+Y = 545
+W = 32
+H = 30
+Z = 0.952
+Tex = ButtonEsc
+Color = White
+Type = Transparent
+Reflection = 1
+ReflectionSpacing = 2
+
+[PartyMainButtonCollection1]
+X = 180
+Y = 270
+W = 150
+H = 50
+Tex = Button
+Color = ColorLight
+DColor = ColorDark
+Type = Transparent
+Texts = 1
+Reflection = 1
+ReflectionSpacing = 15
+DeSelectReflectionSpacing = 280
+Fade = 1
+FadeText = 0
+SelectH = 150
+FadeTex = ButtonFade
+FadeTexPos = 0
+FirstChild = 1
+
+[PartyMainButtonCollection1Text1]
+X = 75
+Y = 10
+Font = 0
+Size = 30
+Align = 1
+Text = SING_MULTI
+Color = White
+
+[PartyMainButtonClassic]
+X = 185
+Y = 310
+W = 140
+H = 30
+Tex = Button
+Color = ColorDark
+DColor = ColorLight
+Type = Transparent
+Texts = 1
+Reflection = 0
+Parent = 1
+
+[PartyMainButtonClassicText1]
+X = 70
+Y = 5
+Font = 0
+Size = 20
+Align = 1
+Text = PARTY_MODE_CLASSIC
+Color = White
+
+[PartyMainButtonClassicFree]
+X = 185
+Y = 345
+W = 140
+H = 30
+Tex = Button
+Color = ColorDark
+DColor = ColorLight
+Type = Transparent
+Texts = 1
+Reflection = 0
+Parent = 1
+
+[PartyMainButtonClassicFreeText1]
+X = 70
+Y = 5
+Font = 0
+Size = 20
+Align = 1
+Text = PARTY_MODE_CLASSIC_FREE
+Color = White
+
+[PartyMainButtonChallenge]
+X = 335
+Y = 270
+W = 150
+H = 50
+Tex = Button
+Color = ColorLight
+DColor = ColorDark
+Type = Transparent
+Texts = 1
+Reflection = 1
+ReflectionSpacing = 15
+DeSelectReflectionSpacing = 280
+Fade = 1
+FadeText = 1
+SelectH = 150
+FadeTex = ButtonFade
+FadeTexPos = 0
+
+[PartyMainButtonChallengeText1]
+X = 75
+Y = 10
+Font = 0
+Size = 30
+Align = 1
+Text = PARTY_MODE_CHALLENGE
+Color = White
+
+[PartyMainButtonTournament]
+X = 490
+Y = 270
+W = 150
+H = 50
+Tex = Button
+Color = ColorLight
+DColor = ColorDark
+Type = Transparent
+Texts = 1
+Reflection = 1
+ReflectionSpacing = 15
+DeSelectReflectionSpacing = 280
+Fade = 1
+FadeText = 1
+SelectH = 150
+FadeTex = ButtonFade
+FadeTexPos = 0
+
+[PartyMainButtonTournamentText1]
+X = 75
+Y = 10
+Font = 0
+Size = 30
+Align = 1
+Text = PARTY_MODE_TOURNAMENT
+Color = White
+
 [PartyNewRound]
 Texts = 7
 

--- a/src/base/UGraphic.pas
+++ b/src/base/UGraphic.pas
@@ -82,6 +82,7 @@ uses
   UScreenSongMenu,
   UScreenSongJumpto,
   {Party Screens}
+  UScreenParty,
   UScreenPartyNewRound,
   UScreenPartyScore,
   UScreenPartyOptions,
@@ -175,6 +176,7 @@ var
 
   //Party Screens
   //ScreenSingModi:         TScreenSingModi;
+  ScreenParty:            TScreenParty;
   ScreenPartyNewRound:    TScreenPartyNewRound;
   ScreenPartyScore:       TScreenPartyScore;
   ScreenPartyWin:         TScreenPartyWin;
@@ -941,14 +943,16 @@ begin
   //ScreenSingModi :=         TScreenSingModi.Create;
   //Log.BenchmarkEnd(3); Log.LogBenchmark('====> Screen Sing with Modi support', 3); Log.BenchmarkStart(3);
   ScreenSongJumpto :=         TScreenSongJumpto.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenPopupCheck & ScreenPopupError'));
+  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenPopupCheck & ScreenPopupError & ScreenPopupInfo'));
   ScreenPopupCheck := TScreenPopupCheck.Create;
   ScreenPopupError := TScreenPopupError.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenPopupInfo & ScreenScoreX & ScreenPartyNewRound'));
   ScreenPopupInfo := TScreenPopupInfo.Create;
+  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenPopupInsertUser & ScreenPopupSendScore & ScreenPopupScoreDownload'));
   ScreenPopupInsertUser := TScreenPopupInsertUser.Create;
   ScreenPopupSendScore := TScreenPopupSendScore.Create;
   ScreenPopupScoreDownload := TScreenPopupScoreDownload.Create;
+  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenParty & ScreenPartyNewRound'));
+  ScreenParty :=            TScreenParty.Create;
   ScreenPartyNewRound :=    TScreenPartyNewRound.Create;
   SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenPartyScore & ScreenPartyWin'));
   ScreenPartyScore :=       TScreenPartyScore.Create;
@@ -1013,6 +1017,7 @@ begin
   ScreenPopupInsertUser.Free;
   ScreenPopupSendScore.Free;
   ScreenPopupScoreDownload.Free;
+  ScreenParty.Free;
   ScreenPartyNewRound.Free;
   ScreenPartyScore.Free;
   ScreenPartyWin.Free;

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -1073,7 +1073,22 @@ type
     IType:            array [0..2] of UTF8String;
   end;
 
+  //Party
+
+  TThemeParty = class(TThemeBasic)
+    ButtonClassic:        TThemeButton;
+    ButtonClassicFree:    TThemeButton;
+    ButtonChallenge:      TThemeButton;
+    ButtonTournament:     TThemeButton;
+
+    TextDescription:      TThemeText;
+    TextDescriptionLong:  TThemeText;
+    Description:          array[0..3] of UTF8String;
+    DescriptionLong:      array[0..3] of UTF8String;
+  end;
+
   //Party Screens
+
   TThemePartyNewRound = class(TThemeBasic)
     TextRound1:        TThemeText;
     TextRound2:        TThemeText;
@@ -1364,6 +1379,7 @@ type
     SongMenu:         TThemeSongMenu;
     SongJumpto:       TThemeSongJumpTo;
     //Party Screens:
+    Party:            TThemeParty;
     PartyNewRound:    TThemePartyNewRound;
     PartyScore:       TThemePartyScore;
     PartyWin:         TThemePartyWin;
@@ -1529,6 +1545,10 @@ begin
 
   SongMenu := TThemeSongMenu.Create;
   SongJumpto := TThemeSongJumpto.Create;
+
+  //Party
+  Party := TThemeParty.Create;
+
   //Party Screens
   PartyNewRound := TThemePartyNewRound.Create;
   PartyWin := TThemePartyWin.Create;
@@ -2487,6 +2507,32 @@ begin
       SongJumpto.SongsFound := Language.Translate('SONG_JUMPTO_SONGSFOUND');
       SongJumpto.NoSongsFound := Language.Translate('SONG_JUMPTO_NOSONGSFOUND');
       SongJumpto.CatText := Language.Translate('SONG_JUMPTO_CATTEXT');
+
+      // Party
+      ThemeLoadBasic(Party, 'PartyMain');
+
+      ThemeLoadText(Party.TextDescription, 'PartyMainTextDescription');
+      ThemeLoadText(Party.TextDescriptionLong, 'PartyMainTextDescriptionLong');
+      ThemeLoadButton(Party.ButtonClassic, 'PartyMainButtonClassic');
+      ThemeLoadButton(Party.ButtonClassicFree, 'PartyMainButtonClassicFree');
+      ThemeLoadButton(Party.ButtonChallenge, 'PartyMainButtonChallenge');
+      ThemeLoadButton(Party.ButtonTournament, 'PartyMainButtonTournament');
+
+      // Party Desc Text Translation Start
+
+      Party.Description[0] := Language.Translate('PARTY_MODE_CLASSIC');
+      Party.DescriptionLong[0] := Language.Translate('PARTY_MODE_CLASSIC_DESC');
+      Party.Description[1] := Language.Translate('PARTY_MODE_CLASSIC_FREE');
+      Party.DescriptionLong[1] := Language.Translate('PARTY_MODE_CLASSIC_FREE_DESC');
+      Party.Description[2] := Language.Translate('PARTY_MODE_CHALLENGE');
+      Party.DescriptionLong[2] := Language.Translate('PARTY_MODE_CHALLENGE_DESC');
+      Party.Description[3] := Language.Translate('PARTY_MODE_TOURNAMENT');
+      Party.DescriptionLong[3] := Language.Translate('PARTY_MODE_TOURNAMENT_DESC');
+
+      // Party Desc Text Translation End
+
+      Party.TextDescription.Text := Party.Description[0];
+      Party.TextDescriptionLong.Text := Party.DescriptionLong[0];
 
       //Party Options
       ThemeLoadBasic(PartyOptions, 'PartyOptions');
@@ -4559,7 +4605,10 @@ begin
   freeandnil(SongJumpto);
   SongJumpto := TThemeSongJumpto.Create;
 
-  //Party Screens
+  //Party
+  freeandnil(Party);
+  Party := TThemeParty.Create;
+
   freeandnil(PartyNewRound);
   PartyNewRound := TThemePartyNewRound.Create;
 

--- a/src/screens/UScreenMain.pas
+++ b/src/screens/UScreenMain.pas
@@ -114,7 +114,7 @@ begin
       Ord('M'): begin
         if (Ini.Players >= 1) and (Party.ModesAvailable) then
         begin
-          FadeTo(@ScreenPartyOptions, SoundLib.Start);
+          FadeTo(@ScreenParty, SoundLib.Start);
           Exit;
         end;
       end;
@@ -172,7 +172,7 @@ begin
           begin
             Party.bPartyGame := true;
 
-            FadeTo(@ScreenPartyOptions, SoundLib.Start);
+            FadeTo(@ScreenParty, SoundLib.Start);
           end
           else //show error message, No Songs Loaded
             ScreenPopupError.ShowPopup(Language.Translate('ERROR_NO_SONGS'));

--- a/src/screens/UScreenParty.pas
+++ b/src/screens/UScreenParty.pas
@@ -1,0 +1,133 @@
+{* UltraStar Deluxe - Karaoke Game
+ *
+ * UltraStar Deluxe is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING. If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ * $URL: $
+ * $Id: $
+ *}
+
+unit UScreenParty;
+
+interface
+
+{$IFDEF FPC}
+  {$MODE Delphi}
+{$ENDIF}
+
+{$I switches.inc}
+
+uses
+  UMenu,
+  sdl2,
+  UMusic,
+  UThemes;
+
+type
+  TScreenParty = class(TMenu)
+    public
+      TextDescription:     integer;
+      TextDescriptionLong: integer;
+
+      constructor Create; override;
+      procedure OnShow; override;
+      function ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean; override;
+      procedure SetInteraction(Num: integer); override;
+      procedure SetAnimationProgress(Progress: real); override;
+  end;
+
+implementation
+
+uses
+  UGraphic,
+  ULanguage,
+  UUnicodeUtils;
+
+function TScreenParty.ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean;
+begin
+  Result := true;
+  if (PressedDown) then
+  begin // Key Down
+    // check normal keys
+    case UCS4UpperCase(CharCode) of
+      Ord('Q'):
+        begin
+          Result := false;
+          Exit;
+        end;
+    end;
+
+    // check special keys
+    case PressedKey of
+      SDLK_ESCAPE,
+      SDLK_BACKSPACE : FadeTo(@ScreenMain, SoundLib.Back);
+      SDLK_RETURN:
+        begin
+          if Interaction = 3 then // challenge not available yet
+            ScreenPopupError.ShowPopup(Language.Translate('PARTY_MODE_NOT_AVAILABLE'))
+          else
+            FadeTo(@ScreenPartyOptions, SoundLib.Start);
+        end;
+
+      SDLK_DOWN:  InteractInc;
+      SDLK_UP:    InteractDec;
+      SDLK_RIGHT: InteractNext;
+      SDLK_LEFT:  InteractPrev;
+    end;
+  end;
+end;
+
+constructor TScreenParty.Create;
+begin
+  inherited Create;
+
+  TextDescription := AddText(Theme.Party.TextDescription);
+  TextDescriptionLong := AddText(Theme.Party.TextDescriptionLong);
+
+  LoadFromTheme(Theme.Party);
+
+  AddButton(Theme.Party.ButtonClassic);
+  AddButton(Theme.Party.ButtonClassicFree);
+  AddButton(Theme.Party.ButtonChallenge);
+  AddButton(Theme.Party.ButtonTournament);
+
+  Interaction := 0;
+end;
+
+procedure TScreenParty.OnShow;
+begin
+  inherited;
+
+end;
+
+procedure TScreenParty.SetInteraction(Num: integer);
+begin
+  inherited SetInteraction(Num);
+  Text[TextDescription].Text     := Theme.Party.Description[Interaction];
+  Text[TextDescriptionLong].Text := Theme.Party.DescriptionLong[Interaction];
+end;
+
+procedure TScreenParty.SetAnimationProgress(Progress: real);
+begin
+  Button[0].Texture.ScaleW := Progress;
+  Button[1].Texture.ScaleW := Progress;
+  Button[2].Texture.ScaleW := Progress;
+end;
+
+end.

--- a/src/screens/UScreenParty.pas
+++ b/src/screens/UScreenParty.pas
@@ -124,10 +124,10 @@ begin
 end;
 
 procedure TScreenParty.SetAnimationProgress(Progress: real);
+var I: integer;
 begin
-  Button[0].Texture.ScaleW := Progress;
-  Button[1].Texture.ScaleW := Progress;
-  Button[2].Texture.ScaleW := Progress;
+  for I := 0 to High(Button) do
+    Button[I].Texture.ScaleW := Progress;
 end;
 
 end.

--- a/src/ultrastardx.dpr
+++ b/src/ultrastardx.dpr
@@ -338,6 +338,7 @@ uses
   UScreenPopup            in 'screens\UScreenPopup.pas',
 
   //Includes - Screens PartyMode
+  UScreenParty            in 'screens\UScreenParty.pas',
   UScreenPartyNewRound    in 'screens\UScreenPartyNewRound.pas',
   UScreenPartyScore       in 'screens\UScreenPartyScore.pas',
   UScreenPartyPlayer      in 'screens\UScreenPartyPlayer.pas',


### PR DESCRIPTION
Instead of having a party menu with a slider to select the party mode and change specific sliders accordingly (and eventually switch to another screen) this new screen route the user to a specific mode's options.

This is a WIP screen and will point to the specific screens instead of ScreenPartyOptions. In order to keep the PR small, I just kept everything in place and didn't change any other behavior/look of the party screen. The party options screen should be split into several option screens, for each unique mode its own.

![137](https://cloud.githubusercontent.com/assets/6833006/17352176/cb96b6b2-5934-11e6-9496-e7acbca4642f.png)

<img src="https://cloud.githubusercontent.com/assets/6833006/17352158/9e5bf1b2-5934-11e6-9989-42a109ef25df.gif" alt="" width="200px">


PS: I am actually working on something similar and that's why I made this smaller PR.