### PR TITLE
Audio decoding with recent FFmpeg version

### DIFF
--- a/configure
+++ b/configure
@@ -6230,7 +6230,7 @@ $as_echo_n "checking version of ffmpeg... " >&6; }
         else
             as_fn_error $? "
 
-Unsupported ffmpeg version, most recent version supported is 2.8.
+Unsupported ffmpeg version, most recent version supported is 3.2.
 " "$LINENO" 5
         fi
 

--- a/dists/autogen/m4/pkg_config_utils.m4
+++ b/dists/autogen/m4/pkg_config_utils.m4
@@ -143,7 +143,7 @@ AC_DEFUN([PKG_VERSION],
         else
             AC_MSG_ERROR([
 
-Unsupported ffmpeg version, most recent version supported is 2.8.
+Unsupported ffmpeg version, most recent version supported is 3.2.
 ])
         fi
         AX_EXTRACT_VERSION(FFMPEG, $FFMPEG_VERSION)

--- a/src/lib/ffmpeg-3.1/avutil.pas
+++ b/src/lib/ffmpeg-3.1/avutil.pas
@@ -358,4 +358,9 @@ begin
     av_mallocz_array := av_mallocz(nmemb * size);
 end;
 
+function AVERROR(e: integer): integer;
+begin
+  AVERROR := AVERROR_SIGN * e;
+end;
+
 end.

--- a/src/lib/ffmpeg-3.1/libavutil/error.pas
+++ b/src/lib/ffmpeg-3.1/libavutil/error.pas
@@ -46,9 +46,11 @@ const
   ENOSYS = ESysENOSYS;
   EILSEQ = ESysEILSEQ;
   EPIPE  = ESysEPIPE;
+  EAGAIN = ESysEAGAIN;
 {$ELSE}
   ENOENT = 2;
   EIO    = 5;
+  EAGAIN = 11;
   ENOMEM = 12;
   EINVAL = 22;
   EPIPE  = 32;  // just an assumption. needs to be checked.
@@ -86,6 +88,7 @@ const
 #define AVUNERROR(e) (e)
 #endif
 *)
+function AVERROR(e: integer): integer;
 
 const
 

--- a/src/lib/ffmpeg-3.2/avutil.pas
+++ b/src/lib/ffmpeg-3.2/avutil.pas
@@ -358,4 +358,9 @@ begin
     av_mallocz_array := av_mallocz(nmemb * size);
 end;
 
+function AVERROR(e: integer): integer;
+begin
+  AVERROR := AVERROR_SIGN * e;
+end;
+
 end.

--- a/src/lib/ffmpeg-3.2/libavutil/error.pas
+++ b/src/lib/ffmpeg-3.2/libavutil/error.pas
@@ -46,9 +46,11 @@ const
   ENOSYS = ESysENOSYS;
   EILSEQ = ESysEILSEQ;
   EPIPE  = ESysEPIPE;
+  EAGAIN = ESysEAGAIN;
 {$ELSE}
   ENOENT = 2;
   EIO    = 5;
+  EAGAIN = 11;
   ENOMEM = 12;
   EINVAL = 22;
   EPIPE  = 32;  // just an assumption. needs to be checked.
@@ -86,6 +88,7 @@ const
 #define AVUNERROR(e) (e)
 #endif
 *)
+function AVERROR(e: integer): integer;
 
 const
 


### PR DESCRIPTION
With these commits USDX correctly decodes MP3s with the current FFmpeg 3.2.2 from jessie-backports.