### PR TITLE
Change the locking in AudioDecoder_FFmpeg

### DIFF
--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -823,9 +823,9 @@ var
 begin
   Result := true;
 
+  SDL_LockMutex(fStateLock);
   while (true) do
   begin
-    SDL_LockMutex(fStateLock);
     LockParser();
     SDL_UnlockMutex(fStateLock);
     try
@@ -833,7 +833,7 @@ begin
       if (IsQuit()) then
       begin
         Result := false;
-        Exit;
+        Break;
       end;
 
       // handle seek-request (Note: no need to lock SeekRequest here)
@@ -945,7 +945,7 @@ begin
             SDL_UnlockMutex(fStateLock);
             // signal end-of-file
             fPacketQueue.PutStatus(PKT_STATUS_FLAG_EOF, nil);
-            Exit;
+            Break;
           end;
         end;
 
@@ -959,7 +959,7 @@ begin
         begin
           // an error occured -> abort and wait for repositioning or termination
           fPacketQueue.PutStatus(PKT_STATUS_FLAG_ERROR, nil);
-          Exit;
+          Break;
         end;
 
         // url_feof() does not detect an EOF for some files
@@ -972,12 +972,12 @@ begin
         if ((fileSize <> 0) and (ByteIOCtx^.pos >= fileSize)) then
         begin
           fPacketQueue.PutStatus(PKT_STATUS_FLAG_EOF, nil);
-          Exit;
+          Break;
         end;
 
         // unknown error occured, exit
         fPacketQueue.PutStatus(PKT_STATUS_FLAG_ERROR, nil);
-        Exit;
+        Break;
       end;
 
       if (Packet.stream_index = fAudioStreamIndex) then
@@ -988,9 +988,9 @@ begin
     finally
       SDL_LockMutex(fStateLock);
       UnlockParser();
-      SDL_UnlockMutex(fStateLock);
     end;
   end;
+  SDL_UnlockMutex(fStateLock);
 end;
 
 

--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -823,7 +823,6 @@ var
 
   procedure UnlockParser();
   begin
-    if fQuitRequest then Exit;
     SDL_LockMutex(fStateLock);
     fParserLocked := false;
     SDL_CondBroadcast(fParserUnlockedCond);

--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -652,14 +652,14 @@ function TFFmpegDecodeStream.GetLoop(): boolean;
 begin
   SDL_LockMutex(fStateLock);
   Result := fLoop;
-   SDL_UnlockMutex(fStateLock);
+  SDL_UnlockMutex(fStateLock);
 end;
 
 procedure TFFmpegDecodeStream.SetLoop(Enabled: boolean);
 begin
   SDL_LockMutex(fStateLock);
   fLoop := Enabled;
-   SDL_UnlockMutex(fStateLock);
+  SDL_UnlockMutex(fStateLock);
 end;
 
 
@@ -679,7 +679,7 @@ begin
   Inc(fParserPauseRequestCount);
   while (fParserLocked) do
     SDL_CondWait(fParserUnlockedCond, fStateLock);
-   SDL_UnlockMutex(fStateLock);
+  SDL_UnlockMutex(fStateLock);
 end;
 
 procedure TFFmpegDecodeStream.ResumeParser();
@@ -693,7 +693,7 @@ begin
   SDL_LockMutex(fStateLock);
   Dec(fParserPauseRequestCount);
   SDL_CondSignal(fParserResumeCond);
-   SDL_UnlockMutex(fStateLock);
+  SDL_UnlockMutex(fStateLock);
 end;
 
 procedure TFFmpegDecodeStream.SetPositionIntern(Time: real; Flush: boolean; Blocking: boolean);
@@ -742,7 +742,7 @@ begin
     // send a reuse signal in case the parser was stopped (e.g. because of an EOF)
     SDL_CondSignal(fParserIdleCond);
   finally
-     SDL_UnlockMutex(fStateLock);
+    SDL_UnlockMutex(fStateLock);
     ResumeDecoder();
     ResumeParser();
   end;
@@ -753,7 +753,7 @@ begin
     SDL_LockMutex(fStateLock);
     while (fSeekRequest) do
       SDL_CondWait(SeekFinishedCond, fStateLock);
