### PR TITLE
Better ffmpeg_version handling in autoconf

### DIFF
--- a/configure
+++ b/configure
@@ -6187,48 +6187,49 @@ eof
         # map avutil library version to ffmpeg version
         { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of ffmpeg" >&5
 $as_echo_n "checking version of ffmpeg... " >&6; }
-        if test $libavutil_VERSION_INT -le 60000000; then
-		if   test $libavutil_VERSION_INT -ge 55027100; then
-			FFMPEG_VERSION="3.1"
-		elif test $libavutil_VERSION_INT -ge 55017100; then
-			FFMPEG_VERSION="3.0"
-		elif test $libavutil_VERSION_INT -ge 54031100; then
-			FFMPEG_VERSION="2.8"
-		elif test $libavutil_VERSION_INT -ge 54027100; then
-			FFMPEG_VERSION="2.7"
-		elif test $libavutil_VERSION_INT -ge 54020100; then
-			FFMPEG_VERSION="2.6"
-		elif test $libavutil_VERSION_INT -ge 54015100; then
-			FFMPEG_VERSION="2.5"
-		elif test $libavutil_VERSION_INT -ge 54007001; then
-			FFMPEG_VERSION="2.4"
-		elif test $libavutil_VERSION_INT -ge 52066100; then
-			FFMPEG_VERSION="2.2"
-		elif test $libavutil_VERSION_INT -ge 52048100; then
-			FFMPEG_VERSION="2.1"
-		elif test $libavutil_VERSION_INT -ge 52038100; then
-			FFMPEG_VERSION="2.0"
-		elif test $libavutil_VERSION_INT -ge 52018100; then
-			FFMPEG_VERSION="1.2"
-		elif test $libavutil_VERSION_INT -ge 52013100; then
-			FFMPEG_VERSION="1.1"
-		elif test $libavutil_VERSION_INT -ge 51073101; then
-			FFMPEG_VERSION="1.0"
-		elif test $libavutil_VERSION_INT -ge 51054100; then
-			FFMPEG_VERSION="0.11"
-		elif test $libavutil_VERSION_INT -ge 51034101; then
-			FFMPEG_VERSION="0.10"
-		elif test $libavutil_VERSION_INT -ge 51032000; then
-			FFMPEG_VERSION="0.9"
-		elif test $libavutil_VERSION_INT -ge 51009001; then
-			FFMPEG_VERSION="0.8"
-		elif test $libavutil_VERSION_INT -ge 50043000; then
-			FFMPEG_VERSION="0.7"
-		else
-			FFMPEG_VERSION="0"
-		fi
-        else
+        if   test $libavutil_VERSION_INT -le 55028100 -a $libavutil_VERSION_INT -ge 55027100; then
+            FFMPEG_VERSION="3.1"
+        elif test $libavutil_VERSION_INT -eq 55017103; then
+            FFMPEG_VERSION="3.0"
+        elif test $libavutil_VERSION_INT -le 54099100 -a $libavutil_VERSION_INT -ge 54030100; then
+            FFMPEG_VERSION="2.8"
+        elif test $libavutil_VERSION_INT -le 54030100 -a $libavutil_VERSION_INT -ge 54027100; then
+            FFMPEG_VERSION="2.7"
+        elif test $libavutil_VERSION_INT -eq 54020100; then
+            FFMPEG_VERSION="2.6"
+        elif test $libavutil_VERSION_INT -eq 54015100; then
+            FFMPEG_VERSION="2.5"
+        elif test $libavutil_VERSION_INT -eq 54007100; then
+            FFMPEG_VERSION="2.4"
+        elif test $libavutil_VERSION_INT -eq 52066100; then
+            FFMPEG_VERSION="2.2"
+        elif test $libavutil_VERSION_INT -le 52048101 -a $libavutil_VERSION_INT -ge 52048100; then
+            FFMPEG_VERSION="2.1"
+        elif test $libavutil_VERSION_INT -le 52038100 -a $libavutil_VERSION_INT -ge 52038000; then
+            FFMPEG_VERSION="2.0"
+        elif test $libavutil_VERSION_INT -le 52018100 -a $libavutil_VERSION_INT -ge 52018000; then
+            FFMPEG_VERSION="1.2"
+        elif test $libavutil_VERSION_INT -le 52013100 -a $libavutil_VERSION_INT -ge 52013000; then
+            FFMPEG_VERSION="1.1"
+        elif test $libavutil_VERSION_INT -le 51073101 -a $libavutil_VERSION_INT -ge 51073000; then
+            FFMPEG_VERSION="1.0"
+        elif test $libavutil_VERSION_INT -le 51054100 -a $libavutil_VERSION_INT -ge 51054000; then
+            FFMPEG_VERSION="0.11"
+        elif test $libavutil_VERSION_INT -le 51035100 -a $libavutil_VERSION_INT -ge 51034101; then
+            FFMPEG_VERSION="0.10"
+        elif test $libavutil_VERSION_INT -eq 51032000; then
+            FFMPEG_VERSION="0.9"
+        elif test $libavutil_VERSION_INT -le 51022002 -a $libavutil_VERSION_INT -ge 51009001; then
+            FFMPEG_VERSION="0.8"
+        elif test $libavutil_VERSION_INT -eq 50043000; then
+            FFMPEG_VERSION="0.7"
+        elif test $libavutil_VERSION_INT -le 50024000 -a $libavutil_VERSION_INT -ge 49000001; then
             FFMPEG_VERSION="0"
+        else
+            as_fn_error $? "
+
+Unsupported ffmpeg version.
+" "$LINENO" 5
         fi
 
     version=$FFMPEG_VERSION

--- a/configure
+++ b/configure
@@ -620,6 +620,11 @@ libswscale_VERSION_MINOR
 libswscale_VERSION_MAJOR
 libswscale_VERSION
 DEFINE_HAVE_FFMPEG
+FFMPEG_VERSION
+FFMPEG_VERSION_INT
+FFMPEG_VERSION_RELEASE
+FFMPEG_VERSION_MINOR
+FFMPEG_VERSION_MAJOR
 libavutil_VERSION_INT
 libavutil_VERSION_RELEASE
 libavutil_VERSION_MINOR
@@ -641,11 +646,6 @@ lua_VERSION_RELEASE
 lua_VERSION_MINOR
 lua_VERSION_MAJOR
 lua_VERSION
-FFMPEG_VERSION
-FFMPEG_VERSION_INT
-FFMPEG_VERSION_RELEASE
-FFMPEG_VERSION_MINOR
-FFMPEG_VERSION_MAJOR
 libpng_VERSION_INT
 libpng_VERSION_RELEASE
 libpng_VERSION_MINOR
@@ -4575,93 +4575,7 @@ eof
 
 
 
-    # for avutil: map library version to ffmpeg version
-    if test libpng = "libavutil"; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of ffmpeg" >&5
-$as_echo_n "checking version of ffmpeg... " >&6; }
-    	if test $libpng_VERSION_INT -le 60000000; then
-		if   test $libpng_VERSION_INT -ge 55027100; then
-			FFMPEG_VERSION="3.1"
-		elif test $libpng_VERSION_INT -ge 55017100; then
-			FFMPEG_VERSION="3.0"
-		elif test $libpng_VERSION_INT -ge 54031100; then
-			FFMPEG_VERSION="2.8"
-		elif test $libpng_VERSION_INT -ge 54027100; then
-			FFMPEG_VERSION="2.7"
-		elif test $libpng_VERSION_INT -ge 54020100; then
-			FFMPEG_VERSION="2.6"
-		elif test $libpng_VERSION_INT -ge 54015100; then
-			FFMPEG_VERSION="2.5"
-		elif test $libpng_VERSION_INT -ge 54007001; then
-			FFMPEG_VERSION="2.4"
-		elif test $libpng_VERSION_INT -ge 52066100; then
-			FFMPEG_VERSION="2.2"
-		elif test $libpng_VERSION_INT -ge 52048100; then
-			FFMPEG_VERSION="2.1"
-		elif test $libpng_VERSION_INT -ge 52038100; then
-			FFMPEG_VERSION="2.0"
-		elif test $libpng_VERSION_INT -ge 52018100; then
-			FFMPEG_VERSION="1.2"
-		elif test $libpng_VERSION_INT -ge 52013100; then
-			FFMPEG_VERSION="1.1"
-		elif test $libpng_VERSION_INT -ge 51073101; then
-			FFMPEG_VERSION="1.0"
-		elif test $libpng_VERSION_INT -ge 51054100; then
-			FFMPEG_VERSION="0.11"
-		elif test $libpng_VERSION_INT -ge 51034101; then
-			FFMPEG_VERSION="0.10"
-		elif test $libpng_VERSION_INT -ge 51032000; then
-			FFMPEG_VERSION="0.9"
-		elif test $libpng_VERSION_INT -ge 51009001; then
-			FFMPEG_VERSION="0.8"
-		elif test $libpng_VERSION_INT -ge 50043000; then
-			FFMPEG_VERSION="0.7"
-		else
-			FFMPEG_VERSION="0"
-		fi
-	else
-		FFMPEG_VERSION="0"
-	fi
 
