### PR TITLE
Automatically collect all OS X libraries for standalone package

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -86,27 +86,6 @@ DEPS += $(PROJECTM_CWRAPPER_DIR)
 endif
 
 #################################################
-# Mac OS X library functions
-#################################################
-# copy the dylib and change its install names
-
-define install_osx_libraries
-    @echo "work on $(dylib)"
-    $(shell $(INSTALL) -m 755 $(dylib) $(macosx_bundle_path)/MacOS)
-    $(shell $(INSTALL_NAME_TOOL) -change $(dylib) @executable_path/$(notdir $(dylib)) $(macosx_bundle_path)/MacOS/ultrastardx)
-    $(shell $(INSTALL_NAME_TOOL) -id @executable_path/$(notdir $(dylib)) $(macosx_bundle_path)/MacOS/$(notdir $(dylib)))
-    $(foreach linked_dylibs_2,$(shell $(OTOOL) -L $(dylib) | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \usr\/lib | grep -v executable_path),$(rename_secondary_osx_libraries))
-endef
-
-define rename_secondary_osx_libraries
-    @echo "change the install name for $(linked_dylibs_2)"
-    $(shell $(INSTALL_NAME_TOOL) -change $(linked_dylibs_2) @executable_path/$(notdir $(linked_dylibs_2)) $(macosx_bundle_path)/MacOS/$(notdir $(dylib)))
-endef
-
-USE_OSX_PACKAGING=@USE_OSX_PACKAGING@
-USE_OSX_PACKAGING_LIBDIR=@USE_OSX_PACKAGING_LIBDIR@
-
-#################################################
 # general targets
 #################################################
 
@@ -442,16 +421,13 @@ macosx-app: all
 	@echo "Have fun."
 	@echo ""
 
-# use pkg-config. The one in the app bundle may already be changed
-ifeq ($(USE_OSX_PACKAGING), brew)
-AVCODECLIBPATH := /$(shell pkg-config --libs-only-L  libavcodec | cut -f 2- -d '/')
-endif
-
-ifeq ($(USE_OSX_PACKAGING), fink)
-AVCODECLIBPATH := $(shell pkg-config --libs-only-L  libavcodec | cut -f 4-5 -d '/' | cut -f 1 -d ' ')
-endif
-
-AVCODECLIB := $(AVCODECLIBPATH)/libavcodec.dylib
+# export some variables used by Makefile.osx-helper
+export USDX_BIN
+export pkgingLibDir
+export macosx_bundle_path
+export INSTALL
+export INSTALL_NAME_TOOL
+export OTOOL
 
 .PHONY: macosx-standalone-app
 macosx-standalone-app: macosx-app 
@@ -462,90 +438,8 @@ macosx-standalone-app: macosx-app
 	@echo "Creating the standalone Mac OS X application"
 	@echo ""
 
