### PR TITLE
glTextWidth: don't subtract left side bearing

### DIFF
--- a/src/base/TextGL.pas
+++ b/src/base/TextGL.pas
@@ -256,7 +256,7 @@ var
   Bounds: TBoundsDbl;
 begin
   Bounds := Fonts[CurrentFont.FontFamily][CurrentFont.FontStyle].Font.BBox(Text, true);
-  Result := Bounds.Right - Bounds.Left;
+  Result := Bounds.Right;
 end;
 
 // Custom GL "Print" Routine


### PR DESCRIPTION
glTextWidth is used in various places to center or right justify text. If the left side bearing of the first glyph is subtracted from the sum of all glyph advancements (2nd param of BBox is true), the text is drawn a tiny bit too far right or might extend past the space allocated for it because glPrint will "draw" the left side bearing even for the first glyph. Also note that the glyph advancement includes the right side bearing of the last glyph.

@bohning, this should fix the problem you noticed in the discussion of PR #428 after it was merged.