-    version=$FFMPEG_VERSION
-
-    # strip leading non-numeric tokens
-    # (necessary for some ffmpeg-packages in ubuntu)
-    # example: 0d.51.1.0 -> 51.1.0
-    version=`echo $version | sed 's/^[^.]*[^0-9.][^.]*\.//'`
-
-    # replace "." and "-" with " " and ignore trailing tokens.
-    # 1.23.4-r2 will be splitted to [maj=1, min=23, rel=4].
-    # In addition we delete everything after the first character
-    # which is not 0-9.
-    # 1.3a4-r32 will be [maj=1, min=3, rel=0].
-    read major minor release ignore <<eof
-        `echo $version | tr '.-' ' ' | sed 's/[^0-9\ ].*//'`
-eof
-    # Note: Do NOT indent the eof-delimiter
-    # We use a here-document (<<< here-strings not POSIX compatible)
-
-    test -z $major && major=0
-    test -z $minor && minor=0
-    test -z $release && release=0
-
-    # strip preceding 0s and set unset version-parts to 0
-    FFMPEG_VERSION_MAJOR=$(($major))
-    FFMPEG_VERSION_MINOR=$(($minor))
-    FFMPEG_VERSION_RELEASE=$(($release))
-    # integer representation: MMMmmmrrr (M:major,m:minor,r:release)
-    # can be used if pkg-config's comparison fails
-    FFMPEG_VERSION_INT=$(($FFMPEG_VERSION_MAJOR*1000000+$FFMPEG_VERSION_MINOR*1000+$FFMPEG_VERSION_RELEASE))
-
-
-
-
-
-
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: [$FFMPEG_VERSION]" >&5
-$as_echo "[$FFMPEG_VERSION]" >&6; }
-    fi
 
 else
     # check for the generic .pc file
@@ -4805,93 +4719,7 @@ eof
 
 
 
-    # for avutil: map library version to ffmpeg version
-    if test libpng = "libavutil"; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of ffmpeg" >&5
-$as_echo_n "checking version of ffmpeg... " >&6; }
-    	if test $libpng_VERSION_INT -le 60000000; then
-		if   test $libpng_VERSION_INT -ge 55027100; then
-			FFMPEG_VERSION="3.1"
-		elif test $libpng_VERSION_INT -ge 55017100; then
-			FFMPEG_VERSION="3.0"
-		elif test $libpng_VERSION_INT -ge 54031100; then
-			FFMPEG_VERSION="2.8"
-		elif test $libpng_VERSION_INT -ge 54027100; then
-			FFMPEG_VERSION="2.7"
-		elif test $libpng_VERSION_INT -ge 54020100; then
-			FFMPEG_VERSION="2.6"
-		elif test $libpng_VERSION_INT -ge 54015100; then
-			FFMPEG_VERSION="2.5"
-		elif test $libpng_VERSION_INT -ge 54007001; then
-			FFMPEG_VERSION="2.4"
-		elif test $libpng_VERSION_INT -ge 52066100; then
-			FFMPEG_VERSION="2.2"
-		elif test $libpng_VERSION_INT -ge 52048100; then
-			FFMPEG_VERSION="2.1"
-		elif test $libpng_VERSION_INT -ge 52038100; then
-			FFMPEG_VERSION="2.0"
-		elif test $libpng_VERSION_INT -ge 52018100; then
-			FFMPEG_VERSION="1.2"
-		elif test $libpng_VERSION_INT -ge 52013100; then
-			FFMPEG_VERSION="1.1"
-		elif test $libpng_VERSION_INT -ge 51073101; then
-			FFMPEG_VERSION="1.0"
-		elif test $libpng_VERSION_INT -ge 51054100; then
-			FFMPEG_VERSION="0.11"
-		elif test $libpng_VERSION_INT -ge 51034101; then
-			FFMPEG_VERSION="0.10"
-		elif test $libpng_VERSION_INT -ge 51032000; then
-			FFMPEG_VERSION="0.9"
-		elif test $libpng_VERSION_INT -ge 51009001; then
-			FFMPEG_VERSION="0.8"
-		elif test $libpng_VERSION_INT -ge 50043000; then
-			FFMPEG_VERSION="0.7"
-		else
-			FFMPEG_VERSION="0"
-		fi
-	else
-		FFMPEG_VERSION="0"
-	fi
 
-    version=$FFMPEG_VERSION
-
-    # strip leading non-numeric tokens
-    # (necessary for some ffmpeg-packages in ubuntu)
-    # example: 0d.51.1.0 -> 51.1.0
-    version=`echo $version | sed 's/^[^.]*[^0-9.][^.]*\.//'`
-
-    # replace "." and "-" with " " and ignore trailing tokens.
-    # 1.23.4-r2 will be splitted to [maj=1, min=23, rel=4].
-    # In addition we delete everything after the first character
-    # which is not 0-9.
-    # 1.3a4-r32 will be [maj=1, min=3, rel=0].
-    read major minor release ignore <<eof
-        `echo $version | tr '.-' ' ' | sed 's/[^0-9\ ].*//'`
-eof
-    # Note: Do NOT indent the eof-delimiter
-    # We use a here-document (<<< here-strings not POSIX compatible)
-
-    test -z $major && major=0
-    test -z $minor && minor=0
-    test -z $release && release=0
-
-    # strip preceding 0s and set unset version-parts to 0
-    FFMPEG_VERSION_MAJOR=$(($major))
-    FFMPEG_VERSION_MINOR=$(($minor))
-    FFMPEG_VERSION_RELEASE=$(($release))
-    # integer representation: MMMmmmrrr (M:major,m:minor,r:release)
-    # can be used if pkg-config's comparison fails
-    FFMPEG_VERSION_INT=$(($FFMPEG_VERSION_MAJOR*1000000+$FFMPEG_VERSION_MINOR*1000+$FFMPEG_VERSION_RELEASE))
-
-
-
-
-
-
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: [$FFMPEG_VERSION]" >&5
-$as_echo "[$FFMPEG_VERSION]" >&6; }
-    fi
 
 fi
 
@@ -5294,93 +5122,7 @@ eof
 
 
 
-    # for avutil: map library version to ffmpeg version
-    if test lua = "libavutil"; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of ffmpeg" >&5
-$as_echo_n "checking version of ffmpeg... " >&6; }
-    	if test $lua_VERSION_INT -le 60000000; then
-		if   test $lua_VERSION_INT -ge 55027100; then
-			FFMPEG_VERSION="3.1"
-		elif test $lua_VERSION_INT -ge 55017100; then
-			FFMPEG_VERSION="3.0"
-		elif test $lua_VERSION_INT -ge 54031100; then
-			FFMPEG_VERSION="2.8"
-		elif test $lua_VERSION_INT -ge 54027100; then
-			FFMPEG_VERSION="2.7"
-		elif test $lua_VERSION_INT -ge 54020100; then
-			FFMPEG_VERSION="2.6"
-		elif test $lua_VERSION_INT -ge 54015100; then
-			FFMPEG_VERSION="2.5"
-		elif test $lua_VERSION_INT -ge 54007001; then
-			FFMPEG_VERSION="2.4"
-		elif test $lua_VERSION_INT -ge 52066100; then
-			FFMPEG_VERSION="2.2"
-		elif test $lua_VERSION_INT -ge 52048100; then
-			FFMPEG_VERSION="2.1"
-		elif test $lua_VERSION_INT -ge 52038100; then
-			FFMPEG_VERSION="2.0"
-		elif test $lua_VERSION_INT -ge 52018100; then
-			FFMPEG_VERSION="1.2"
-		elif test $lua_VERSION_INT -ge 52013100; then
-			FFMPEG_VERSION="1.1"
-		elif test $lua_VERSION_INT -ge 51073101; then
-			FFMPEG_VERSION="1.0"
-		elif test $lua_VERSION_INT -ge 51054100; then
-			FFMPEG_VERSION="0.11"
-		elif test $lua_VERSION_INT -ge 51034101; then
-			FFMPEG_VERSION="0.10"
-		elif test $lua_VERSION_INT -ge 51032000; then
-			FFMPEG_VERSION="0.9"
-		elif test $lua_VERSION_INT -ge 51009001; then
-			FFMPEG_VERSION="0.8"
-		elif test $lua_VERSION_INT -ge 50043000; then
-			FFMPEG_VERSION="0.7"
-		else
-			FFMPEG_VERSION="0"
-		fi
-	else
-		FFMPEG_VERSION="0"
-	fi
 
