### PR TITLE
Add MIDI support for other platform

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -393,6 +393,34 @@ fi
 PKG_HAVE([portmixer], [portmixer], no)
 AC_SUBST_DEFINE(HAVE_PORTMIXER, $portmixer_HAVE)
 
+AC_ARG_ENABLE(portmidi, [AS_HELP_STRING([--disable-portmidi], [Disable PortTime Midi loop])])
+AC_ARG_WITH(porttime, [AS_HELP_STRING([--with-porttime], [Use PortTime instead of SDL Midi loop])])
+
+if [[ x$enable_portmidi != xno ]] ; then
+    AC_CHECK_LIB([portmidi], [Pm_Initialize], [
+        portmidi_HAVE=yes
+        if [[ x$with_porttime = xyes ]] ; then
+            porttime_HAVE=yes
+            AC_CHECK_LIB([portmidi], [Pt_Start], [porttime_LIB_NAME=portmidi],
+                [AC_CHECK_LIB([porttime], [Pt_Start], [porttime_LIB_NAME=porttime],
+                     [AC_MSG_ERROR([PortTime library not found])])])
+        else
+            porttime_HAVE=no
+        fi
+        ], [
+        if [[ x$enable_portmidi = xyes ]] ; then
+            AC_MSG_ERROR([PortMidi library not found])
+        else
+            portmidi_HAVE=no
+        fi
+        ])
+else
+	portmidi_HAVE=no
+fi
+AC_SUBST_DEFINE(HAVE_PORTMIDI, $portmidi_HAVE)
+AC_SUBST_DEFINE(HAVE_PORTTIME, $porttime_HAVE)
+AC_SUBST(porttime_LIB_NAME)
+
 # determine linker-flags
 if test x$FPC_PLATFORM = xdarwin; then
   LDFLAGS="-macosx_version_min 10.4 -undefined dynamic_lookup -headerpad_max_install_names -L/usr/X11/lib"

--- a/dists/linux/build-deps.sh
+++ b/dists/linux/build-deps.sh
@@ -117,6 +117,29 @@ make $makearg
 make install
 make distclean
 
+echo "Building PortMidi"
+cd "$SRC"
+find portmidi/ portmidi-debian/patches/ -type f | while read a ; do
+	tr -d '\r' < "$a" > t
+	cat t >$a
+done
+rm t
+cd portmidi
+while read a ; do
+	patch -l -p1 < ../portmidi-debian/patches/$a
+done < ../portmidi-debian/patches/series
+mkdir -p build
+cd build
+cmake \
+	-DCMAKE_CACHEFILE_DIR=$(pwd)/out \
+	-DCMAKE_INSTALL_PREFIX="$PREFIX" \
+	-DCMAKE_BUILD_TYPE="Release" \
+	..
+make portmidi-dynamic
+make -C pm_dylib install
+cd ..
+rm -R build
+
 # echo "Building projectM"
 # cd "$SRC/projectm"
 # mkdir -p build

--- a/dists/linux/dl.sh
+++ b/dists/linux/dl.sh
@@ -11,6 +11,8 @@ deps+=('ffmpeg,https://ffmpeg.org/releases/ffmpeg-3.2.2.tar.gz')
 deps+=('portaudio,http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz')
 deps+=('freetype,http://download.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.gz')
 deps+=('libpng,https://sourceforge.net/projects/libpng/files/libpng16/older-releases/1.6.28/libpng-1.6.28.tar.gz/download')
+deps+=('portmidi,https://sourceforge.net/projects/portmedia/files/portmidi/217/portmidi-src-217.zip/download')
+deps+=('portmidi-debian,http://http.debian.net/debian/pool/main/p/portmidi/portmidi_217-6.debian.tar.xz')
 
 rm -rf deps
 
@@ -20,6 +22,31 @@ for i in "${deps[@]}"; do
 	name="${dep[0]}"
 	url="${dep[1]}"
 	echo "Downloading $url"
