### PR TITLE
Increase audio device polling time to 1500ms

### DIFF
--- a/src/media/UAudioCore_Portaudio.pas
+++ b/src/media/UAudioCore_Portaudio.pas
@@ -314,8 +314,8 @@ begin
   end;
 
   cbWorks := false;
-  // check if the callback was called (poll for max. 400ms)
-  for cbPolls := 1 to 40 do
+  // check if the callback was called (poll for max. 1500ms)
+  for cbPolls := 1 to 150 do
   begin
     // if the test-callback was called it should be aborted now
     if (Pa_IsStreamActive(stream) = 0) then


### PR DESCRIPTION
Polling on Mac OS X 10.11 seems to be taking between 450-1100ms. Fixes #119