### PR TITLE
Use UTF-8 strings by default regardless of OS locale

### DIFF
--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -109,6 +109,7 @@ begin
   {$IFNDEF Debug}
   try
   {$ENDIF}
+    SetMultiByteConversionCodePage(CP_UTF8);
     WindowTitle := USDXVersionStr;
 
     Platform.Init;


### PR DESCRIPTION
This is a fix/workaround for issue #424.
It significantly reduces the amount of question marks displayed when USDX is stared on Linux in an environment that does not select an UTF-8 locale. 

What is not fixed by this commit is that file names still use the code page of the locale. So if you start USDX with LC_CTYPE=C, you can't play songs that have files with non-ASCII characters in their name. There is no way to properly fix this in USDX. It is true that part of the problem stems from the conversion of the RawByteStrings returned by the filesystem functions to UTF8Strings. But eventually USDX has to convert filenames from the UTF-8/CP1250/CP1252-encoded text files to what it believes is the native encoding for file names.