-    version=$FFMPEG_VERSION
-
-    # strip leading non-numeric tokens
-    # (necessary for some ffmpeg-packages in ubuntu)
-    # example: 0d.51.1.0 -> 51.1.0
-    version=`echo $version | sed 's/^[^.]*[^0-9.][^.]*\.//'`
-
-    # replace "." and "-" with " " and ignore trailing tokens.
-    # 1.23.4-r2 will be splitted to [maj=1, min=23, rel=4].
-    # In addition we delete everything after the first character
-    # which is not 0-9.
-    # 1.3a4-r32 will be [maj=1, min=3, rel=0].
-    read major minor release ignore <<eof
-        `echo $version | tr '.-' ' ' | sed 's/[^0-9\ ].*//'`
-eof
-    # Note: Do NOT indent the eof-delimiter
-    # We use a here-document (<<< here-strings not POSIX compatible)
-
-    test -z $major && major=0
-    test -z $minor && minor=0
-    test -z $release && release=0
-
-    # strip preceding 0s and set unset version-parts to 0
-    FFMPEG_VERSION_MAJOR=$(($major))
-    FFMPEG_VERSION_MINOR=$(($minor))
-    FFMPEG_VERSION_RELEASE=$(($release))
-    # integer representation: MMMmmmrrr (M:major,m:minor,r:release)
-    # can be used if pkg-config's comparison fails
-    FFMPEG_VERSION_INT=$(($FFMPEG_VERSION_MAJOR*1000000+$FFMPEG_VERSION_MINOR*1000+$FFMPEG_VERSION_RELEASE))
-
-
-
-
-
-
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: [$FFMPEG_VERSION]" >&5
-$as_echo "[$FFMPEG_VERSION]" >&6; }
-    fi
 
 else
 
@@ -5525,93 +5267,7 @@ eof
 
 
 
-    # for avutil: map library version to ffmpeg version
-    if test lua = "libavutil"; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of ffmpeg" >&5
-$as_echo_n "checking version of ffmpeg... " >&6; }
-    	if test $lua_VERSION_INT -le 60000000; then
-		if   test $lua_VERSION_INT -ge 55027100; then
-			FFMPEG_VERSION="3.1"
-		elif test $lua_VERSION_INT -ge 55017100; then
-			FFMPEG_VERSION="3.0"
-		elif test $lua_VERSION_INT -ge 54031100; then
-			FFMPEG_VERSION="2.8"
-		elif test $lua_VERSION_INT -ge 54027100; then
-			FFMPEG_VERSION="2.7"
-		elif test $lua_VERSION_INT -ge 54020100; then
-			FFMPEG_VERSION="2.6"
-		elif test $lua_VERSION_INT -ge 54015100; then
-			FFMPEG_VERSION="2.5"
-		elif test $lua_VERSION_INT -ge 54007001; then
-			FFMPEG_VERSION="2.4"
-		elif test $lua_VERSION_INT -ge 52066100; then
-			FFMPEG_VERSION="2.2"
-		elif test $lua_VERSION_INT -ge 52048100; then
-			FFMPEG_VERSION="2.1"
-		elif test $lua_VERSION_INT -ge 52038100; then
-			FFMPEG_VERSION="2.0"
-		elif test $lua_VERSION_INT -ge 52018100; then
-			FFMPEG_VERSION="1.2"
-		elif test $lua_VERSION_INT -ge 52013100; then
-			FFMPEG_VERSION="1.1"
-		elif test $lua_VERSION_INT -ge 51073101; then
-			FFMPEG_VERSION="1.0"
-		elif test $lua_VERSION_INT -ge 51054100; then
-			FFMPEG_VERSION="0.11"
-		elif test $lua_VERSION_INT -ge 51034101; then
-			FFMPEG_VERSION="0.10"
-		elif test $lua_VERSION_INT -ge 51032000; then
-			FFMPEG_VERSION="0.9"
-		elif test $lua_VERSION_INT -ge 51009001; then
-			FFMPEG_VERSION="0.8"
-		elif test $lua_VERSION_INT -ge 50043000; then
-			FFMPEG_VERSION="0.7"
-		else
-			FFMPEG_VERSION="0"
-		fi
-	else
-		FFMPEG_VERSION="0"
-	fi
 
-    version=$FFMPEG_VERSION
-
-    # strip leading non-numeric tokens
-    # (necessary for some ffmpeg-packages in ubuntu)
-    # example: 0d.51.1.0 -> 51.1.0
-    version=`echo $version | sed 's/^[^.]*[^0-9.][^.]*\.//'`
-
-    # replace "." and "-" with " " and ignore trailing tokens.
-    # 1.23.4-r2 will be splitted to [maj=1, min=23, rel=4].
-    # In addition we delete everything after the first character
-    # which is not 0-9.
-    # 1.3a4-r32 will be [maj=1, min=3, rel=0].
-    read major minor release ignore <<eof
-        `echo $version | tr '.-' ' ' | sed 's/[^0-9\ ].*//'`
-eof
-    # Note: Do NOT indent the eof-delimiter
-    # We use a here-document (<<< here-strings not POSIX compatible)
-
-    test -z $major && major=0
-    test -z $minor && minor=0
-    test -z $release && release=0
-
-    # strip preceding 0s and set unset version-parts to 0
-    FFMPEG_VERSION_MAJOR=$(($major))
-    FFMPEG_VERSION_MINOR=$(($minor))
-    FFMPEG_VERSION_RELEASE=$(($release))
-    # integer representation: MMMmmmrrr (M:major,m:minor,r:release)
-    # can be used if pkg-config's comparison fails
-    FFMPEG_VERSION_INT=$(($FFMPEG_VERSION_MAJOR*1000000+$FFMPEG_VERSION_MINOR*1000+$FFMPEG_VERSION_RELEASE))
-
-
-
-
-
-
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: [$FFMPEG_VERSION]" >&5
-$as_echo "[$FFMPEG_VERSION]" >&6; }
-    fi
 
 	else
 
@@ -5756,93 +5412,7 @@ eof
 
 
 
-    # for avutil: map library version to ffmpeg version
-    if test lua = "libavutil"; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of ffmpeg" >&5
-$as_echo_n "checking version of ffmpeg... " >&6; }
-    	if test $lua_VERSION_INT -le 60000000; then
-		if   test $lua_VERSION_INT -ge 55027100; then
-			FFMPEG_VERSION="3.1"
-		elif test $lua_VERSION_INT -ge 55017100; then
-			FFMPEG_VERSION="3.0"
-		elif test $lua_VERSION_INT -ge 54031100; then
-			FFMPEG_VERSION="2.8"
-		elif test $lua_VERSION_INT -ge 54027100; then
-			FFMPEG_VERSION="2.7"
-		elif test $lua_VERSION_INT -ge 54020100; then
-			FFMPEG_VERSION="2.6"
-		elif test $lua_VERSION_INT -ge 54015100; then
-			FFMPEG_VERSION="2.5"
-		elif test $lua_VERSION_INT -ge 54007001; then
-			FFMPEG_VERSION="2.4"
-		elif test $lua_VERSION_INT -ge 52066100; then
-			FFMPEG_VERSION="2.2"
-		elif test $lua_VERSION_INT -ge 52048100; then
-			FFMPEG_VERSION="2.1"
-		elif test $lua_VERSION_INT -ge 52038100; then
-			FFMPEG_VERSION="2.0"
-		elif test $lua_VERSION_INT -ge 52018100; then
-			FFMPEG_VERSION="1.2"
-		elif test $lua_VERSION_INT -ge 52013100; then
-			FFMPEG_VERSION="1.1"
-		elif test $lua_VERSION_INT -ge 51073101; then
-			FFMPEG_VERSION="1.0"
-		elif test $lua_VERSION_INT -ge 51054100; then
-			FFMPEG_VERSION="0.11"
-		elif test $lua_VERSION_INT -ge 51034101; then
-			FFMPEG_VERSION="0.10"
-		elif test $lua_VERSION_INT -ge 51032000; then
-			FFMPEG_VERSION="0.9"
-		elif test $lua_VERSION_INT -ge 51009001; then
-			FFMPEG_VERSION="0.8"
-		elif test $lua_VERSION_INT -ge 50043000; then
-			FFMPEG_VERSION="0.7"
-		else
-			FFMPEG_VERSION="0"
-		fi
-	else
-		FFMPEG_VERSION="0"
-	fi
 
