### PR TITLE
Fix build of OS X Travis job

### DIFF
--- a/configure
+++ b/configure
@@ -5454,7 +5454,14 @@ See the pkg-config man page for more details.
 # It only takes the last from the list, assuming that this is the latest
 # version.
 if [ x$libavcodec_HAVE = xno -a x$FPC_PLATFORM = xdarwin ]; then
-    PKG_CONFIG_PATH=`find $FPCDIR/lib/ffmpeg* -name libavcodec.pc | tail -n 1 | xargs dirname`:$PKG_CONFIG_PATH export PKG_CONFIG_PATH
+    if [ x$enable_osx_fink != x ]; then
+        PKG_CONFIG_PATH=`find /sw/lib -name libavcodec.pc | tail -n 1 | xargs dirname`:$PKG_CONFIG_PATH
+    elif [ x$enable_osx_brew != x ]; then
+        PKG_CONFIG_PATH=`find /usr/local/opt/ffmpeg*/lib /usr/local/lib -name libavcodec.pc | tail -n 1 | xargs dirname`:$PKG_CONFIG_PATH
+    else
+        PKG_CONFIG_PATH=`find $FPCDIR/lib/ffmpeg* -name libavcodec.pc | tail -n 1 | xargs dirname`:$PKG_CONFIG_PATH
+    fi
+    export PKG_CONFIG_PATH
 
     have_lib="no"
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libavcodec" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -245,7 +245,14 @@ PKG_HAVE([libavcodec], [libavcodec], check)
 # It only takes the last from the list, assuming that this is the latest 
 # version.
 if [[ x$libavcodec_HAVE = xno -a x$FPC_PLATFORM = xdarwin ]]; then
-    PKG_CONFIG_PATH=`find $FPCDIR/lib/ffmpeg* -name libavcodec.pc | tail -n 1 | xargs dirname`:$PKG_CONFIG_PATH export PKG_CONFIG_PATH
+    if [[ x$enable_osx_fink != x ]]; then
+        PKG_CONFIG_PATH=`find /sw/lib -name libavcodec.pc | tail -n 1 | xargs dirname`:$PKG_CONFIG_PATH
+    elif [[ x$enable_osx_brew != x ]]; then
+        PKG_CONFIG_PATH=`find /usr/local/opt/ffmpeg*/lib /usr/local/lib -name libavcodec.pc | tail -n 1 | xargs dirname`:$PKG_CONFIG_PATH
+    else
+        PKG_CONFIG_PATH=`find $FPCDIR/lib/ffmpeg* -name libavcodec.pc | tail -n 1 | xargs dirname`:$PKG_CONFIG_PATH
+    fi
+    export PKG_CONFIG_PATH
     PKG_HAVE([libavcodec], [libavcodec], yes)
 fi
 PKG_VERSION([libavcodec], [libavcodec])

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 if [ -n "$LAZ_OPT" ]; then
     # Lazarus build (with wine)


### PR DESCRIPTION
The Travis job for OS X installs FFmpeg 2.8 with Homebrew. When ffmpeg28 was moved from homebrew-versions to homebrew-core it was set to keg-only. This makes homebrew omit the symlinks to /usr/local/lib because it would conflict with the unversioned ffmpeg formula. To use FFmpeg 2.8 one has to explicitly look into /usr/local/opt/ffmpeg@2.8/lib. The problem was not noticed earlier because the Travis build script ignores the exit code of configure.

The first commit forces the build script to exit if any command fails. The second commit adds more search paths depending on the OS X package manager. The else branch is just for compatibility.