### PR TITLE
Prevent an infinite recursion in FindFilesByExtension()

### DIFF
--- a/src/base/USongs.pas
+++ b/src/base/USongs.pas
@@ -282,7 +282,7 @@ begin
     FileName := FileInfo.Name;
     if ((FileInfo.Attr and faDirectory) <> 0) then
     begin
-      if Recursive and (not FileName.Equals('.')) and (not FileName.Equals('..')) then
+      if Recursive and (not FileName.Equals('.')) and (not FileName.Equals('..')) and (not FileName.Equals('')) then
         FindFilesByExtension(Dir.Append(FileName), Ext, true, Files);
     end
     else


### PR DESCRIPTION
This situation may occur in some situations where the FileSystem iterator
produces an empty string. A probably better fix would be to patch this later.

Fixes #309.