-    version=$FFMPEG_VERSION
-
-    # strip leading non-numeric tokens
-    # (necessary for some ffmpeg-packages in ubuntu)
-    # example: 0d.51.1.0 -> 51.1.0
-    version=`echo $version | sed 's/^[^.]*[^0-9.][^.]*\.//'`
-
-    # replace "." and "-" with " " and ignore trailing tokens.
-    # 1.23.4-r2 will be splitted to [maj=1, min=23, rel=4].
-    # In addition we delete everything after the first character
-    # which is not 0-9.
-    # 1.3a4-r32 will be [maj=1, min=3, rel=0].
-    read major minor release ignore <<eof
-        `echo $version | tr '.-' ' ' | sed 's/[^0-9\ ].*//'`
-eof
-    # Note: Do NOT indent the eof-delimiter
-    # We use a here-document (<<< here-strings not POSIX compatible)
-
-    test -z $major && major=0
-    test -z $minor && minor=0
-    test -z $release && release=0
-
-    # strip preceding 0s and set unset version-parts to 0
-    FFMPEG_VERSION_MAJOR=$(($major))
-    FFMPEG_VERSION_MINOR=$(($minor))
-    FFMPEG_VERSION_RELEASE=$(($release))
-    # integer representation: MMMmmmrrr (M:major,m:minor,r:release)
-    # can be used if pkg-config's comparison fails
-    FFMPEG_VERSION_INT=$(($FFMPEG_VERSION_MAJOR*1000000+$FFMPEG_VERSION_MINOR*1000+$FFMPEG_VERSION_RELEASE))
-
-
-
-
-
-
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: [$FFMPEG_VERSION]" >&5
-$as_echo "[$FFMPEG_VERSION]" >&6; }
-    fi
 
 		else
 
@@ -5986,93 +5556,7 @@ eof
 
 
 
-    # for avutil: map library version to ffmpeg version
-    if test lua = "libavutil"; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of ffmpeg" >&5
-$as_echo_n "checking version of ffmpeg... " >&6; }
-    	if test $lua_VERSION_INT -le 60000000; then
-		if   test $lua_VERSION_INT -ge 55027100; then
-			FFMPEG_VERSION="3.1"
-		elif test $lua_VERSION_INT -ge 55017100; then
-			FFMPEG_VERSION="3.0"
-		elif test $lua_VERSION_INT -ge 54031100; then
-			FFMPEG_VERSION="2.8"
-		elif test $lua_VERSION_INT -ge 54027100; then
-			FFMPEG_VERSION="2.7"
-		elif test $lua_VERSION_INT -ge 54020100; then
-			FFMPEG_VERSION="2.6"
-		elif test $lua_VERSION_INT -ge 54015100; then
-			FFMPEG_VERSION="2.5"
-		elif test $lua_VERSION_INT -ge 54007001; then
-			FFMPEG_VERSION="2.4"
-		elif test $lua_VERSION_INT -ge 52066100; then
-			FFMPEG_VERSION="2.2"
-		elif test $lua_VERSION_INT -ge 52048100; then
-			FFMPEG_VERSION="2.1"
-		elif test $lua_VERSION_INT -ge 52038100; then
-			FFMPEG_VERSION="2.0"
-		elif test $lua_VERSION_INT -ge 52018100; then
-			FFMPEG_VERSION="1.2"
-		elif test $lua_VERSION_INT -ge 52013100; then
-			FFMPEG_VERSION="1.1"
-		elif test $lua_VERSION_INT -ge 51073101; then
-			FFMPEG_VERSION="1.0"
-		elif test $lua_VERSION_INT -ge 51054100; then
-			FFMPEG_VERSION="0.11"
-		elif test $lua_VERSION_INT -ge 51034101; then
-			FFMPEG_VERSION="0.10"
-		elif test $lua_VERSION_INT -ge 51032000; then
-			FFMPEG_VERSION="0.9"
-		elif test $lua_VERSION_INT -ge 51009001; then
-			FFMPEG_VERSION="0.8"
-		elif test $lua_VERSION_INT -ge 50043000; then
-			FFMPEG_VERSION="0.7"
-		else
-			FFMPEG_VERSION="0"
-		fi
-	else
-		FFMPEG_VERSION="0"
-	fi
 
-    version=$FFMPEG_VERSION
-
-    # strip leading non-numeric tokens
-    # (necessary for some ffmpeg-packages in ubuntu)
-    # example: 0d.51.1.0 -> 51.1.0
-    version=`echo $version | sed 's/^[^.]*[^0-9.][^.]*\.//'`
-
-    # replace "." and "-" with " " and ignore trailing tokens.
-    # 1.23.4-r2 will be splitted to [maj=1, min=23, rel=4].
-    # In addition we delete everything after the first character
-    # which is not 0-9.
-    # 1.3a4-r32 will be [maj=1, min=3, rel=0].
-    read major minor release ignore <<eof
-        `echo $version | tr '.-' ' ' | sed 's/[^0-9\ ].*//'`
-eof
-    # Note: Do NOT indent the eof-delimiter
-    # We use a here-document (<<< here-strings not POSIX compatible)
-
-    test -z $major && major=0
-    test -z $minor && minor=0
-    test -z $release && release=0
-
-    # strip preceding 0s and set unset version-parts to 0
-    FFMPEG_VERSION_MAJOR=$(($major))
-    FFMPEG_VERSION_MINOR=$(($minor))
-    FFMPEG_VERSION_RELEASE=$(($release))
-    # integer representation: MMMmmmrrr (M:major,m:minor,r:release)
-    # can be used if pkg-config's comparison fails
-    FFMPEG_VERSION_INT=$(($FFMPEG_VERSION_MAJOR*1000000+$FFMPEG_VERSION_MINOR*1000+$FFMPEG_VERSION_RELEASE))
-
-
-
-
-
-
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: [$FFMPEG_VERSION]" >&5
-$as_echo "[$FFMPEG_VERSION]" >&6; }
-    fi
 
 		fi
 	fi
@@ -6294,93 +5778,7 @@ eof
 
 
 
-    # for avutil: map library version to ffmpeg version
-    if test libavcodec = "libavutil"; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of ffmpeg" >&5
-$as_echo_n "checking version of ffmpeg... " >&6; }
-    	if test $libavcodec_VERSION_INT -le 60000000; then
-		if   test $libavcodec_VERSION_INT -ge 55027100; then
-			FFMPEG_VERSION="3.1"
-		elif test $libavcodec_VERSION_INT -ge 55017100; then
-			FFMPEG_VERSION="3.0"
-		elif test $libavcodec_VERSION_INT -ge 54031100; then
-			FFMPEG_VERSION="2.8"
-		elif test $libavcodec_VERSION_INT -ge 54027100; then
-			FFMPEG_VERSION="2.7"
-		elif test $libavcodec_VERSION_INT -ge 54020100; then
-			FFMPEG_VERSION="2.6"
-		elif test $libavcodec_VERSION_INT -ge 54015100; then
-			FFMPEG_VERSION="2.5"
-		elif test $libavcodec_VERSION_INT -ge 54007001; then
-			FFMPEG_VERSION="2.4"
-		elif test $libavcodec_VERSION_INT -ge 52066100; then
-			FFMPEG_VERSION="2.2"
-		elif test $libavcodec_VERSION_INT -ge 52048100; then
-			FFMPEG_VERSION="2.1"
-		elif test $libavcodec_VERSION_INT -ge 52038100; then
-			FFMPEG_VERSION="2.0"
-		elif test $libavcodec_VERSION_INT -ge 52018100; then
-			FFMPEG_VERSION="1.2"
-		elif test $libavcodec_VERSION_INT -ge 52013100; then
-			FFMPEG_VERSION="1.1"
-		elif test $libavcodec_VERSION_INT -ge 51073101; then
-			FFMPEG_VERSION="1.0"
-		elif test $libavcodec_VERSION_INT -ge 51054100; then
-			FFMPEG_VERSION="0.11"
-		elif test $libavcodec_VERSION_INT -ge 51034101; then
-			FFMPEG_VERSION="0.10"
-		elif test $libavcodec_VERSION_INT -ge 51032000; then
-			FFMPEG_VERSION="0.9"
-		elif test $libavcodec_VERSION_INT -ge 51009001; then
-			FFMPEG_VERSION="0.8"
-		elif test $libavcodec_VERSION_INT -ge 50043000; then
-			FFMPEG_VERSION="0.7"
-		else
-			FFMPEG_VERSION="0"
-		fi
-	else
-		FFMPEG_VERSION="0"
-	fi
 
