### PR TITLE
Revert leftover of "audiobuffer requires size of int, not of byte."

### DIFF
--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -141,7 +141,7 @@ type
       // state-vars for AudioCallback (locked by DecoderLock)
       fAudioBufferPos:  integer;
       fAudioBufferSize: integer;
-      fAudioBuffer:     PIntegerArray;
+      fAudioBuffer:     PByteArray;
 
       fFilename: IPath;
 
@@ -158,7 +158,7 @@ type
       procedure PauseParser();
       procedure ResumeParser();
 
-      function DecodeFrame(Buffer: PIntegerArray; BufferSize: integer): integer;
+      function DecodeFrame(Buffer: PByteArray; BufferSize: integer): integer;
       procedure FlushCodecBuffers();
       procedure PauseDecoder();
       procedure ResumeDecoder();
@@ -976,7 +976,7 @@ begin
   end;
 end;
 
-function TFFmpegDecodeStream.DecodeFrame(Buffer: PIntegerArray; BufferSize: integer): integer;
+function TFFmpegDecodeStream.DecodeFrame(Buffer: PByteArray; BufferSize: integer): integer;
 var
   PaketDecodedSize: integer; // size of packet data used for decoding
   DataSize: integer;         // size of output data decoded by FFmpeg
@@ -1022,7 +1022,7 @@ begin
       PaketDecodedSize := avcodec_decode_audio4(fCodecCtx, AVFrame,
             @got_frame_ptr, @fAudioPaket);
       DataSize := AVFrame.nb_samples;
-      Buffer   := PIntegerArray(AVFrame.data[0]);
+      Buffer   := PByteArray(AVFrame.data[0]);
       {$ELSEIF LIBAVCODEC_VERSION >= 52122000} // 52.122.0
       PaketDecodedSize := avcodec_decode_audio3(fCodecCtx, PSmallint(Buffer),
                   DataSize, @fAudioPaket);


### PR DESCRIPTION
This reverts another part of commit
8f124684198e2a99e69cfc1075890902ddc67521, probably fixing #211