### PR TITLE
Use only a single provider for GL and GLU

### DIFF
--- a/src/base/UFont.pas
+++ b/src/base/UFont.pas
@@ -51,7 +51,6 @@ uses
   {$IFEND}
   FreeType,
   dglOpenGL,
-  glu,
   sdl2,
   Math,
   Classes,
@@ -1223,9 +1222,9 @@ end;
  *}
 function TScalableFont.GetMipmapLevel(): integer;
 var
-  ModelMatrix, ProjMatrix: T16dArray;
+  ModelMatrix, ProjMatrix: TGLMatrixd4;
   WinCoords: array[0..2, 0..2] of GLdouble;
-  ViewPortArray: TViewPortArray;
+  ViewPortArray: TGLVectori4;
   Dist, Dist2, DistSum: double;
   WidthScale, HeightScale: double;
 const

--- a/src/lib/dglOpenGL/dglOpenGL.pas
+++ b/src/lib/dglOpenGL/dglOpenGL.pas
@@ -49,6 +49,11 @@
 
 ============================================================================== }
 
+{$define DGL_USE_SDL}
+{
+  Load the OpenGL library and query its functions using SDL.
+}
+
 {$define DGL_DEPRECATED}
 {
   This define defines if the header should use deprecated ARB stuff or not.
@@ -175,6 +180,7 @@ uses
   {$IFDEF DGL_WIN}, Windows{$ENDIF}
   {$IFDEF DGL_64BIT} ,math {$ENDIF}
   {$IFDEF DGL_LINUX}, X, XLib, XUtil{$ENDIF}
+  {$IFDEF DGL_USE_SDL}, SDL2{$ENDIF}
   ;
 
 type
@@ -15112,6 +15118,12 @@ function dglFreeLibrary(LibHandle: Pointer): Boolean;
 begin
   if LibHandle = nil then
     Result := False
+  {$IFDEF DGL_USE_SDL}
+  else if LibHandle = @GL_LibHandle then begin
+    SDL_GL_UnloadLibrary();
+    Result := True
+  end
+  {$ENDIF}
   else
     {$IFDEF DGL_WIN}
     Result := FreeLibrary(HMODULE(LibHandle));
@@ -15136,6 +15148,12 @@ begin
   if LibHandle = nil then
     LibHandle := GL_LibHandle;
 
+  {$IFDEF DGL_USE_SDL}
+    if LibHandle = @GL_LibHandle then begin
+      Result := SDL_GL_GetProcAddress(ProcName);
+      exit;
+    end;
+  {$ENDIF}
 
   {$IFDEF DGL_WIN}
     Result := GetProcAddress(HMODULE(LibHandle), ProcName);
@@ -15252,7 +15270,13 @@ begin
     dglFreeLibrary(GLU_LibHandle);
 
   // load library
+{$IFDEF DGL_USE_SDL}
+  GL_LibHandle := nil;
+  if SDL_GL_LoadLibrary(nil) = 0 then
+    GL_LibHandle := @GL_LibHandle;
+{$ELSE}
   GL_LibHandle := dglLoadLibrary(PChar(LibName));
+{$ENDIF}
   GLU_LibHandle := dglLoadLibrary(PChar(GLULibName));
 
   // load GL functions

--- a/src/lib/dglOpenGL/dglOpenGL.pas
+++ b/src/lib/dglOpenGL/dglOpenGL.pas
@@ -14776,8 +14776,8 @@ const
     OPENGL_LIBNAME = '/System/Library/Frameworks/OpenGL.framework/Libraries/libGL.dylib';
     GLU_LIBNAME = '/System/Library/Frameworks/OpenGL.framework/Libraries/libGLU.dylib';
   {$ELSE}
-    OPENGL_LIBNAME = 'libGL.so';
-    GLU_LIBNAME = 'libGLU.so';
+    OPENGL_LIBNAME = 'libGL.so.1';
+    GLU_LIBNAME = 'libGLU.so.1';
   {$ENDIF}
 {$ENDIF}
 


### PR DESCRIPTION
We were mixing GL calls from dglOpenGL with GL contexts from SDL and GLU calls from Free Pascal's glu unit with GLU calls from dglOpenGL. This caused problems on at least one dual GPU system where libGL.so did not point to the same library as libGL.so.1, as dglOpenGL uses the former filename and everyone else uses the latter filename on Linux.