-    version=$FFMPEG_VERSION
-
-    # strip leading non-numeric tokens
-    # (necessary for some ffmpeg-packages in ubuntu)
-    # example: 0d.51.1.0 -> 51.1.0
-    version=`echo $version | sed 's/^[^.]*[^0-9.][^.]*\.//'`
-
-    # replace "." and "-" with " " and ignore trailing tokens.
-    # 1.23.4-r2 will be splitted to [maj=1, min=23, rel=4].
-    # In addition we delete everything after the first character
-    # which is not 0-9.
-    # 1.3a4-r32 will be [maj=1, min=3, rel=0].
-    read major minor release ignore <<eof
-        `echo $version | tr '.-' ' ' | sed 's/[^0-9\ ].*//'`
-eof
-    # Note: Do NOT indent the eof-delimiter
-    # We use a here-document (<<< here-strings not POSIX compatible)
-
-    test -z $major && major=0
-    test -z $minor && minor=0
-    test -z $release && release=0
-
-    # strip preceding 0s and set unset version-parts to 0
-    FFMPEG_VERSION_MAJOR=$(($major))
-    FFMPEG_VERSION_MINOR=$(($minor))
-    FFMPEG_VERSION_RELEASE=$(($release))
-    # integer representation: MMMmmmrrr (M:major,m:minor,r:release)
-    # can be used if pkg-config's comparison fails
-    FFMPEG_VERSION_INT=$(($FFMPEG_VERSION_MAJOR*1000000+$FFMPEG_VERSION_MINOR*1000+$FFMPEG_VERSION_RELEASE))
-
-
-
-
-
-
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: [$FFMPEG_VERSION]" >&5
-$as_echo "[$FFMPEG_VERSION]" >&6; }
-    fi
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for avcodec_decode_audio in -lavcodec" >&5
@@ -6643,93 +6041,7 @@ eof
 
 
 
-    # for avutil: map library version to ffmpeg version
-    if test libavformat = "libavutil"; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of ffmpeg" >&5
-$as_echo_n "checking version of ffmpeg... " >&6; }
-    	if test $libavformat_VERSION_INT -le 60000000; then
-		if   test $libavformat_VERSION_INT -ge 55027100; then
-			FFMPEG_VERSION="3.1"
-		elif test $libavformat_VERSION_INT -ge 55017100; then
-			FFMPEG_VERSION="3.0"
-		elif test $libavformat_VERSION_INT -ge 54031100; then
-			FFMPEG_VERSION="2.8"
-		elif test $libavformat_VERSION_INT -ge 54027100; then
-			FFMPEG_VERSION="2.7"
-		elif test $libavformat_VERSION_INT -ge 54020100; then
-			FFMPEG_VERSION="2.6"
-		elif test $libavformat_VERSION_INT -ge 54015100; then
-			FFMPEG_VERSION="2.5"
-		elif test $libavformat_VERSION_INT -ge 54007001; then
-			FFMPEG_VERSION="2.4"
-		elif test $libavformat_VERSION_INT -ge 52066100; then
-			FFMPEG_VERSION="2.2"
-		elif test $libavformat_VERSION_INT -ge 52048100; then
-			FFMPEG_VERSION="2.1"
-		elif test $libavformat_VERSION_INT -ge 52038100; then
-			FFMPEG_VERSION="2.0"
-		elif test $libavformat_VERSION_INT -ge 52018100; then
-			FFMPEG_VERSION="1.2"
-		elif test $libavformat_VERSION_INT -ge 52013100; then
-			FFMPEG_VERSION="1.1"
-		elif test $libavformat_VERSION_INT -ge 51073101; then
-			FFMPEG_VERSION="1.0"
-		elif test $libavformat_VERSION_INT -ge 51054100; then
-			FFMPEG_VERSION="0.11"
-		elif test $libavformat_VERSION_INT -ge 51034101; then
-			FFMPEG_VERSION="0.10"
-		elif test $libavformat_VERSION_INT -ge 51032000; then
-			FFMPEG_VERSION="0.9"
-		elif test $libavformat_VERSION_INT -ge 51009001; then
-			FFMPEG_VERSION="0.8"
-		elif test $libavformat_VERSION_INT -ge 50043000; then
-			FFMPEG_VERSION="0.7"
-		else
-			FFMPEG_VERSION="0"
-		fi
-	else
-		FFMPEG_VERSION="0"
-	fi
 
-    version=$FFMPEG_VERSION
-
-    # strip leading non-numeric tokens
-    # (necessary for some ffmpeg-packages in ubuntu)
-    # example: 0d.51.1.0 -> 51.1.0
-    version=`echo $version | sed 's/^[^.]*[^0-9.][^.]*\.//'`
-
-    # replace "." and "-" with " " and ignore trailing tokens.
-    # 1.23.4-r2 will be splitted to [maj=1, min=23, rel=4].
-    # In addition we delete everything after the first character
-    # which is not 0-9.
-    # 1.3a4-r32 will be [maj=1, min=3, rel=0].
-    read major minor release ignore <<eof
-        `echo $version | tr '.-' ' ' | sed 's/[^0-9\ ].*//'`
-eof
-    # Note: Do NOT indent the eof-delimiter
-    # We use a here-document (<<< here-strings not POSIX compatible)
-
-    test -z $major && major=0
-    test -z $minor && minor=0
-    test -z $release && release=0
-
-    # strip preceding 0s and set unset version-parts to 0
-    FFMPEG_VERSION_MAJOR=$(($major))
-    FFMPEG_VERSION_MINOR=$(($minor))
-    FFMPEG_VERSION_RELEASE=$(($release))
-    # integer representation: MMMmmmrrr (M:major,m:minor,r:release)
-    # can be used if pkg-config's comparison fails
-    FFMPEG_VERSION_INT=$(($FFMPEG_VERSION_MAJOR*1000000+$FFMPEG_VERSION_MINOR*1000+$FFMPEG_VERSION_RELEASE))
-
-
-
-
-
-
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: [$FFMPEG_VERSION]" >&5
-$as_echo "[$FFMPEG_VERSION]" >&6; }
-    fi
 
 
     have_lib="no"
@@ -6871,11 +6183,11 @@ eof
 
 
 
-    # for avutil: map library version to ffmpeg version
-    if test libavutil = "libavutil"; then
+
+        # map avutil library version to ffmpeg version
         { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of ffmpeg" >&5
 $as_echo_n "checking version of ffmpeg... " >&6; }
-    	if test $libavutil_VERSION_INT -le 60000000; then
+        if test $libavutil_VERSION_INT -le 60000000; then
 		if   test $libavutil_VERSION_INT -ge 55027100; then
 			FFMPEG_VERSION="3.1"
 		elif test $libavutil_VERSION_INT -ge 55017100; then
@@ -6915,9 +6227,9 @@ $as_echo_n "checking version of ffmpeg... " >&6; }
 		else
 			FFMPEG_VERSION="0"
 		fi
-	else
-		FFMPEG_VERSION="0"
-	fi
+        else
+            FFMPEG_VERSION="0"
+        fi
 
     version=$FFMPEG_VERSION
 
@@ -6957,7 +6269,7 @@ eof
 
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: [$FFMPEG_VERSION]" >&5
 $as_echo "[$FFMPEG_VERSION]" >&6; }
-    fi
+
 
 if [ x$libavcodec_HAVE = xyes -a x$libavformat_HAVE = xyes -a x$libavutil_HAVE = xyes ]; then
     ffmpeg_HAVE=yes
@@ -7114,93 +6426,7 @@ eof
 
 
 
