### PR TITLE
Fix Travis on OS X

### DIFF
--- a/tools/travis/install.sh
+++ b/tools/travis/install.sh
@@ -17,8 +17,8 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
         fpc portaudio binutils freetype libpng lua libtiff \
         portmidi
 
-    # This is from: https://github.com/Homebrew/homebrew-versions
-    brew install ffmpeg28
+    # This is from: https://github.com/Homebrew/homebrew-core
+    brew install ffmpeg@4
 
 else
     # Linux build


### PR DESCRIPTION
As noted in #428 our Travis job for OS X is broken again as the prebuilt ffmpeg@2.8 library from Homebrew has an unsatisfied dependency on libjack.
We do have support FFmpeg 4.1, so let's use it.