### PR TITLE
Minor build system changes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -567,6 +567,8 @@ macosx-dmg: macosx-standalone-app
 	$(HDIUTIL) attach UltraStarDeluxe.sparseimage
 	/bin/ln -s /Applications /Volumes/UltraStarDeluxe/Applications
 	/bin/cp -R UltraStarDeluxe.app /Volumes/UltraStarDeluxe
+	$(MKDIR) /Volumes/UltraStarDeluxe/Licenses
+	find $(USDX_GAME_DIR) -name 'LICENSE.*' -maxdepth 1 -exec cp {} /Volumes/UltraStarDeluxe/Licenses \;
 #	/bin/cp ultrastardx/icons/UltraStarDeluxeVolumeIcon.icns /Volumes/UltraStarDeluxe/.VolumeIcon.icns
 #	/Developer/Tools/SetFile -a C /Volumes/UltraStarDeluxe/.VolumeIcon.icns /Volumes/UltraStarDeluxe
 	$(HDIUTIL) detach /Volumes/UltraStarDeluxe

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,10 @@
 #!/bin/sh
-AUTOGEN_DIR=dists/autogen
-aclocal -I ${AUTOGEN_DIR}/m4 && autoconf
+# Run this to set up the build system: configure, makefiles, etc.
+set -e
+
+srcdir=`dirname $0`
+test -n "$srcdir" && cd "$srcdir"
+
+echo "Updating build configuration files for USDX, please wait..."
+
+autoreconf -isf


### PR DESCRIPTION
This adds a message to autogen.sh and simplifies it by using `autoreconf`.

Additionally the Licenses for 3rd party libs are added to the dmg for macOS.