-	mkdir -p "deps/$name"
-	curl --progress-bar -L "$url" | tar -xz -C "deps/$name" --strip-components=1
+	filename="${url%/download}"
+	case "$filename" in
+	*.zip)
+		mkdir -p deps
+		curl --progress-bar -L "$url" -o deps/$name.zip
+		mkdir -p "deps/$name.tmp"
+		unzip -q deps/$name.zip -d "deps/$name.tmp"
+		rm deps/$name.zip
+		mv "deps/$name.tmp/"* "deps/$name"
+		rmdir "deps/$name.tmp"
+		;;
+
+	*.tar|*.tar.gz|*.tar.xz|*.tar.bz2|*.tgz)
+		case "$filename" in
+		*xz)	compressor=J ;;
+		*bz2)	compressor=j ;;
+		*gz)	compressor=z ;;
+		*)	compressor= ;;
+		esac
+		mkdir -p "deps/$name"
+		curl --progress-bar -L "$url" | tar -x$compressor -C "deps/$name" --strip-components=1
+		;;
+
+	*)
+		echo "Unsupported archive format"
+		false
+	esac
 done

--- a/src/config.inc.in
+++ b/src/config.inc.in
@@ -86,3 +86,11 @@
 {$IFEND}
 
 {$@DEFINE_HAVE_PORTMIXER@ HavePortmixer}
+{$@DEFINE_HAVE_PORTMIDI@ UsePortMidi}
+{$IF Defined(UsePortMidi)}
+  {$DEFINE UseMIDIPort}
+{$IFEND}
+{$@DEFINE_HAVE_PORTTIME@ UsePortTime}
+{$IF Defined(IncludeConstants)}
+  porttime_lib_name = '@porttime_LIB_NAME@';
+{$IFEND}

--- a/src/config.inc.in
+++ b/src/config.inc.in
@@ -91,6 +91,7 @@
   {$DEFINE UseMIDIPort}
 {$IFEND}
 {$@DEFINE_HAVE_PORTTIME@ UsePortTime}
+{$@DEFINE_HAVE_PORTTIME@ PortTime_in_@porttime_LIB_NAME@}
 {$IF Defined(IncludeConstants)}
   porttime_lib_name = '@porttime_LIB_NAME@';
 {$IFEND}

--- a/src/lib/midi/DelphiMcb.pas
+++ b/src/lib/midi/DelphiMcb.pas
@@ -21,6 +21,7 @@ uses
   MMsystem,
   CircBuf,
   MidiDefs,
