### PR TITLE
add script to extend history with svn commits

### DIFF
--- a/get-svn-history.sh
+++ b/get-svn-history.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+git fetch origin 'refs/replace/*:refs/replace/*'


### PR DESCRIPTION
As discussed on IRC, the script added by this commit will fetch a replacement ref from the server to fake the history of the master branch to also include the commits done on the old svn repository.

For the script to work, first fetch the ref from my repository and push it into the official repository:
`git fetch https://github.com/s09bQ5/USDX.git 'refs/replace/*:refs/replace/*'`
`git push origin 'refs/replace/*'`
(If you are paranoid, use `c4fc4aaf35a1c6469f747f50afcbac10be9e3342` instead of `*`)