### PR TITLE
Fix textinput for SDL2

### DIFF
--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -533,17 +533,6 @@ begin
             except
             end;
 
-            Writeln('');
-            if Event.type_ = SDL_TEXTINPUT then
-              Writeln('TEXTINPUT')
-            else
-              Writeln('KEYDOWN');
-            Writeln('Text: ' + Event.text.text);
-            Writeln('KeyCharUnicode: ' + IntToStr(KeyCharUnicode));
-            Writeln('Scancode name: ' + SDL_GetScancodeName(Event.key.keysym.scancode));
-            Writeln('Scancode: ' + IntToStr(Event.key.keysym.scancode));
-            Writeln('Sym: ' + IntToStr(Event.key.keysym.sym));
-
             // if print is pressed -> make screenshot and save to screenshot path
             if (Event.key.keysym.sym = SDLK_SYSREQ) or (Event.key.keysym.sym = SDLK_PRINTSCREEN) then
               Display.SaveScreenShot

--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -525,18 +525,12 @@ begin
           if not Assigned(Display.NextScreen) then
           begin //drop input when changing screens
             KeyCharUnicode:=0;
-            if (Event.type_ = SDL_TEXTINPUT) and (Event.key.keysym.unicode <> 0) then
+            if (Event.type_ = SDL_TEXTINPUT) then
             try
               s1:=Event.text.text;
               KeyCharUnicode:=UnicodeStringToUCS4String(UnicodeString(UTF8String(Event.text.text)))[0];
               //KeyCharUnicode:=UnicodeStringToUCS4String(UnicodeString(Event.key.keysym.unicode))[1];//Event.text.text)[0];
             except
-            end
-            // TODO: hacky workaround for enabling keyboard simulation of controllers. use SDL2 new input handling SDL_StartTextInput and SDL_StopTextInput(
-            else if Event.key.keysym.unicode = 0 then
-            begin
-              s1 := SDL_GetScancodeName(Event.key.keysym.scancode);
-              if Length(s1) = 1 then KeyCharUnicode := Ord(s1[1])
             end;
 
             // if print is pressed -> make screenshot and save to screenshot path

--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -525,13 +525,24 @@ begin
           if not Assigned(Display.NextScreen) then
           begin //drop input when changing screens
             KeyCharUnicode:=0;
-            if (Event.type_ = SDL_TEXTINPUT) then
+            if (Event.type_ = SDL_TEXTINPUT) and (Event.text.text <> '') then
             try
               s1:=Event.text.text;
               KeyCharUnicode:=UnicodeStringToUCS4String(UnicodeString(UTF8String(Event.text.text)))[0];
               //KeyCharUnicode:=UnicodeStringToUCS4String(UnicodeString(Event.key.keysym.unicode))[1];//Event.text.text)[0];
             except
             end;
+
+            Writeln('');
+            if Event.type_ = SDL_TEXTINPUT then
+              Writeln('TEXTINPUT')
+            else
+              Writeln('KEYDOWN');
+            Writeln('Text: ' + Event.text.text);
+            Writeln('KeyCharUnicode: ' + IntToStr(KeyCharUnicode));
+            Writeln('Scancode name: ' + SDL_GetScancodeName(Event.key.keysym.scancode));
+            Writeln('Scancode: ' + IntToStr(Event.key.keysym.scancode));
+            Writeln('Sym: ' + IntToStr(Event.key.keysym.sym));
 
             // if print is pressed -> make screenshot and save to screenshot path
             if (Event.key.keysym.sym = SDLK_SYSREQ) or (Event.key.keysym.sym = SDLK_PRINTSCREEN) then

--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -527,7 +527,6 @@ begin
             KeyCharUnicode:=0;
             if (Event.type_ = SDL_TEXTINPUT) and (Event.text.text <> '') then
             try
-              s1:=Event.text.text;
               KeyCharUnicode:=UnicodeStringToUCS4String(UnicodeString(UTF8String(Event.text.text)))[0];
               //KeyCharUnicode:=UnicodeStringToUCS4String(UnicodeString(Event.key.keysym.unicode))[1];//Event.text.text)[0];
             except


### PR DESCRIPTION
This fixes issues with textinput on SDL2, such as duplicated letters appearing.