-     SDL_UnlockMutex(fStateLock);
+    SDL_UnlockMutex(fStateLock);
   end;
 end;
 
@@ -778,7 +778,7 @@ begin
     SDL_LockMutex(fStateLock);
     while (not (fSeekRequest or fQuitRequest)) do
       SDL_CondWait(fParserIdleCond, fStateLock);
-     SDL_UnlockMutex(fStateLock);
+    SDL_UnlockMutex(fStateLock);
     end
     else
     begin
@@ -834,7 +834,7 @@ var
     SDL_LockMutex(fStateLock);
     fParserLocked := false;
     SDL_CondBroadcast(fParserUnlockedCond);
-     SDL_UnlockMutex(fStateLock);
+    SDL_UnlockMutex(fStateLock);
   end;
 
 begin
@@ -920,7 +920,7 @@ begin
           fSeekRequest := false;
           SDL_CondBroadcast(SeekFinishedCond);
         finally
-           SDL_UnlockMutex(fStateLock);
+          SDL_UnlockMutex(fStateLock);
           ResumeDecoder();
         end;
       end;
@@ -1014,7 +1014,7 @@ begin
   Inc(fDecoderPauseRequestCount);
   while (fDecoderLocked) do
     SDL_CondWait(fDecoderUnlockedCond, fStateLock);
-   SDL_UnlockMutex(fStateLock);
+  SDL_UnlockMutex(fStateLock);
 end;
 
 procedure TFFmpegDecodeStream.ResumeDecoder();
@@ -1022,7 +1022,7 @@ begin
   SDL_LockMutex(fStateLock);
   Dec(fDecoderPauseRequestCount);
   SDL_CondSignal(fDecoderResumeCond);
-   SDL_UnlockMutex(fStateLock);
+  SDL_UnlockMutex(fStateLock);
 end;
 
 procedure TFFmpegDecodeStream.FlushCodecBuffers();

--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -809,19 +809,15 @@ var
   procedure LockParser();
   begin
     if fQuitRequest then Exit;
-    SDL_LockMutex(fStateLock);
     while (fParserPauseRequestCount > 0) do
       SDL_CondWait(fParserResumeCond, fStateLock);
     fParserLocked := true;
-    SDL_UnlockMutex(fStateLock);
   end;
 
   procedure UnlockParser();
   begin
-    SDL_LockMutex(fStateLock);
     fParserLocked := false;
     SDL_CondBroadcast(fParserUnlockedCond);
-    SDL_UnlockMutex(fStateLock);
   end;
 
 begin
@@ -829,7 +825,9 @@ begin
 
   while (true) do
   begin
+    SDL_LockMutex(fStateLock);
     LockParser();
+    SDL_UnlockMutex(fStateLock);
     try
 
       if (IsQuit()) then
@@ -988,7 +986,9 @@ begin
         av_free_packet(@Packet);
 
     finally
+      SDL_LockMutex(fStateLock);
       UnlockParser();
+      SDL_UnlockMutex(fStateLock);
     end;
   end;
 end;

--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -528,8 +528,11 @@ begin
   if (fParseThread <> nil) then
   begin
     // and wait until it terminates
-    //SDL_WaitThread(fParseThread, PInt(ThreadResult));
+    SDL_WaitThread(fParseThread, @ThreadResult);
+    SDL_LockMutex(fStateLock);
     fParseThread := nil;
+    SDL_CondBroadcast(SeekFinishedCond);
+    SDL_UnlockMutex(fStateLock);
   end;
 
   {$IFDEF ConvertPlanar}

--- a/src/media/UAudioPlayback_SoftMixer.pas
+++ b/src/media/UAudioPlayback_SoftMixer.pas
@@ -419,9 +419,9 @@ begin
   Stop();
 
   // Note: PerformOnClose must be called before SourceStream is invalidated
-  //PerformOnClose();
+  PerformOnClose();
   // and free data
-  //Reset();
+  Reset();
 end;
 
 procedure TGenericPlaybackStream.LockSampleBuffer();


### PR DESCRIPTION
and fix #244.

The changes are done in very small steps to make them easier to understand.
I hope that all locking problems are gone now and there is no delay when waiting for the termination of the parsing thread. The changes have not seen much testing, though.