-    # for avutil: map library version to ffmpeg version
-    if test libswscale = "libavutil"; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of ffmpeg" >&5
-$as_echo_n "checking version of ffmpeg... " >&6; }
-    	if test $libswscale_VERSION_INT -le 60000000; then
-		if   test $libswscale_VERSION_INT -ge 55027100; then
-			FFMPEG_VERSION="3.1"
-		elif test $libswscale_VERSION_INT -ge 55017100; then
-			FFMPEG_VERSION="3.0"
-		elif test $libswscale_VERSION_INT -ge 54031100; then
-			FFMPEG_VERSION="2.8"
-		elif test $libswscale_VERSION_INT -ge 54027100; then
-			FFMPEG_VERSION="2.7"
-		elif test $libswscale_VERSION_INT -ge 54020100; then
-			FFMPEG_VERSION="2.6"
-		elif test $libswscale_VERSION_INT -ge 54015100; then
-			FFMPEG_VERSION="2.5"
-		elif test $libswscale_VERSION_INT -ge 54007001; then
-			FFMPEG_VERSION="2.4"
-		elif test $libswscale_VERSION_INT -ge 52066100; then
-			FFMPEG_VERSION="2.2"
-		elif test $libswscale_VERSION_INT -ge 52048100; then
-			FFMPEG_VERSION="2.1"
-		elif test $libswscale_VERSION_INT -ge 52038100; then
-			FFMPEG_VERSION="2.0"
-		elif test $libswscale_VERSION_INT -ge 52018100; then
-			FFMPEG_VERSION="1.2"
-		elif test $libswscale_VERSION_INT -ge 52013100; then
-			FFMPEG_VERSION="1.1"
-		elif test $libswscale_VERSION_INT -ge 51073101; then
-			FFMPEG_VERSION="1.0"
-		elif test $libswscale_VERSION_INT -ge 51054100; then
-			FFMPEG_VERSION="0.11"
-		elif test $libswscale_VERSION_INT -ge 51034101; then
-			FFMPEG_VERSION="0.10"
-		elif test $libswscale_VERSION_INT -ge 51032000; then
-			FFMPEG_VERSION="0.9"
-		elif test $libswscale_VERSION_INT -ge 51009001; then
-			FFMPEG_VERSION="0.8"
-		elif test $libswscale_VERSION_INT -ge 50043000; then
-			FFMPEG_VERSION="0.7"
-		else
-			FFMPEG_VERSION="0"
-		fi
-	else
-		FFMPEG_VERSION="0"
-	fi
 
-    version=$FFMPEG_VERSION
-
-    # strip leading non-numeric tokens
-    # (necessary for some ffmpeg-packages in ubuntu)
-    # example: 0d.51.1.0 -> 51.1.0
-    version=`echo $version | sed 's/^[^.]*[^0-9.][^.]*\.//'`
-
-    # replace "." and "-" with " " and ignore trailing tokens.
-    # 1.23.4-r2 will be splitted to [maj=1, min=23, rel=4].
-    # In addition we delete everything after the first character
-    # which is not 0-9.
-    # 1.3a4-r32 will be [maj=1, min=3, rel=0].
-    read major minor release ignore <<eof
-        `echo $version | tr '.-' ' ' | sed 's/[^0-9\ ].*//'`
-eof
-    # Note: Do NOT indent the eof-delimiter
-    # We use a here-document (<<< here-strings not POSIX compatible)
-
-    test -z $major && major=0
-    test -z $minor && minor=0
-    test -z $release && release=0
-
-    # strip preceding 0s and set unset version-parts to 0
-    FFMPEG_VERSION_MAJOR=$(($major))
-    FFMPEG_VERSION_MINOR=$(($minor))
-    FFMPEG_VERSION_RELEASE=$(($release))
-    # integer representation: MMMmmmrrr (M:major,m:minor,r:release)
-    # can be used if pkg-config's comparison fails
-    FFMPEG_VERSION_INT=$(($FFMPEG_VERSION_MAJOR*1000000+$FFMPEG_VERSION_MINOR*1000+$FFMPEG_VERSION_RELEASE))
-
-
-
-
-
-
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: [$FFMPEG_VERSION]" >&5
-$as_echo "[$FFMPEG_VERSION]" >&6; }
-    fi
 
 
     if [ x$libswscale_HAVE = xyes ]; then
@@ -7354,93 +6580,7 @@ eof
 
 
 
-    # for avutil: map library version to ffmpeg version
-    if test libprojectM = "libavutil"; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of ffmpeg" >&5
-$as_echo_n "checking version of ffmpeg... " >&6; }
-    	if test $libprojectM_VERSION_INT -le 60000000; then
-		if   test $libprojectM_VERSION_INT -ge 55027100; then
-			FFMPEG_VERSION="3.1"
-		elif test $libprojectM_VERSION_INT -ge 55017100; then
-			FFMPEG_VERSION="3.0"
-		elif test $libprojectM_VERSION_INT -ge 54031100; then
-			FFMPEG_VERSION="2.8"
-		elif test $libprojectM_VERSION_INT -ge 54027100; then
-			FFMPEG_VERSION="2.7"
-		elif test $libprojectM_VERSION_INT -ge 54020100; then
-			FFMPEG_VERSION="2.6"
-		elif test $libprojectM_VERSION_INT -ge 54015100; then
-			FFMPEG_VERSION="2.5"
-		elif test $libprojectM_VERSION_INT -ge 54007001; then
-			FFMPEG_VERSION="2.4"
-		elif test $libprojectM_VERSION_INT -ge 52066100; then
-			FFMPEG_VERSION="2.2"
-		elif test $libprojectM_VERSION_INT -ge 52048100; then
-			FFMPEG_VERSION="2.1"
-		elif test $libprojectM_VERSION_INT -ge 52038100; then
-			FFMPEG_VERSION="2.0"
-		elif test $libprojectM_VERSION_INT -ge 52018100; then
-			FFMPEG_VERSION="1.2"
-		elif test $libprojectM_VERSION_INT -ge 52013100; then
-			FFMPEG_VERSION="1.1"
-		elif test $libprojectM_VERSION_INT -ge 51073101; then
-			FFMPEG_VERSION="1.0"
-		elif test $libprojectM_VERSION_INT -ge 51054100; then
-			FFMPEG_VERSION="0.11"
-		elif test $libprojectM_VERSION_INT -ge 51034101; then
-			FFMPEG_VERSION="0.10"
-		elif test $libprojectM_VERSION_INT -ge 51032000; then
-			FFMPEG_VERSION="0.9"
-		elif test $libprojectM_VERSION_INT -ge 51009001; then
-			FFMPEG_VERSION="0.8"
-		elif test $libprojectM_VERSION_INT -ge 50043000; then
-			FFMPEG_VERSION="0.7"
-		else
-			FFMPEG_VERSION="0"
-		fi
-	else
-		FFMPEG_VERSION="0"
-	fi
 
-    version=$FFMPEG_VERSION
-
-    # strip leading non-numeric tokens
-    # (necessary for some ffmpeg-packages in ubuntu)
-    # example: 0d.51.1.0 -> 51.1.0
-    version=`echo $version | sed 's/^[^.]*[^0-9.][^.]*\.//'`
-
-    # replace "." and "-" with " " and ignore trailing tokens.
-    # 1.23.4-r2 will be splitted to [maj=1, min=23, rel=4].
-    # In addition we delete everything after the first character
-    # which is not 0-9.
-    # 1.3a4-r32 will be [maj=1, min=3, rel=0].
-    read major minor release ignore <<eof
-        `echo $version | tr '.-' ' ' | sed 's/[^0-9\ ].*//'`
-eof
-    # Note: Do NOT indent the eof-delimiter
-    # We use a here-document (<<< here-strings not POSIX compatible)
-
-    test -z $major && major=0
-    test -z $minor && minor=0
-    test -z $release && release=0
-
-    # strip preceding 0s and set unset version-parts to 0
-    FFMPEG_VERSION_MAJOR=$(($major))
-    FFMPEG_VERSION_MINOR=$(($minor))
-    FFMPEG_VERSION_RELEASE=$(($release))
-    # integer representation: MMMmmmrrr (M:major,m:minor,r:release)
-    # can be used if pkg-config's comparison fails
-    FFMPEG_VERSION_INT=$(($FFMPEG_VERSION_MAJOR*1000000+$FFMPEG_VERSION_MINOR*1000+$FFMPEG_VERSION_RELEASE))
-
-
-
-
-
-
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: [$FFMPEG_VERSION]" >&5
-$as_echo "[$FFMPEG_VERSION]" >&6; }
-    fi
 
 
     if [ x$libprojectM_HAVE = xyes ]; then
@@ -7668,93 +6808,7 @@ eof
 
 
 