+  MidiConsWin,
   MidiCons;
 
 procedure MidiHandler(

--- a/src/lib/midi/MidiCons.pas
+++ b/src/lib/midi/MidiCons.pas
@@ -13,11 +13,6 @@ interface
   {$H+} // use long strings
 {$ENDIF}
 
-{$IFNDEF FPC}
-uses
-  Messages;
-{$ENDIF}
-
 const
   MIDI_ALLNOTESOFF     = $7B;
   MIDI_NOTEON          = $90;
@@ -39,13 +34,6 @@ const
   MIDI_STOP            = $FC;
   MIDI_ACTIVESENSING   = $FE;
   MIDI_SYSTEMRESET     = $FF;
-
-{$IFDEF FPC}
-  WM_USER              = $400;        { standard WM_USER value }
-{$ENDIF}
-
-  MIM_OVERFLOW         = WM_USER;     { Input buffer overflow }
-  MOM_PLAYBACK_DONE    = WM_USER + 1; { Timed playback complete }
 
 implementation
 

--- a/src/lib/midi/MidiConsWin.pas
+++ b/src/lib/midi/MidiConsWin.pas
@@ -1,0 +1,31 @@
+{ $Header: /MidiComp/MidiCons.pas 2     10/06/97 7:33 Davec $ }
+
+{ Written by David Churcher <dchurcher@cix.compulink.co.uk>,
+  released to the public domain. }
+
+{ Windows Midi Constants }
+unit MidiConsWin;
+
+interface
+
+{$IFDEF FPC}
+  {$MODE Delphi}
+  {$H+} // use long strings
+{$ENDIF}
+
+{$IFNDEF FPC}
+uses
+  Messages;
+{$ENDIF}
+
+const
+{$IFDEF FPC}
+  WM_USER              = $400;        { standard WM_USER value }
+{$ENDIF}
+
+  MIM_OVERFLOW         = WM_USER;     { Input buffer overflow }
+  MOM_PLAYBACK_DONE    = WM_USER + 1; { Timed playback complete }
+
+implementation
+
+end.

--- a/src/lib/midi/MidiFile.pas
+++ b/src/lib/midi/MidiFile.pas
@@ -736,7 +736,8 @@ begin
   GetMem(chunkData, chunkLength + 10);
   MidiFile.Read(chunkData^, chunkLength);
   chunkIndex := chunkData;
-  chunkEnd := PByte(integer(chunkIndex) + integer(chunkLength) - 1);
+  chunkEnd := chunkIndex;
+  Inc(chunkEnd, chunkLength - 1);
 end;
 
 procedure TMidifile.ReadChunk;
@@ -791,7 +792,7 @@ begin
     currentTrack := TMidiTrack.Create;
     currentTrack.OnMidiEvent := FOnMidiEvent;
     Tracks.add(currentTrack);
-    while integer(chunkIndex) < integer(chunkEnd) do
+    while chunkIndex < chunkEnd do
     begin
       // each event starts with var length delta time
       dTime := ReadVarLength;

--- a/src/lib/midi/MidiFile.pas
+++ b/src/lib/midi/MidiFile.pas
@@ -321,6 +321,11 @@ begin
     end;
   end;
 end;
+
+function GetMillisecondTime: integer;
+begin
+  result := windows.GetTickCount;
+end;
 {$ENDIF}
 
 constructor TMidiTrack.Create;
@@ -521,7 +526,7 @@ procedure TMidifile.MidiTimer(Sender: TObject);
 begin
   if playing then
   begin
-    PlayToTime(GetTickCount - PlayStartTime);
+    PlayToTime(GetMillisecondTime - PlayStartTime);
     if assigned(FOnUpdateEvent) then FOnUpdateEvent(self);
   end;
 end;
@@ -533,7 +538,7 @@ var
 begin
   for i := 0 to tracks.count - 1 do
     TMidiTrack(tracks[i]).Rewind(0);
-  playStartTime := getTickCount;
+  playStartTime := GetMillisecondTime;
   playing := true;
 
   SetMidiTimer;
@@ -544,7 +549,7 @@ end;
 {$WARNINGS OFF}
 procedure TMidifile.ContinuePlaying;
 begin
-  PlayStartTime := GetTickCount - currentTime;
+  PlayStartTime := GetMillisecondTime - currentTime;
   playing := true;
 
   SetMidiTimer;

--- a/src/lib/midi/MidiIn.pas
+++ b/src/lib/midi/MidiIn.pas
@@ -118,6 +118,7 @@ uses
   MidiDefs,
   MidiType,
   MidiCons,
+  MidiConsWin,
   CircBuf,
   DelphiMcb;
 

--- a/src/lib/portmidi/MidiOut.pas
+++ b/src/lib/portmidi/MidiOut.pas
@@ -1,0 +1,79 @@
+unit MidiOut;
+
+interface
+
+{$IFDEF FPC}
+  {$MODE Delphi}
+  {$H+} // use long strings
+{$ENDIF}
+
+uses
+  portmidi;
+
+type
+  TMidiOutput = class
+  protected
+    FProductName: string; { product name }
+    stream: PortMidiStream;
+    id: PmDeviceID;
+
+  public
+    procedure Open;
+    procedure Close;
+    procedure PutShort(MidiMessage: byte; Data1: byte; Data2: byte);
+    constructor Create(AOwner: pointer);
+    destructor Destroy; override;
+
+  published
+    property ProductName: string read FProductName;
+  end;
+
+implementation
+
+constructor Tmidioutput.Create(AOwner: pointer);
+var
+  info: PPmDeviceInfo;
+begin
+  inherited Create;
+  id := Pm_GetDefaultOutputDeviceID;
+  if id = -1 then
+    id := 0;
+  info :=Pm_GetDeviceInfo(id);
+  if info = nil then
+    id := -1
+  else
+    FProductName := info^.name;
+  stream := nil;
+end;
+
+destructor Tmidioutput.Destroy;
+begin
+  Close;
+  inherited Destroy;
+end;
+
+procedure Tmidioutput.Open;
+begin
+  if id <> -1 then
+    Pm_OpenOutput(@stream, id, nil, 16, nil, nil, 0);
+end;
+
+procedure TMidiOutput.PutShort(MidiMessage: byte; Data1: byte; Data2: byte);
+begin
+  if stream <> nil then
+    Pm_WriteShort(stream, 0, Pm_Message(MidiMessage, Data1, Data2));
+end;
+
+procedure Tmidioutput.Close;
+begin
+  if stream <> nil then
+  begin
+    Pm_Close(stream);
+    stream := nil;
+  end;
+end;
+
+begin
+  Pm_Initialize;
+end.
+

--- a/src/lib/portmidi/portmidi.pp
+++ b/src/lib/portmidi/portmidi.pp
@@ -1,0 +1,292 @@
+{
+  PortMidi bindings for FreePascal
+  Latest version available at: http://sourceforge.net/apps/trac/humus/
+  
+  Copyright (c) 2010 HuMuS Project
+  Maintained by Roland Schaefer
+
+  PortMidi Portable Real-Time MIDI Library
+  Latest version available at: http://sourceforge.net/apps/trac/humus/
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files
+  (the "Software"), to deal in the Software without restriction,
+  including without limitation the rights to use, copy, modify, merge,
+  publish, distribute, sublicense, and/or sell copies of the Software,
+  and to permit persons to whom the Software is furnished to do so,
+  subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+  ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+  CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+  The text above constitutes the entire PortMidi license; however, 
+  the PortMusic community also makes the following non-binding requests:
+
+  Any person wishing to distribute modifications to the Software is
+  requested to send the modifications to the original developer so that
+  they can be incorporated into the canonical version. It is also
+  requested that these non-binding requests be included along with the 
+  license above.
+}
+
+
+unit PortMidi;
+
+
+interface
+
+{$MODE FPC}
+{$CALLING CDECL}
+{$MACRO ON}
+
+
+uses
+  CTypes;
+
+
+{$DEFINE EXTERNALSPEC := external 'portmidi' name}
+
+{$IFDEF LINKOBJECT}
+  {$LINKLIB portmidi.o}
+{$ENDIF}
+
+
+
+type
+  CInt32 = CInt;
+  CUInt32 = CUInt;
+
+const
+  PM_DEFAULT_SYSEX_BUFFER_SIZE : CInt = CInt(1024);
+
+type
+  PmError = CInt;
+
+const
+  pmNoError           : PmError = 0;
+  pmNoData            : PmError = 0;
+  pmGotData           : PmError = 1;
+  pmHostError         : PmError = -10000;
+  pmInvalidDeviceId   : PmError = -9999;
+  pmInsufficientMemory: PmError = -9998;
+  pmBufferTooSmall    : PmError = -9997;
+  pmBufferOverflow    : PmError = -9996;
+  pmBadPtr            : PmError = -9995;
+  pmBadData           : PmError = -9994;
+  pmInternalError     : PmError = -9993;
+  pmBufferMaxSize     : PmError = -9992;
+
+
+function Pm_Initialize : PmError;
+  EXTERNALSPEC 'Pm_Initialize';
+
+function Pm_Terminate : PmError;
+  EXTERNALSPEC 'Pm_Terminate';
+
+type
+  PortMidiStream = Pointer;
+  PPortMidiStream = ^PortMidiStream;
+
+function Pm_HasHostError(stream : PortMidiStream) : CInt;
+  EXTERNALSPEC 'Pm_HasHostError';
+
+function Pm_GetErrorText(errnum : PmError) : PChar;
+  EXTERNALSPEC 'Pm_GetErrorText';
+
+
+procedure Pm_GetHostErrorText(msg : PChar; Len : CUInt);
+  EXTERNALSPEC 'Pm_GetHostErrorText';
+
+const
+  HDRLENGTH             = 50;
+  PM_HOST_ERROR_MSG_LEN = 256;
+
+type
+  PmDeviceID = CInt;
+
+const
+  pmNoDevice  = -1;
+
+type
+  PMDeviceInfo = record
+    structVersion : CInt;
+    interf : PChar;
+    name : PChar;
+    input : CInt;
+    output : CInt;
+    opened : CInt;
+  end;
+  PPMDeviceInfo = ^PMDeviceInfo;
+
+function Pm_CountDevices : CInt;
+  EXTERNALSPEC 'Pm_CountDevices';
+
+function Pm_GetDefaultInputDeviceID : PmDeviceID;
+  EXTERNALSPEC 'Pm_GetDefaultInputDeviceID';
+
+function Pm_GetDefaultOutputDeviceID : PmDeviceID;
+  EXTERNALSPEC 'Pm_GetDefaultOutputDeviceID';
+
+type
+  PmTimestamp = CInt32;
+
+type
+  PmTimeProcPtr = function(time_info : Pointer) : PmTimestamp;
+
+function PmBefore(t1, t2 : PmTimestamp) : Boolean; inline;
+
+function Pm_GetDeviceInfo(id : PmDeviceID) : PPmDeviceInfo;
+  EXTERNALSPEC 'Pm_GetDeviceInfo';
+
+function Pm_OpenInput(stream : PPortMidiStream;
+  inputDevice : PmDeviceID;
+  inputDriverInfo : Pointer;
+  bufferSize : CInt32;
+  time_proc : PmTimeProcPtr;
+  time_info : Pointer ) : PmError;
+  EXTERNALSPEC 'Pm_OpenInput';
+
+function Pm_OpenOutput(stream : PPortMidiStream;
+  outputDevice : PmDeviceID;
+  outputDriverInfo : Pointer;
+  bufferSize : CInt32;
+  time_proc : PmTimeProcPtr;
+  time_info : Pointer;
+  latency : CInt32 ) : PmError;
+  EXTERNALSPEC 'Pm_OpenOutput';
+
+const
+  PM_FILT_ACTIVE             = (1 shl $0E);
+  PM_FILT_SYSEX              = (1 shl $00);
+  PM_FILT_CLOCK              = (1 shl $08);
+  PM_FILT_PLAY               = ((1 shl $0A) or (1 shl $0C)
+                                or (1 shl $0B));
+  PM_FILT_TICK               = (1 shl $09);
+  PM_FILT_FD                 = (1 shl $0D);
+  PM_FILT_UNDEFINED          = (1 shl $0D);
+  PM_FILT_RESET              = (1 shl $0F);
+  PM_FILT_REALTIME           = ((1 shl $0E)
+                                or (1 shl $00) or (1 shl $08)
+                                or ((1 shl $0A) or (1 shl $0C)
+                                    or (1 shl $0B))
+                                or (1 shl $0D)
+                                or (1 shl $0F) or (1 shl $09));
+  PM_FILT_NOTE               = ((1 shl $19) or (1 shl $18));
+  PM_FILT_CHANNEL_AFTERTOUCH = (1 shl $1D);
+  PM_FILT_POLY_AFTERTOUCH    = (1 shl $1A);
+  PM_FILT_AFTERTOUCH         = ((1 shl $1D)
+                                or (1 shl $1A));
+  PM_FILT_PROGRAM            = (1 shl $1C);
+  PM_FILT_CONTROL            = (1 shl $1B);
+  PM_FILT_PITCHBEND          = (1 shl $1E);
+  PM_FILT_MTC                = (1 shl $01);
+  PM_FILT_SONG_POSITION      = (1 shl $02);
+  PM_FILT_SONG_SELECT        = (1 shl $03);
+  PM_FILT_TUNE               = (1 shl $06);
+  PM_FILT_SYSTEMCOMMON       = ((1 shl $01) or (1 shl $02)
+                                or (1 shl $03) or (1 shl $06));
+
+function Pm_SetFilter(stream : PortMidiStream; filters : CInt32 ) : PmError;
+  EXTERNALSPEC 'Pm_SetFilte';
+
+function Pm_Channel(channel : CInt) : CInt; inline;
+
+function Pm_SetChannelMask(stream : PortMidiStream; mask : CInt) : PmError;
+  EXTERNALSPEC 'Pm_SetChannelMask';
+
+function Pm_Abort(stream : PortMidiStream) : PmError;
+  EXTERNALSPEC 'Pm_Abort';
+
+function Pm_Close(stream : PortMidiStream) : PmError;
+  EXTERNALSPEC 'Pm_Close';
+
+function Pm_Synchronize(stream : PortMidiStream) : PmError;
+  EXTERNALSPEC 'Pm_Synchronize';
+
+function Pm_Message(status, data1, data2 : CInt) : CInt; inline;
+
+function Pm_MessageStatus(msg : CInt) : CInt; inline;
+
+function Pm_MessageData1(msg : CInt) : CInt; inline;
+
+function Pm_MessageData2(msg : CInt) : CInt; inline;
+
+type
+  PmMessage = CInt32;
+
+type
+  PmEvent = record
+    message_ : PmMessage;
+    timestamp : PmTimestamp;
+  end;
+  PPmEvent = ^PmEvent;
+
+function Pm_Read(stream : PortMidiStream; buffer : PPmEvent; length : CInt32 ) : CInt;
+  EXTERNALSPEC 'Pm_Read';
+
+function Pm_Poll(stream : PortMidiStream) : PmError;
+  EXTERNALSPEC 'Pm_Poll';
+
+function Pm_Write(stream : PortMidiStream; buffer : PPmEvent;
+  length : CInt32 ) : PmError;
+  EXTERNALSPEC 'Pm_Write';
+
+function Pm_WriteShort(stream : PortMidiStream; when : PmTimestamp;
+  msg : CInt32) : PmError;
+  EXTERNALSPEC 'Pm_WriteShort';
+
+function Pm_WriteSysEx(stream : PortMidiStream; when : PmTimestamp;
+  msg : PChar) : PmError;
+  EXTERNALSPEC 'Pm_WriteSysEx';
+
+
+implementation
+
+
+
+function PmBefore(t1, t2 : PmTimestamp) : Boolean; inline;
+begin
+  PmBefore := ((t1-t2) < 0);
+end;
+
+
+function Pm_Channel(channel : CInt) : CInt; inline;
+begin
+  Pm_Channel := (1 shl channel);
+end;
+
+function Pm_Message(status, data1, data2 : CInt) : CInt; inline;
+begin
+  Pm_Message := ((((data2) shl 16) and $FF0000)
+    or (((data1) shl 8) and $FF00)
+    or ((status) and $FF));
+end;
+
+
+function Pm_MessageStatus(msg : CInt) : CInt; inline;
+begin
+  Pm_MessageStatus := ((msg) and $FF);
+end;
+
+
+function Pm_MessageData1(msg : CInt) : CInt; inline;
+begin
+  Pm_MessageData1 := (((msg) shr 8) and $FF);
+end;
+
+
+function Pm_MessageData2(msg : CInt) : CInt; inline;
+begin
+  Pm_MessageData2 := (((msg) shr 16) and $FF);
+end;
+
+
+end.

--- a/src/lib/portmidi/portmidi.pp
+++ b/src/lib/portmidi/portmidi.pp
@@ -56,6 +56,10 @@ uses
 
 {$IFDEF LINKOBJECT}
   {$LINKLIB portmidi.o}
+{$ELSE}
+  {$IFDEF Darwin}
+    {$LINKLIB libportmidi}
+  {$ENDIF}
 {$ENDIF}
 
 

--- a/src/lib/portmidi/porttime.pp
+++ b/src/lib/portmidi/porttime.pp
@@ -46,6 +46,7 @@ interface
 {$CALLING CDECL}
 {$MACRO ON}
 
+{$I switches.inc}
 
 uses
   UConfig,
@@ -56,6 +57,14 @@ uses
 
 {$IFDEF LINKOBJECT}
   {$LINKLIB portmidi.o}
+{$ELSE}
+  {$IFDEF Darwin}
+    {$IFDEF PortTime_in_portmidi}
+      {$LINKLIB libportmidi}
+    {$ELSE}
+      {$LINKLIB libporttime}
+    {$ENDIF}
+  {$ENDIF}
 {$ENDIF}
 
 

--- a/src/lib/portmidi/porttime.pp
+++ b/src/lib/portmidi/porttime.pp
@@ -1,0 +1,97 @@
+{
+  PortMidi bindings for FreePascal
+  Latest version available at: http://sourceforge.net/apps/trac/humus/
+  
+  Copyright (c) 2010 HuMuS Project
+  Maintained by Roland Schaefer
+
+  PortMidi Portable Real-Time MIDI Library
+  Latest version available at: http://sourceforge.net/apps/trac/humus/
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files
+  (the "Software"), to deal in the Software without restriction,
+  including without limitation the rights to use, copy, modify, merge,
+  publish, distribute, sublicense, and/or sell copies of the Software,
+  and to permit persons to whom the Software is furnished to do so,
+  subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+  ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+  CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+  The text above constitutes the entire PortMidi license; however, 
+  the PortMusic community also makes the following non-binding requests:
+
+  Any person wishing to distribute modifications to the Software is
+  requested to send the modifications to the original developer so that
+  they can be incorporated into the canonical version. It is also
+  requested that these non-binding requests be included along with the 
+  license above.
+}
+
+unit PortTime;
+
+
+interface
+
+{$MODE FPC}
+{$CALLING CDECL}
+{$MACRO ON}
+
+
+uses
+  UConfig,
+  CTypes;
+
+
+{$DEFINE EXTERNALSPEC := external porttime_lib_name name}
+
+{$IFDEF LINKOBJECT}
+  {$LINKLIB portmidi.o}
+{$ENDIF}
+
+
+
+type
+ PtError = CInt;
+
+const
+  ptNoError             : PtError = 0;
+  ptHostError           : PtError = -10000;
+  ptAlreadyStarted      : PtError = -9999;
+  ptAlreadyStopped      : PtError = -9998;
+  ptInsufficientMemory  : PtError = -99997;
+
+type
+  PtTimestamp = CInt32;
+
+type
+  PtCallback = procedure(timestamp : PtTimestamp; userData : Pointer);
+
+function Pt_Start(resolution : CInt; callback : PtCallback;
+  userData : Pointer) : PtError;
+  EXTERNALSPEC 'Pt_Start';
+
+function Pt_Stop : PtError;
+  EXTERNALSPEC 'Pt_Stop';
+
+function Pt_Started : CInt;
+  EXTERNALSPEC 'Pt_Started';
+
+function Pt_Time : PtTimestamp;
+  EXTERNALSPEC 'Pt_Time';
+
+procedure Pt_Sleep(duration : CInt32);
+  EXTERNALSPEC 'Pt_Sleep';
+
+implementation
+
+end.

--- a/src/ultrastardx.dpr
+++ b/src/ultrastardx.dpr
@@ -84,6 +84,12 @@ uses
   {$IFDEF UsePortmixer}
   portmixer              in 'lib\portmixer\portmixer.pas',
   {$ENDIF}
+  {$IFDEF UsePortMidi}
+  portmidi               in 'lib\portmidi\portmidi.pp',
+  {$ENDIF}
+  {$IFDEF UsePortTime}
+  porttime               in 'lib\portmidi\porttime.pp',
+  {$ENDIF}
 
   {$IFDEF UseFFmpeg}
     {$IFDEF FPC} // This solution is not very elegant, but working
@@ -127,15 +133,21 @@ uses
   {$ENDIF}
 
   {$IFDEF UseMIDIPort}
-  MidiCons      in 'lib\midi\MidiCons.pas',
-  MidiConsWin   in 'lib\midi\MidiConsWin.pas',
+    MidiCons          in 'lib\midi\MidiCons.pas',
+    MidiFile          in 'lib\midi\MidiFile.pas',
 
-  CircBuf       in 'lib\midi\CircBuf.pas',
-  DelphiMcb     in 'lib\midi\DelphiMcb.pas',
-  MidiDefs      in 'lib\midi\MidiDefs.pas',
-  MidiFile      in 'lib\midi\MidiFile.pas',
-  MidiOut       in 'lib\midi\MidiOut.pas',
-  MidiType      in 'lib\midi\MidiType.pas',
+    {$IFDEF MSWINDOWS}
+      CircBuf         in 'lib\midi\CircBuf.pas',
+      MidiConsWin     in 'lib\midi\MidiConsWin.pas',
+      DelphiMcb       in 'lib\midi\DelphiMcb.pas',
+      MidiDefs        in 'lib\midi\MidiDefs.pas',
+      MidiType        in 'lib\midi\MidiType.pas',
+      MidiOut         in 'lib\midi\MidiOut.pas',
+    {$ELSE}
+      {$IFDEF UsePortMidi}
+        MidiOut       in 'lib\portmidi\MidiOut.pas',
+      {$ENDIF}
+    {$ENDIF}
   {$ENDIF}
 
   {$IFDEF MSWINDOWS}

--- a/src/ultrastardx.dpr
+++ b/src/ultrastardx.dpr
@@ -128,6 +128,7 @@ uses
 
   {$IFDEF UseMIDIPort}
   MidiCons      in 'lib\midi\MidiCons.pas',
+  MidiConsWin   in 'lib\midi\MidiConsWin.pas',
 
   CircBuf       in 'lib\midi\CircBuf.pas',
   DelphiMcb     in 'lib\midi\DelphiMcb.pas',

--- a/tools/travis/install.sh
+++ b/tools/travis/install.sh
@@ -14,7 +14,8 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     #brew cask install xquartz
 
     brew install sdl2 sdl2_gfx sdl2_image sdl2_mixer sdl2_net sdl2_ttf \
-        fpc portaudio binutils sqlite freetype libpng pcre lua libtiff
+        fpc portaudio binutils sqlite freetype libpng pcre lua libtiff \
+        portmidi
 
     # This is from: https://github.com/Homebrew/homebrew-versions
     brew install ffmpeg28


### PR DESCRIPTION
This should fix #297.

So far only Linux has been tested. Windows still uses the old code, though it is also supported by PortMidi. I hope I didn't break support for Windows while restructuring the code. A fix for 64 bit architectures is also included. Btw., do we still support compilation with Delphi?