### PR TITLE
Fix single-channel USB mics on macOS

### DIFF
--- a/src/media/UAudioInput_Portaudio.pas
+++ b/src/media/UAudioInput_Portaudio.pas
@@ -86,7 +86,7 @@ type
 
 function MicrophoneCallback(input: pointer; output: pointer; frameCount: culong;
       timeInfo: PPaStreamCallbackTimeInfo; statusFlags: TPaStreamCallbackFlags;
-      inputDevice: pointer): cint; cdecl; forward;
+      inputDevice: TAudioInputDevice): cint; cdecl; forward;
 
 function MicrophoneTestCallback(input: pointer; output: pointer; frameCount: culong;
       timeInfo: PPaStreamCallbackTimeInfo; statusFlags: TPaStreamCallbackFlags;
@@ -514,9 +514,12 @@ end;
  *}
 function MicrophoneCallback(input: pointer; output: pointer; frameCount: culong;
       timeInfo: PPaStreamCallbackTimeInfo; statusFlags: TPaStreamCallbackFlags;
-      inputDevice: pointer): cint; cdecl;
+      inputDevice: TAudioInputDevice): cint; cdecl;
+var
+  AudioFormat:             TAudioFormatInfo;
 begin
-  AudioInputProcessor.HandleMicrophoneData(input, frameCount*4, inputDevice);
+  AudioFormat := inputDevice.AudioFormat;
+  AudioInputProcessor.HandleMicrophoneData(input, frameCount * AudioFormat.FrameSize, inputDevice);
   result := paContinue;
 end;
 


### PR DESCRIPTION
Hi, I think this solves #150, which I think it's also the cause for #221 and #333.

I think the problem was this fixed value of 4 multiplying frameCount, because when I took a look at my mics connected, the AudioInput.FrameSize for them was 2 (but the default Macbook device was actually 4, as the fixed number). So that made things read more buffer than it was actually being written, and thus generating noise (because, I imagine, random bits in that unwritten buffer space).

This seems to make my USB mics work, and my default Macbook audio device also keeps working.

**Disclaimer**: I don't know Pascal, and I don't know about audio processing, so please take a careful look :)