-    # for avutil: map library version to ffmpeg version
-    if test portaudio = "libavutil"; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of ffmpeg" >&5
-$as_echo_n "checking version of ffmpeg... " >&6; }
-    	if test $portaudio_VERSION_INT -le 60000000; then
-		if   test $portaudio_VERSION_INT -ge 55027100; then
-			FFMPEG_VERSION="3.1"
-		elif test $portaudio_VERSION_INT -ge 55017100; then
-			FFMPEG_VERSION="3.0"
-		elif test $portaudio_VERSION_INT -ge 54031100; then
-			FFMPEG_VERSION="2.8"
-		elif test $portaudio_VERSION_INT -ge 54027100; then
-			FFMPEG_VERSION="2.7"
-		elif test $portaudio_VERSION_INT -ge 54020100; then
-			FFMPEG_VERSION="2.6"
-		elif test $portaudio_VERSION_INT -ge 54015100; then
-			FFMPEG_VERSION="2.5"
-		elif test $portaudio_VERSION_INT -ge 54007001; then
-			FFMPEG_VERSION="2.4"
-		elif test $portaudio_VERSION_INT -ge 52066100; then
-			FFMPEG_VERSION="2.2"
-		elif test $portaudio_VERSION_INT -ge 52048100; then
-			FFMPEG_VERSION="2.1"
-		elif test $portaudio_VERSION_INT -ge 52038100; then
-			FFMPEG_VERSION="2.0"
-		elif test $portaudio_VERSION_INT -ge 52018100; then
-			FFMPEG_VERSION="1.2"
-		elif test $portaudio_VERSION_INT -ge 52013100; then
-			FFMPEG_VERSION="1.1"
-		elif test $portaudio_VERSION_INT -ge 51073101; then
-			FFMPEG_VERSION="1.0"
-		elif test $portaudio_VERSION_INT -ge 51054100; then
-			FFMPEG_VERSION="0.11"
-		elif test $portaudio_VERSION_INT -ge 51034101; then
-			FFMPEG_VERSION="0.10"
-		elif test $portaudio_VERSION_INT -ge 51032000; then
-			FFMPEG_VERSION="0.9"
-		elif test $portaudio_VERSION_INT -ge 51009001; then
-			FFMPEG_VERSION="0.8"
-		elif test $portaudio_VERSION_INT -ge 50043000; then
-			FFMPEG_VERSION="0.7"
-		else
-			FFMPEG_VERSION="0"
-		fi
-	else
-		FFMPEG_VERSION="0"
-	fi
 
-    version=$FFMPEG_VERSION
-
-    # strip leading non-numeric tokens
-    # (necessary for some ffmpeg-packages in ubuntu)
-    # example: 0d.51.1.0 -> 51.1.0
-    version=`echo $version | sed 's/^[^.]*[^0-9.][^.]*\.//'`
-
-    # replace "." and "-" with " " and ignore trailing tokens.
-    # 1.23.4-r2 will be splitted to [maj=1, min=23, rel=4].
-    # In addition we delete everything after the first character
-    # which is not 0-9.
-    # 1.3a4-r32 will be [maj=1, min=3, rel=0].
-    read major minor release ignore <<eof
-        `echo $version | tr '.-' ' ' | sed 's/[^0-9\ ].*//'`
-eof
-    # Note: Do NOT indent the eof-delimiter
-    # We use a here-document (<<< here-strings not POSIX compatible)
-
-    test -z $major && major=0
-    test -z $minor && minor=0
-    test -z $release && release=0
-
-    # strip preceding 0s and set unset version-parts to 0
-    FFMPEG_VERSION_MAJOR=$(($major))
-    FFMPEG_VERSION_MINOR=$(($minor))
-    FFMPEG_VERSION_RELEASE=$(($release))
-    # integer representation: MMMmmmrrr (M:major,m:minor,r:release)
-    # can be used if pkg-config's comparison fails
-    FFMPEG_VERSION_INT=$(($FFMPEG_VERSION_MAJOR*1000000+$FFMPEG_VERSION_MINOR*1000+$FFMPEG_VERSION_RELEASE))
-
-
-
-
-
-
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: [$FFMPEG_VERSION]" >&5
-$as_echo "[$FFMPEG_VERSION]" >&6; }
-    fi
 
 
     if [ x$portaudio_HAVE = xyes ]; then
@@ -7907,93 +6961,7 @@ eof
 
 
 
-    # for avutil: map library version to ffmpeg version
-    if test libpcre = "libavutil"; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of ffmpeg" >&5
-$as_echo_n "checking version of ffmpeg... " >&6; }
-    	if test $libpcre_VERSION_INT -le 60000000; then
-		if   test $libpcre_VERSION_INT -ge 55027100; then
-			FFMPEG_VERSION="3.1"
-		elif test $libpcre_VERSION_INT -ge 55017100; then
-			FFMPEG_VERSION="3.0"
-		elif test $libpcre_VERSION_INT -ge 54031100; then
-			FFMPEG_VERSION="2.8"
-		elif test $libpcre_VERSION_INT -ge 54027100; then
-			FFMPEG_VERSION="2.7"
-		elif test $libpcre_VERSION_INT -ge 54020100; then
-			FFMPEG_VERSION="2.6"
-		elif test $libpcre_VERSION_INT -ge 54015100; then
-			FFMPEG_VERSION="2.5"
-		elif test $libpcre_VERSION_INT -ge 54007001; then
-			FFMPEG_VERSION="2.4"
-		elif test $libpcre_VERSION_INT -ge 52066100; then
-			FFMPEG_VERSION="2.2"
-		elif test $libpcre_VERSION_INT -ge 52048100; then
-			FFMPEG_VERSION="2.1"
-		elif test $libpcre_VERSION_INT -ge 52038100; then
-			FFMPEG_VERSION="2.0"
-		elif test $libpcre_VERSION_INT -ge 52018100; then
-			FFMPEG_VERSION="1.2"
-		elif test $libpcre_VERSION_INT -ge 52013100; then
-			FFMPEG_VERSION="1.1"
-		elif test $libpcre_VERSION_INT -ge 51073101; then
-			FFMPEG_VERSION="1.0"
-		elif test $libpcre_VERSION_INT -ge 51054100; then
-			FFMPEG_VERSION="0.11"
-		elif test $libpcre_VERSION_INT -ge 51034101; then
-			FFMPEG_VERSION="0.10"
-		elif test $libpcre_VERSION_INT -ge 51032000; then
-			FFMPEG_VERSION="0.9"
-		elif test $libpcre_VERSION_INT -ge 51009001; then
-			FFMPEG_VERSION="0.8"
-		elif test $libpcre_VERSION_INT -ge 50043000; then
-			FFMPEG_VERSION="0.7"
-		else
-			FFMPEG_VERSION="0"
-		fi
-	else
-		FFMPEG_VERSION="0"
-	fi
 
-    version=$FFMPEG_VERSION
-
-    # strip leading non-numeric tokens
-    # (necessary for some ffmpeg-packages in ubuntu)
-    # example: 0d.51.1.0 -> 51.1.0
-    version=`echo $version | sed 's/^[^.]*[^0-9.][^.]*\.//'`
-
-    # replace "." and "-" with " " and ignore trailing tokens.
-    # 1.23.4-r2 will be splitted to [maj=1, min=23, rel=4].
-    # In addition we delete everything after the first character
-    # which is not 0-9.
-    # 1.3a4-r32 will be [maj=1, min=3, rel=0].
-    read major minor release ignore <<eof
-        `echo $version | tr '.-' ' ' | sed 's/[^0-9\ ].*//'`
-eof
-    # Note: Do NOT indent the eof-delimiter
-    # We use a here-document (<<< here-strings not POSIX compatible)
-
-    test -z $major && major=0
-    test -z $minor && minor=0
-    test -z $release && release=0
-
-    # strip preceding 0s and set unset version-parts to 0
-    FFMPEG_VERSION_MAJOR=$(($major))
-    FFMPEG_VERSION_MINOR=$(($minor))
-    FFMPEG_VERSION_RELEASE=$(($release))
-    # integer representation: MMMmmmrrr (M:major,m:minor,r:release)
-    # can be used if pkg-config's comparison fails
-    FFMPEG_VERSION_INT=$(($FFMPEG_VERSION_MAJOR*1000000+$FFMPEG_VERSION_MINOR*1000+$FFMPEG_VERSION_RELEASE))
-
-
-
-
-
-
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: [$FFMPEG_VERSION]" >&5
-$as_echo "[$FFMPEG_VERSION]" >&6; }
-    fi
 
 
     if [ x$libpcre_HAVE = xyes ]; then

--- a/dists/autogen/get-ffmpeg-versions.sh
+++ b/dists/autogen/get-ffmpeg-versions.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+DIR=$(dirname $0)/../../
+cd "$DIR/src/lib/"
+
+FFMPEG_VERSIONS=$(ls -d1 ffmpeg* | sort -rV)
+
+for version in $FFMPEG_VERSIONS; do
+
+	grep -e 'LIBAVUTIL_\(MIN\|MAX\)_VERSION_.*=' $version/avutil.pas | tr -d '\n' | \
+		sed -e 's/ *LIBAVUTIL_\(MIN\|MAX\)_VERSION_MAJOR *= *\([0-9]*\);.*\1_VERSION_MINOR *= *\([0-9]*\);.*\1_VERSION_RELEASE *= *\([0-9]*\);/\1 \2 \3 \4\n/g' | \
+                {
+			echo -n $version
+			while read mode major minor release ; do
+				printf " %s %02d%03d%03d " "$mode" "$major" "$minor" "$release"
+			done
+			echo
+		}
+done | \
+sed \
+	-e 's/MIN/$libavutil_VERSION_INT -ge/' \
+	-e 's/MAX/$libavutil_VERSION_INT -le/' \
+	-e 's/-le \([0-9]*\) .* -ge \1/-eq \1/' \
+	-e 's/^ffmpeg-\([0-9.]*\) \(.*\) /elif test \2; then\n    FFMPEG_VERSION="\1"/' \
+	-e 's/^ffmpeg \(.*\) /elif test \1; then\n    FFMPEG_VERSION="0"/' \
+	-e 's/\([0-9]\) *$libavutil/\1 -a $libavutil/' \
+	-e '1s/^elif/if  /' \
+        -e 's/libavutil_VERSION_INT/[$1][_VERSION_INT]/g' \
+	-e 's/^/        /gm'