-ifeq ($(USE_OSX_PACKAGING), brew)
-	@echo "avcodec lib found: $(AVCODECLIB)"
-endif
-ifeq ($(USE_OSX_PACKAGING), fink)
-	@echo "avcodec lib found: $(finkLibDir)/$(AVCODECLIB)"
-endif
-# work on the dylibs in $(macosx_bundle_path)/MacOS/ultrastardx
-	@echo "[generic] copying libs of ultrastardx"
-	$(foreach dylib,$(shell $(OTOOL) -L $(macosx_bundle_path)/MacOS/ultrastardx | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-
-# work on the secondary dylibs from ffmpeg
-# libavcodec references all tertiary libraries of the ffmpeg libs
-ifeq ($(USE_OSX_PACKAGING), brew)
-	@echo "[brew] copying libs of libavcodec"
-	$(foreach dylib,$(shell $(OTOOL) -L $(AVCODECLIB) | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-endif
-ifeq ($(USE_OSX_PACKAGING), fink)
-	@echo "[fink] copying libs of libavcodec"
-	$(foreach dylib,$(shell $(OTOOL) -L $(finkLibDir)/$(AVCODECLIB) | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-endif
-
-# same procedure in libfaac. it gets libgnugetopt
-	@echo "[generic] copying libs of libfaac"
-	$(foreach dylib,$(shell $(OTOOL) -L $(pkgingLibDir)/libfaac.dylib      | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-
-# same procedure for tertiary libs in SDL2_image
-	@echo "[generic] copying libs of libSDL2_image"
-	$(foreach dylib,$(shell $(OTOOL) -L $(pkgingLibDir)/libSDL2_image.dylib | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-
-# same procedure for secondary libs in libtiff
-	@echo "[generic] copying libs of libtiff"
-	$(foreach dylib,$(shell $(OTOOL) -L $(pkgingLibDir)/libtiff.dylib | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-
-# same procedure for secondary libs in libfreetype
-ifeq ($(USE_OSX_PACKAGING), brew)
-	@echo "[brew] copying libs of libfreetype"
-	$(foreach dylib,$(shell $(OTOOL) -L $(pkgingLibDir)/libfreetype.dylib | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-endif
-ifeq ($(USE_OSX_PACKAGING), fink)
-	@echo "[fink] copying libs of libfreetype"
-	$(foreach dylib,$(shell $(OTOOL) -L $(finkLibDir)/freetype219/lib/libfreetype.dylib | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-endif
-
-# same procedure for secondary libs in libfontconfig
-ifeq ($(USE_OSX_PACKAGING), brew)
-	@echo "[brew] copying libs of libfontconfig"
-	$(foreach dylib,$(shell $(OTOOL) -L $(pkgingLibDir)/libfontconfig.dylib | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-endif
-ifeq ($(USE_OSX_PACKAGING), fink)
-	@echo "[fink] copying libs of libfontconfig"
-	$(foreach dylib,$(shell $(OTOOL) -L $(finkLibDir)/fontconfig2/lib/libfontconfig.dylib | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-endif
-
-ifeq ($(USE_OSX_PACKAGING), fink)
-	# same procedure for secondary libs in libzvbi
-	@echo "[fink] copying libs of libzvbi"
-	$(foreach dylib,$(shell $(OTOOL) -L $(brewLibDir)/libzvbi.dylib | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-
-	# same procedure for secondary libs in libquvi
-	@echo "[fink] copying libs of libquvi"
-	$(foreach dylib,$(shell $(OTOOL) -L $(brewLibDir)/libquvi.dylib | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-
-	# same procedure for secondary libs in libssh2
-	@echo "[fink] copying libs of libssh2"
-	$(foreach dylib,$(shell $(OTOOL) -L $(brewLibDir)/libssh2.dylib | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-	
-	# same procedure for secondary libs in libcaca
-	@echo "[fink] copying libs of libssh2"
-	$(foreach dylib,$(shell $(OTOOL) -L $(brewLibDir)/libcaca.dylib | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-
-	# same procedure for secondary libs in libbluray
-	@echo "[fink] copying libs of libblueray"
-	$(foreach dylib,$(shell $(OTOOL) -L $(brewLibDir)/libbluray.dylib | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-
-	# X11 libs as well, because users may not have installed it.
-	@echo "[fink] copying libs of libX11"
-	$(foreach dylib,$(shell $(OTOOL) -L /opt/X11/lib/libX11.6.dylib  | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib),$(install_osx_libraries))
-endif
-
-	@echo ""
-	@echo "libpcre.dylib must be work on additionally, since it is not linked to the executable but opened using dlopen"
-	$(shell $(INSTALL) -m 755 $(pkgingLibDir)/libpcre.dylib $(macosx_bundle_path)/MacOS)
-	$(shell $(INSTALL_NAME_TOOL) -change $(pkgingLibDir)/libpcre.dylib @executable_path/libpcre.dylib $(macosx_bundle_path)/MacOS/libpcre.dylib)
-	$(shell $(INSTALL_NAME_TOOL) -id @executable_path/libpcre.dylib $(macosx_bundle_path)/MacOS/libpcre.dylib)
+	@rm -f $(macosx_bundle_path)/MacOS/$(USDX_BIN_NAME)
+	@$(MAKE) -f Makefile.osx-helper
 
 # do  not forget to sign the code
 #	codesign -f -s USDX-codesign UltraStarDeluxe.app

--- a/Makefile.osx-helper
+++ b/Makefile.osx-helper
@@ -1,0 +1,52 @@
+getdylibs = $(shell $(OTOOL) -L $(1) | grep version | cut -f 1 -d ' ' | grep -v \/System\/Library | grep -v \/usr\/lib | grep -v executable_path)
+dest = $(macosx_bundle_path)/MacOS/$(notdir $(1))
+
+# Let's create a list of all libraries used at runtime, starting with the
+# application and the dlopen'ed libpcre.
+
+FILES :=
+NEWFILES := $(USDX_BIN) $(pkgingLibDir)/libpcre.dylib
+
+define recurse
+FILES := $$(FILES) $$(NEWFILES)
+NEWFILES := $$(filter-out $$(FILES),$$(sort $$(foreach dylib,$$(NEWFILES),$$(call getdylibs,$$(dylib)))))
+ifneq ($$(NEWFILES),)
+$$(eval $$(recurse))
+endif
+endef
+
+$(eval $(recurse))
+
+# Libavutil is referenced as /usr/local/opt/ffmpeg@2.8/lib/libavutil.54.dylib by
+# ultrastardx and as /usr/local/Cellar/ffmpeg@2.8/2.8.11/lib/libavutil.54.dylib
+# by libavcodec. We don't want make to call the installdylib rule for both in
+# parallel. Handle this by creating a variable libavutil.54.dylib that is
+# assigned the full path. The last one wins.
+
+define removedupes
+$(1) := $(2)
+endef
+
+$(foreach dylib,$(FILES),$(eval $(call removedupes,$(notdir $(dylib)),$(dylib))))
+FILES := $(sort $(foreach dylib,$(FILES),$($(notdir $(dylib)))))
+
+# The first rule in this file and thus the default target:
+all: $(foreach dylib,$(FILES),$(call dest,$(dylib)))
+
+define changeimport
+	@echo change the install name for $(2)
+	@$(INSTALL_NAME_TOOL) -change $(2) @executable_path/$(notdir $(2)) $(1)
+
+endef
+
+define installdylib
+$(call dest,$(1)): $(1)
+	@echo work on $(1)
+	@$(INSTALL) -m 755  $(1) $(call dest,$(1))
+ifneq ($(1),$(USDX_BIN))
+	@$(INSTALL_NAME_TOOL) -id @executable_path/$(notdir $(1)) $(call dest,$(1))
+endif
+	$$(foreach dylib,$$(call getdylibs,$(1)),$$(call changeimport,$(call dest,$(1)),$$(dylib)))
+endef
+
+$(foreach dylib,$(FILES),$(eval $(call installdylib,$(dylib))))


### PR DESCRIPTION
This should fix the problem we have with the OS X Travis build, where some libraries (f.ex. libx264) are missing from the standalone application package.