### PR TITLE
Fix controller keyboard simulation

### DIFF
--- a/src/base/UJoystick.pas
+++ b/src/base/UJoystick.pas
@@ -285,6 +285,7 @@ var
 procedure InitializeJoystick;
 procedure FinalizeJoyStick;
 function HasJoyStick: boolean;
+function ShouldSimulateJoystickKeyInput(Event: TSDL_event): boolean;
 
 procedure OnJoystickPollEvent(Event: TSDL_event);
 
@@ -794,10 +795,15 @@ begin
   JoyEvent.key.keysym.sym := Key;
   JoyEvent.key.keysym.scancode := SDL_GetScancodeFromKey(Key);
 
-  // always send empty/zero unicode char as workaround. Check UMain.CheckEvents
-  JoyEvent.key.keysym.unicode := 0;
+  // set un-defined unicode char to distinguish keyboard simulated events from real input events as workaround. Check UMain.CheckEvents and ShouldSimulateJoystickKeyInput
+  JoyEvent.key.keysym.unicode := SizeOf(Uint32);
 
   SDL_PushEvent(@JoyEvent);
+end;
+
+function ShouldSimulateJoystickKeyInput(Event: TSDL_event): boolean;
+begin
+  Result := HasJoyStick() and (Event.key.keysym.unicode = SizeOf(Uint32));
 end;
 
 // TODO: Move to Joystick manager

--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -530,6 +530,14 @@ begin
               KeyCharUnicode:=UnicodeStringToUCS4String(UnicodeString(UTF8String(Event.text.text)))[0];
               //KeyCharUnicode:=UnicodeStringToUCS4String(UnicodeString(Event.key.keysym.unicode))[1];//Event.text.text)[0];
             except
+            end
+            // TODO: hacky workaround for enabling keyboard simulation of controllers. use SDL2 new input handling SDL_StartTextInput and SDL_StopTextInput(
+            else if (Event.type_ <> SDL_TEXTINPUT) and
+              (Event.key.keysym.unicode = 0) // verify if the event is not a valid keyboard-text-input (and originating from keyboard simulation)
+              then
+            begin
+              s1 := SDL_GetScancodeName(Event.key.keysym.scancode);
+              if Length(s1) = 1 then KeyCharUnicode := Ord(s1[1])
             end;
 
             // if print is pressed -> make screenshot and save to screenshot path

--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -533,7 +533,7 @@ begin
             end
             // TODO: hacky workaround for enabling keyboard simulation of controllers. use SDL2 new input handling SDL_StartTextInput and SDL_StopTextInput(
             else if (Event.type_ <> SDL_TEXTINPUT) and
-              (Event.key.keysym.unicode = 0) // verify if the event is not a valid keyboard-text-input (and originating from keyboard simulation)
+              ShouldSimulateJoystickKeyInput(Event) // verify if the event is not a valid keyboard-text-input (and originating from keyboard simulation)
               then
             begin
               s1 := SDL_GetScancodeName(Event.key.keysym.scancode);


### PR DESCRIPTION
Fixes controller keyboard simulation (like button 3 and 4 for [M] and [R]), resolves issue reported by #242. Reverts changes from 2180f0bc4dec45942470cb505f819b8fdef67953 done to controller keyboard simulation, by removing the translation of ScanCode inputs (from KeyDown event) to a key code (UCS4CharKey).

Additionally, to prevent duplicate errors (what the orignal fix was about) there's a double check for a text input event; added additional comment about that specific if-check.

This change needs testing if a duplicate character input still occurs.

@daniel-j, since you worked on that original fix to avoid the duplicate characters, can you verify it doesn't happen with this change?