--- a/dists/autogen/m4/pkg_config_utils.m4
+++ b/dists/autogen/m4/pkg_config_utils.m4
@@ -100,48 +100,49 @@ AC_DEFUN([PKG_VERSION],
     ifelse($1, [libavutil], [
         # map avutil library version to ffmpeg version
         AC_MSG_CHECKING([version of ffmpeg])
-        if test $[$1][_VERSION_INT] -le 60000000; then
-		if   test $[$1][_VERSION_INT] -ge 55027100; then
-			FFMPEG_VERSION="3.1"
-		elif test $[$1][_VERSION_INT] -ge 55017100; then
-			FFMPEG_VERSION="3.0"
-		elif test $[$1][_VERSION_INT] -ge 54031100; then
-			FFMPEG_VERSION="2.8"    	    	
-		elif test $[$1][_VERSION_INT] -ge 54027100; then
-			FFMPEG_VERSION="2.7"    	    	
-		elif test $[$1][_VERSION_INT] -ge 54020100; then
-			FFMPEG_VERSION="2.6"    	    	
-		elif test $[$1][_VERSION_INT] -ge 54015100; then
-			FFMPEG_VERSION="2.5"    	    	
-		elif test $[$1][_VERSION_INT] -ge 54007001; then
-			FFMPEG_VERSION="2.4"    	
-		elif test $[$1][_VERSION_INT] -ge 52066100; then
-			FFMPEG_VERSION="2.2"    	
-		elif test $[$1][_VERSION_INT] -ge 52048100; then
-			FFMPEG_VERSION="2.1"
-		elif test $[$1][_VERSION_INT] -ge 52038100; then
-			FFMPEG_VERSION="2.0"
-		elif test $[$1][_VERSION_INT] -ge 52018100; then
-			FFMPEG_VERSION="1.2"
-		elif test $[$1][_VERSION_INT] -ge 52013100; then
-			FFMPEG_VERSION="1.1"
-		elif test $[$1][_VERSION_INT] -ge 51073101; then
-			FFMPEG_VERSION="1.0"
-		elif test $[$1][_VERSION_INT] -ge 51054100; then
-			FFMPEG_VERSION="0.11"
-		elif test $[$1][_VERSION_INT] -ge 51034101; then
-			FFMPEG_VERSION="0.10"
-		elif test $[$1][_VERSION_INT] -ge 51032000; then
-			FFMPEG_VERSION="0.9"
-		elif test $[$1][_VERSION_INT] -ge 51009001; then
-			FFMPEG_VERSION="0.8"
-		elif test $[$1][_VERSION_INT] -ge 50043000; then
-			FFMPEG_VERSION="0.7"
-		else
-			FFMPEG_VERSION="0"
-		fi
-        else
+        if   test $[$1][_VERSION_INT] -le 55028100 -a $[$1][_VERSION_INT] -ge 55027100; then
+            FFMPEG_VERSION="3.1"
+        elif test $[$1][_VERSION_INT] -eq 55017103; then
+            FFMPEG_VERSION="3.0"
+        elif test $[$1][_VERSION_INT] -le 54099100 -a $[$1][_VERSION_INT] -ge 54030100; then
+            FFMPEG_VERSION="2.8"
+        elif test $[$1][_VERSION_INT] -le 54030100 -a $[$1][_VERSION_INT] -ge 54027100; then
+            FFMPEG_VERSION="2.7"
+        elif test $[$1][_VERSION_INT] -eq 54020100; then
+            FFMPEG_VERSION="2.6"
+        elif test $[$1][_VERSION_INT] -eq 54015100; then
+            FFMPEG_VERSION="2.5"
+        elif test $[$1][_VERSION_INT] -eq 54007100; then
+            FFMPEG_VERSION="2.4"
+        elif test $[$1][_VERSION_INT] -eq 52066100; then
+            FFMPEG_VERSION="2.2"
+        elif test $[$1][_VERSION_INT] -le 52048101 -a $[$1][_VERSION_INT] -ge 52048100; then
+            FFMPEG_VERSION="2.1"
+        elif test $[$1][_VERSION_INT] -le 52038100 -a $[$1][_VERSION_INT] -ge 52038000; then
+            FFMPEG_VERSION="2.0"
+        elif test $[$1][_VERSION_INT] -le 52018100 -a $[$1][_VERSION_INT] -ge 52018000; then
+            FFMPEG_VERSION="1.2"
+        elif test $[$1][_VERSION_INT] -le 52013100 -a $[$1][_VERSION_INT] -ge 52013000; then
+            FFMPEG_VERSION="1.1"
+        elif test $[$1][_VERSION_INT] -le 51073101 -a $[$1][_VERSION_INT] -ge 51073000; then
+            FFMPEG_VERSION="1.0"
+        elif test $[$1][_VERSION_INT] -le 51054100 -a $[$1][_VERSION_INT] -ge 51054000; then
+            FFMPEG_VERSION="0.11"
+        elif test $[$1][_VERSION_INT] -le 51035100 -a $[$1][_VERSION_INT] -ge 51034101; then
+            FFMPEG_VERSION="0.10"
+        elif test $[$1][_VERSION_INT] -eq 51032000; then
+            FFMPEG_VERSION="0.9"
+        elif test $[$1][_VERSION_INT] -le 51022002 -a $[$1][_VERSION_INT] -ge 51009001; then
+            FFMPEG_VERSION="0.8"
+        elif test $[$1][_VERSION_INT] -eq 50043000; then
+            FFMPEG_VERSION="0.7"
+        elif test $[$1][_VERSION_INT] -le 50024000 -a $[$1][_VERSION_INT] -ge 49000001; then
             FFMPEG_VERSION="0"
+        else
+            AC_MSG_ERROR([
+
+Unsupported ffmpeg version.
+])
         fi
         AX_EXTRACT_VERSION(FFMPEG, $FFMPEG_VERSION)
         AC_SUBST(FFMPEG_VERSION)

--- a/dists/autogen/m4/pkg_config_utils.m4
+++ b/dists/autogen/m4/pkg_config_utils.m4
@@ -97,10 +97,10 @@ AC_DEFUN([PKG_VERSION],
     fi
     AX_EXTRACT_VERSION([$1], $[$1][_VERSION])
 
-    # for avutil: map library version to ffmpeg version
-    if test $1 = "libavutil"; then
+    ifelse($1, [libavutil], [
+        # map avutil library version to ffmpeg version
         AC_MSG_CHECKING([version of ffmpeg])
-    	if test $[$1][_VERSION_INT] -le 60000000; then
+        if test $[$1][_VERSION_INT] -le 60000000; then
 		if   test $[$1][_VERSION_INT] -ge 55027100; then
 			FFMPEG_VERSION="3.1"
 		elif test $[$1][_VERSION_INT] -ge 55017100; then
@@ -140,13 +140,13 @@ AC_DEFUN([PKG_VERSION],
 		else
 			FFMPEG_VERSION="0"
 		fi
-	else
-		FFMPEG_VERSION="0"
-	fi
+        else
+            FFMPEG_VERSION="0"
+        fi
         AX_EXTRACT_VERSION(FFMPEG, $FFMPEG_VERSION)
         AC_SUBST(FFMPEG_VERSION)
         AC_MSG_RESULT(@<:@$FFMPEG_VERSION@:>@)
-    fi
+    ])
 ])
 
 # SYNOPSIS


### PR DESCRIPTION
This are three small patches for the autoconf stuff for the ffmpeg_version handling:

* Replace a shell test with a m4 macro to cleanup the generated configure file.
* Add a script to parse the ffmpeg version ranges from the source files in `src/lib/ffmpeg*/`.
* Update the m4 macro to use version ranges for the ffmpeg check, to fail early with unsupported ffmpeg versions.