### PR TITLE
Linux: Remove libcwrap from build, it causes errors on some systems

### DIFF
--- a/dists/linux/build-deps.sh
+++ b/dists/linux/build-deps.sh
@@ -13,8 +13,8 @@ PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
 export CC="gcc"
 export CXX="g++"
 
-export CC="$CC -U_FORTIFY_SOURCE -include $PREFIX/libcwrap.h"
-export CXX="$CXX -U_FORTIFY_SOURCE -D_GLIBCXX_USE_CXX11_ABI=0 -include $PREFIX/libcwrap.h"
+# export CC="$CC -U_FORTIFY_SOURCE -include $SRC/libcwrap.h"
+# export CXX="$CXX -U_FORTIFY_SOURCE -D_GLIBCXX_USE_CXX11_ABI=0 -include $SRC/libcwrap.h"
 
 echo "Building dependencies"
 
@@ -24,7 +24,6 @@ makearg="-j$(nproc)"
 clean_prefix() {
 	rm -rf "$PREFIX"
 	mkdir -pv $PREFIX/{bin,include,lib}
-	cp -f "$SRC/libcwrap.h" "$PREFIX/libcwrap.h"
 }
 
 build_zlib() {

--- a/dists/linux/build.sh
+++ b/dists/linux/build.sh
@@ -14,8 +14,8 @@ PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
 export CC="gcc"
 export CXX="g++"
 
-export CC="$CC -U_FORTIFY_SOURCE -include $PREFIX/libcwrap.h"
-export CXX="$CXX -U_FORTIFY_SOURCE -D_GLIBCXX_USE_CXX11_ABI=0 -include $PREFIX/libcwrap.h"
+# export CC="$CC -U_FORTIFY_SOURCE -include $SRC/libcwrap.h"
+# export CXX="$CXX -U_FORTIFY_SOURCE -D_GLIBCXX_USE_CXX11_ABI=0 -include $SRC/libcwrap.h"
 
 echo "Building UltraStar Deluxe"
 cd "$root/../.."

--- a/dists/linux/dl.sh
+++ b/dists/linux/dl.sh
@@ -14,7 +14,7 @@ deps+=('libpng,https://download.sourceforge.net/libpng/libpng-1.6.36.tar.xz')
 deps+=('portmidi,https://sourceforge.net/projects/portmedia/files/portmidi/217/portmidi-src-217.zip/download')
 deps+=('portmidi-debian,http://http.debian.net/debian/pool/main/p/portmidi/portmidi_217-6.debian.tar.xz')
 deps+=('zlib,https://zlib.net/zlib-1.2.11.tar.gz')
-deps+=('libcwrap.h,https://raw.githubusercontent.com/wheybags/glibc_version_header/master/version_headers/force_link_glibc_2.10.2.h')
+# deps+=('libcwrap.h,https://raw.githubusercontent.com/wheybags/glibc_version_header/master/version_headers/force_link_glibc_2.10.2.h')
 
 rm -rf deps
 


### PR DESCRIPTION
Will have to research this more, but disabling it is the easiest fix.