### PR TITLE
Add wrapper for OpenCV C++ API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ config.status
 __history
 aclocal.m4
 /autom4te.cache/
+/CMakeFiles/
 link.res
 ppaslink.sh
 /UltraStarDeluxe.app/*

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,7 +23,7 @@ Have fun and enjoy working on a game that easily can hit 5.000 downloads in a we
 - **OpenGL** is used for all the graphics drawing + rendering stuff. Currently, this is mostly based on the horribly old OpenGL 1.x drawing stuff. If you know OpenGL >2.1 / OpenGL ES then please help to implement the required shading stuff and replace the old opengl instructions by the new ones. I already ported to the **dglOpenGL** library, so anything up to OpenGL 4.x should be fully supported and easily usable - just bear in mind there is lots of hardware out there that doesn't do anything newer then OpenGL 3 feature set. Also, if you don't know OpenGL that much but know SDL2 quite good, feel free to switch from directly calling OpenGL to the functions which are provided by SDL2.
 - **projectM** is used for visualisation.
 - **ffmpeg** is used for most video and audio stuff. On Windows, the bass library is used for playing mp3 files because of licensing issues of mp3 codecs.
-- **OpenCV** highgui is used for getting images from the webcam.
+- **OpenCV** videoio is used for getting images from the webcam.
 - **sqlite** is used for creating and accessing databases to store song scores, already scanned songs, avatar image caches and so on. Remember that changing database setup will require adding an automatic upgrade script or resetting the database file for all users and loosing ist content.
 
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -77,12 +77,23 @@ PROJECTM_CWRAPPER_DIR := $(USDX_LIB_DIR)/projectM/cwrapper
 USE_PROJECTM_CWRAPPER = @USE_PROJECTM_CWRAPPER@
 
 #################################################
+# OpenCV
+#################################################
+
+OPENCV_CWRAPPER_DIR := $(USDX_LIB_DIR)/openCV3
+USE_OPENCV_CWRAPPER = @USE_OPENCV_CWRAPPER@
+
+#################################################
 # Dependencies
 #################################################
 
 DEPS :=
 ifeq ($(USE_PROJECTM_CWRAPPER), yes)
 DEPS += $(PROJECTM_CWRAPPER_DIR)
+endif
+
+ifeq ($(USE_OPENCV_CWRAPPER), yes)
+DEPS += $(OPENCV_CWRAPPER_DIR)
 endif
 
 #################################################

--- a/Makefile.in
+++ b/Makefile.in
@@ -468,7 +468,7 @@ macosx-dmg: macosx-standalone-app
 	fi
 	$(RM) UltraStarDeluxe.dmg
 	$(RM) UltraStarDeluxe.sparseimage
-	$(HDIUTIL) create -type SPARSE -size 200m -fs HFS+ -volname UltraStarDeluxe -ov UltraStarDeluxe.sparseimage
+	$(HDIUTIL) create -type SPARSE -size 300m -fs HFS+ -volname UltraStarDeluxe -ov UltraStarDeluxe.sparseimage
 	$(HDIUTIL) attach UltraStarDeluxe.sparseimage
 	/bin/ln -s /Applications /Volumes/UltraStarDeluxe/Applications
 	/bin/cp -R UltraStarDeluxe.app /Volumes/UltraStarDeluxe

--- a/README.md
+++ b/README.md
@@ -253,9 +253,11 @@ For linking and running the game, the following libraries are also required:
 #### Compiling on Linux/BSD using make
 1. make sure all required libraries are installed 
   * for current debian / ubuntu: 
-    `sudo apt-get update && sudo apt-get install git automake make gcc fpc libsdl2-image-dev libavformat-dev libswscale-dev libsqlite3-dev libfreetype6-dev portaudio19-dev libportmidi-dev liblua5.3-dev libopencv-highgui-dev`
+    `sudo apt-get update && sudo apt-get install git automake make gcc fpc libsdl2-image-dev libavformat-dev libswscale-dev libsqlite3-dev libfreetype6-dev portaudio19-dev libportmidi-dev liblua5.3-dev libopencv-videoio-dev`
   * if you want to build --with-libprojectM, you also need
     `sudo apt-get install g++ libprojectm-dev`
+  * if you want to build --with-opencv-cxx-api, you also need
+    `sudo apt-get install g++ libopencv-dev`
   * for Fedora with RPM Fusion:
     `sudo dnf install git automake make gcc fpc SDL2_image-devel ffmpeg-devel sqlite-devel freetype-devel portaudio-devel portmidi-devel lua-devel opencv-devel`
     and to be able to use --with-libprojectM:

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,8 @@ AC_PROG_INSTALL
 AC_PROG_SED
 AC_PROG_GREP
 #AC_PROG_EGREP
+CMAKE_FIND_BINARY
+[[ -n "$CMAKE_BINARY" ]] || CMAKE_BINARY=false
 
 # -----------------------------------------
 # macro declarations
@@ -88,6 +90,12 @@ AC_ARG_WITH([libprojectM],
     [AS_HELP_STRING([--with-libprojectM],
       [enable projectM visualization support @<:@default=no@:>@])],
     [with_libprojectM=$withval], [with_libprojectM="no"])
+
+# add OpenCV option
+AC_ARG_WITH([opencv-cxx-api],
+    [AS_HELP_STRING([--with-opencv-cxx-api],
+      [use current OpenCV C++ API @<:@default=no@:>@])],
+    [with_opencv_cxx_api=$withval], [with_opencv_cxx_api="no"])
 
 # print misc options header
 AC_ARG_WITH([cfg-dummy2], [
@@ -333,6 +341,20 @@ AX_EXTRACT_VERSION(FFMPEG, $FFMPEG_VERSION)
 AC_SUBST(FFMPEG_VERSION)
 AC_MSG_RESULT(@<:@$FFMPEG_VERSION@:>@)
 
+AC_MSG_NOTICE([Checking for C++ compiler])
+AC_PROG_CXX
+AC_LANG_PUSH([C++])
+AC_MSG_CHECKING([if C++ toolchain works])
+cxx_works=no
+use_cxx=no
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[])],
+		  [AC_LINK_IFELSE([AC_LANG_PROGRAM([],[])],
+				  [AC_MSG_RESULT([yes])
+				   cxx_works=yes],
+				  [AC_MSG_RESULT([linking C++ programs does not work])])],
+		  [AC_MSG_RESULT([C++ compiler does not work])])
+AC_LANG_POP([C++])
+
 # find projectM version
 libprojectM_PKG="libprojectM >= 0.98"
 PKG_HAVE([libprojectM], [$libprojectM_PKG], no)
@@ -346,25 +368,68 @@ PKG_VALUE([libprojectM], [DATADIR], [variable=pkgdatadir], [$libprojectM_PKG],
           [projectM data-directory for presets etc. (e.g. /usr/share/projectM)])
 # check if we need the c-wrapper
 if [[ "$libprojectM_VERSION_MAJOR" -ge 1 ]]; then
-    libprojectM_USE_CWRAPPER=yes
-    AC_MSG_NOTICE([Need C++ compiler to build libprojectM wrapper])
-    AC_PROG_CXX
-    AC_LANG_PUSH([C++])
-    AC_MSG_CHECKING([if C++ toolchain works])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[])],,[AC_MSG_FAILURE([C++ compiler does not work])])
-    AC_LINK_IFELSE([AC_LANG_PROGRAM([],[])],,[AC_MSG_FAILURE([linking C++ programs does not work])])
-    AC_MSG_RESULT([yes])
+	if [[ "$cxx_works" = yes ]] ; then
+		libprojectM_USE_CWRAPPER=yes
+		use_cxx=yes
+	else
+		AC_MSG_FAILURE([Need C++ compiler to build libprojectM wrapper])
+	fi
+else
+	libprojectM_USE_CWRAPPER=no
+fi
+AC_SUBST(USE_PROJECTM_CWRAPPER, $libprojectM_USE_CWRAPPER)
+
+opencv_core_standalone=no
+opencv_imgproc_standalone=no
+opencv_videoio_standalone=no
+if [[ "$with_opencv_cxx_api" = yes ]] ; then
+	if [[ "$cxx_works" = yes ]] ; then
+		AX_CXX_COMPILE_STDCXX([11])
+		CMAKE_FIND_PACKAGE([OpenCV], [CXX], [GNU], , [OpenCV_HAVE=yes], [OpenCV_HAVE=no])
+		if [[ "$OpenCV_HAVE" != yes ]] ; then
+			PKG_HAVE([OpenCV], [opencv4], no)
+			if [[ "$OpenCV_HAVE" != yes ]] ; then
+				PKG_HAVE([OpenCV], [opencv >= 3.0.0], yes)
+				OpenCV_CXXFLAGS=`$PKG_CONFIG --cflags "opencv >= 3.0.0"`
+			else
+				OpenCV_CXXFLAGS=`$PKG_CONFIG --cflags opencv4`
+			fi
+		fi
+		opencv_USE_CWRAPPER=yes
+		use_cxx=yes
+		for lib in $OpenCV_LIBS ; do
+			case "${lib##*/}" in
+			*opencv_core*)    opencv_core_standalone=yes ;;
+			*opencv_imgproc*) opencv_imgproc_standalone=yes ;;
+			*opencv_videoio*) opencv_videoio_standalone=yes ;;
+			*) continue ;;
+			esac
+			case "$lib" in
+			-L)  LIBS="$LIBS $lib" ;;
+			*/*) LIBS="$LIBS -L${lib%/*}" ;;
+			esac
+		done
+		AC_SUBST(OpenCV_CXXFLAGS)
+	else
+		AC_MSG_FAILURE([Need C++ compiler to build OpenCV wrapper])
+	fi
+else
+	opencv_USE_CWRAPPER=no
+fi
+AC_SUBST_DEFINE(USE_OPENCV_CWRAPPER, $opencv_USE_CWRAPPER)
+AC_SUBST(USE_OPENCV_CWRAPPER, $opencv_USE_CWRAPPER)
+AC_SUBST_DEFINE(OPENCV_CORE_STANDALONE, $opencv_core_standalone)
+AC_SUBST_DEFINE(OPENCV_IMGPROC_STANDALONE, $opencv_imgproc_standalone)
+AC_SUBST_DEFINE(OPENCV_VIDEOIO_STANDALONE, $opencv_videoio_standalone)
+
+if [[ "$use_cxx" = yes ]] ; then
     # Hack to link to libstdc++ through libprojectM where needed
     # Of course only works if libprojectM is a shared library
     # --no-copy-dt-needed-entries is the default since Binutils 2.22
     if test x$ac_cv_prog_ppc_copy_dt_needed_entries = xyes ; then
         PFLAGS_EXTRA="$PFLAGS_EXTRA -k\"--copy-dt-needed-entries\""
     fi
-    AC_LANG_POP([C++])
-else
-    libprojectM_USE_CWRAPPER=no
 fi
-AC_SUBST(USE_PROJECTM_CWRAPPER, $libprojectM_USE_CWRAPPER)
 
 # find portaudio
 PKG_HAVE([portaudio], [portaudio-2.0], yes)
@@ -420,6 +485,9 @@ AC_CONFIG_FILES([src/Makefile])
 AC_CONFIG_FILES([src/config-$FPC_PLATFORM.inc:src/config.inc.in])
 if [[ x$libprojectM_USE_CWRAPPER = xyes ]]; then
     AC_CONFIG_FILES([src/lib/projectM/cwrapper/Makefile])
+fi
+if [[ x$opencv_USE_CWRAPPER = xyes ]]; then
+    AC_CONFIG_FILES([src/lib/openCV3/Makefile])
 fi
 AC_OUTPUT
 

--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,7 @@ Build-Depends: debhelper (>= 10),
  portaudio19-dev,
  libportmidi-dev,
  libswscale-dev,
+ libopencv-dev,
  libprojectm-dev
 Standards-Version: 3.9.8
 Homepage: https://usdx.eu
@@ -26,8 +27,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
          fonts-dejavu-core, fonts-freefont-ttf
 Recommends: projectm-data,
             ttf-bitstream-vera
-Suggests: fonts-wqy-microhei, libopencv-highgui-dev,
-          libopencv-imgproc-dev, libopencv-core-dev
+Suggests: fonts-wqy-microhei
 Description: Free and Open Source karaoke game
  A karaoke game similar to SingStar™ where one or more players perform a song
  and the game scores their performances, depending on the pitch of the voice

--- a/debian/rules
+++ b/debian/rules
@@ -17,6 +17,7 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 		--bindir=/usr/games \
 		--datarootdir=/usr/share/games \
+		--with-opencv-cxx-api \
 		--with-libprojectM
 
 

--- a/dists/autogen/m4/ax_cxx_compile_stdcxx.m4
+++ b/dists/autogen/m4/ax_cxx_compile_stdcxx.m4
@@ -1,0 +1,951 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CXX_COMPILE_STDCXX(VERSION, [ext|noext], [mandatory|optional])
+#
+# DESCRIPTION
+#
+#   Check for baseline language coverage in the compiler for the specified
+#   version of the C++ standard.  If necessary, add switches to CXX and
+#   CXXCPP to enable support.  VERSION may be '11' (for the C++11 standard)
+#   or '14' (for the C++14 standard).
+#
+#   The second argument, if specified, indicates whether you insist on an
+#   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
+#   -std=c++11).  If neither is specified, you get whatever works, with
+#   preference for an extended mode.
+#
+#   The third argument, if specified 'mandatory' or if left unspecified,
+#   indicates that baseline support for the specified C++ standard is
+#   required and that the macro should error out if no mode with that
+#   support is found.  If specified 'optional', then configuration proceeds
+#   regardless, after defining HAVE_CXX${VERSION} if and only if a
+#   supporting mode is found.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
+#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
+#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
+#   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
+#   Copyright (c) 2019 Enji Cooper <yaneurabeya@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 11
+
+dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
+dnl  (serial version number 13).
+
+AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
+  m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
+        [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
+        [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
+        [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$2], [], [],
+        [$2], [ext], [],
+        [$2], [noext], [],
+        [m4_fatal([invalid second argument `$2' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$3], [], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [optional], [ax_cxx_compile_cxx$1_required=false],
+        [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
+  AC_LANG_PUSH([C++])dnl
+  ac_success=no
+
+  m4_if([$2], [noext], [], [dnl
+  if test x$ac_success = xno; then
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      switch="-std=gnu++${alternative}"
+      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+      AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                     $cachevar,
+        [ac_save_CXX="$CXX"
+         CXX="$CXX $switch"
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+          [eval $cachevar=yes],
+          [eval $cachevar=no])
+         CXX="$ac_save_CXX"])
+      if eval test x\$$cachevar = xyes; then
+        CXX="$CXX $switch"
+        if test -n "$CXXCPP" ; then
+          CXXCPP="$CXXCPP $switch"
+        fi
+        ac_success=yes
+        break
+      fi
+    done
+  fi])
+
+  m4_if([$2], [ext], [], [dnl
+  if test x$ac_success = xno; then
+    dnl HP's aCC needs +std=c++11 according to:
+    dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
+    dnl Cray's crayCC needs "-h std=c++11"
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}"; do
+        cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+        AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                       $cachevar,
+          [ac_save_CXX="$CXX"
+           CXX="$CXX $switch"
+           AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+            [eval $cachevar=yes],
+            [eval $cachevar=no])
+           CXX="$ac_save_CXX"])
+        if eval test x\$$cachevar = xyes; then
+          CXX="$CXX $switch"
+          if test -n "$CXXCPP" ; then
+            CXXCPP="$CXXCPP $switch"
+          fi
+          ac_success=yes
+          break
+        fi
+      done
+      if test x$ac_success = xyes; then
+        break
+      fi
+    done
+  fi])
+  AC_LANG_POP([C++])
+  if test x$ax_cxx_compile_cxx$1_required = xtrue; then
+    if test x$ac_success = xno; then
+      AC_MSG_ERROR([*** A compiler with support for C++$1 language features is required.])
+    fi
+  fi
+  if test x$ac_success = xno; then
+    HAVE_CXX$1=0
+    AC_MSG_NOTICE([No compiler with C++$1 support was found])
+  else
+    HAVE_CXX$1=1
+    AC_DEFINE(HAVE_CXX$1,1,
+              [define if the compiler supports basic C++$1 syntax])
+  fi
+  AC_SUBST(HAVE_CXX$1)
+])
+
+
+dnl  Test body for checking C++11 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_11],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+)
+
+
+dnl  Test body for checking C++14 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+)
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+)
+
+dnl  Tests for new features in C++11
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_11], [[
+
+// If the compiler admits that it is not ready for C++11, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201103L
+
+#error "This is not a C++11 compiler"
+
+#else
+
+namespace cxx11
+{
+
+  namespace test_static_assert
+  {
+
+    template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+  }
+
+  namespace test_final_override
+  {
+
+    struct Base
+    {
+      virtual ~Base() {}
+      virtual void f() {}
+    };
+
+    struct Derived : public Base
+    {
+      virtual ~Derived() override {}
+      virtual void f() override {}
+    };
+
+  }
+
+  namespace test_double_right_angle_brackets
+  {
+
+    template < typename T >
+    struct check {};
+
+    typedef check<void> single_type;
+    typedef check<check<void>> double_type;
+    typedef check<check<check<void>>> triple_type;
+    typedef check<check<check<check<void>>>> quadruple_type;
+
+  }
+
+  namespace test_decltype
+  {
+
+    int
+    f()
+    {
+      int a = 1;
+      decltype(a) b = 2;
+      return a + b;
+    }
+
+  }
+
+  namespace test_type_deduction
+  {
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static const bool value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static const bool value = true;
+    };
+
+    template < typename T1, typename T2 >
+    auto
+    add(T1 a1, T2 a2) -> decltype(a1 + a2)
+    {
+      return a1 + a2;
+    }
+
+    int
+    test(const int c, volatile int v)
+    {
+      static_assert(is_same<int, decltype(0)>::value == true, "");
+      static_assert(is_same<int, decltype(c)>::value == false, "");
+      static_assert(is_same<int, decltype(v)>::value == false, "");
+      auto ac = c;
+      auto av = v;
+      auto sumi = ac + av + 'x';
+      auto sumf = ac + av + 1.0;
+      static_assert(is_same<int, decltype(ac)>::value == true, "");
+      static_assert(is_same<int, decltype(av)>::value == true, "");
+      static_assert(is_same<int, decltype(sumi)>::value == true, "");
+      static_assert(is_same<int, decltype(sumf)>::value == false, "");
+      static_assert(is_same<int, decltype(add(c, v))>::value == true, "");
+      return (sumf > 0.0) ? sumi : add(c, v);
+    }
+
+  }
+
+  namespace test_noexcept
+  {
+
+    int f() { return 0; }
+    int g() noexcept { return 0; }
+
+    static_assert(noexcept(f()) == false, "");
+    static_assert(noexcept(g()) == true, "");
+
+  }
+
+  namespace test_constexpr
+  {
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c_r(const CharT *const s, const unsigned long acc) noexcept
+    {
+      return *s ? strlen_c_r(s + 1, acc + 1) : acc;
+    }
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c(const CharT *const s) noexcept
+    {
+      return strlen_c_r(s, 0UL);
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("1") == 1UL, "");
+    static_assert(strlen_c("example") == 7UL, "");
+    static_assert(strlen_c("another\0example") == 7UL, "");
+
+  }
+
+  namespace test_rvalue_references
+  {
+
+    template < int N >
+    struct answer
+    {
+      static constexpr int value = N;
+    };
+
+    answer<1> f(int&)       { return answer<1>(); }
+    answer<2> f(const int&) { return answer<2>(); }
+    answer<3> f(int&&)      { return answer<3>(); }
+
+    void
+    test()
+    {
+      int i = 0;
+      const int c = 0;
+      static_assert(decltype(f(i))::value == 1, "");
+      static_assert(decltype(f(c))::value == 2, "");
+      static_assert(decltype(f(0))::value == 3, "");
+    }
+
+  }
+
+  namespace test_uniform_initialization
+  {
+
+    struct test
+    {
+      static const int zero {};
+      static const int one {1};
+    };
+
+    static_assert(test::zero == 0, "");
+    static_assert(test::one == 1, "");
+
+  }
+
+  namespace test_lambdas
+  {
+
+    void
+    test1()
+    {
+      auto lambda1 = [](){};
+      auto lambda2 = lambda1;
+      lambda1();
+      lambda2();
+    }
+
+    int
+    test2()
+    {
+      auto a = [](int i, int j){ return i + j; }(1, 2);
+      auto b = []() -> int { return '0'; }();
+      auto c = [=](){ return a + b; }();
+      auto d = [&](){ return c; }();
+      auto e = [a, &b](int x) mutable {
+        const auto identity = [](int y){ return y; };
+        for (auto i = 0; i < a; ++i)
+          a += b--;
+        return x + identity(a + b);
+      }(0);
+      return a + b + c + d + e;
+    }
+
+    int
+    test3()
+    {
+      const auto nullary = [](){ return 0; };
+      const auto unary = [](int x){ return x; };
+      using nullary_t = decltype(nullary);
+      using unary_t = decltype(unary);
+      const auto higher1st = [](nullary_t f){ return f(); };
+      const auto higher2nd = [unary](nullary_t f1){
+        return [unary, f1](unary_t f2){ return f2(unary(f1())); };
+      };
+      return higher1st(nullary) + higher2nd(nullary)(unary);
+    }
+
+  }
+
+  namespace test_variadic_templates
+  {
+
+    template <int...>
+    struct sum;
+
+    template <int N0, int... N1toN>
+    struct sum<N0, N1toN...>
+    {
+      static constexpr auto value = N0 + sum<N1toN...>::value;
+    };
+
+    template <>
+    struct sum<>
+    {
+      static constexpr auto value = 0;
+    };
+
+    static_assert(sum<>::value == 0, "");
+    static_assert(sum<1>::value == 1, "");
+    static_assert(sum<23>::value == 23, "");
+    static_assert(sum<1, 2>::value == 3, "");
+    static_assert(sum<5, 5, 11>::value == 21, "");
+    static_assert(sum<2, 3, 5, 7, 11, 13>::value == 41, "");
+
+  }
+
+  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
+  // because of this.
+  namespace test_template_alias_sfinae
+  {
+
+    struct foo {};
+
+    template<typename T>
+    using member = typename T::member_type;
+
+    template<typename T>
+    void func(...) {}
+
+    template<typename T>
+    void func(member<T>*) {}
+
+    void test();
+
+    void test() { func<foo>(0); }
+
+  }
+
+}  // namespace cxx11
+
+#endif  // __cplusplus >= 201103L
+
+]])
+
+
+dnl  Tests for new features in C++14
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_14], [[
+
+// If the compiler admits that it is not ready for C++14, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201402L
+
+#error "This is not a C++14 compiler"
+
+#else
+
+namespace cxx14
+{
+
+  namespace test_polymorphic_lambdas
+  {
+
+    int
+    test()
+    {
+      const auto lambda = [](auto&&... args){
+        const auto istiny = [](auto x){
+          return (sizeof(x) == 1UL) ? 1 : 0;
+        };
+        const int aretiny[] = { istiny(args)... };
+        return aretiny[0];
+      };
+      return lambda(1, 1L, 1.0f, '1');
+    }
+
+  }
+
+  namespace test_binary_literals
+  {
+
+    constexpr auto ivii = 0b0000000000101010;
+    static_assert(ivii == 42, "wrong value");
+
+  }
+
+  namespace test_generalized_constexpr
+  {
+
+    template < typename CharT >
+    constexpr unsigned long
+    strlen_c(const CharT *const s) noexcept
+    {
+      auto length = 0UL;
+      for (auto p = s; *p; ++p)
+        ++length;
+      return length;
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("x") == 1UL, "");
+    static_assert(strlen_c("test") == 4UL, "");
+    static_assert(strlen_c("another\0test") == 7UL, "");
+
+  }
+
+  namespace test_lambda_init_capture
+  {
+
+    int
+    test()
+    {
+      auto x = 0;
+      const auto lambda1 = [a = x](int b){ return a + b; };
+      const auto lambda2 = [a = lambda1(x)](){ return a; };
+      return lambda2();
+    }
+
+  }
+
+  namespace test_digit_separators
+  {
+
+    constexpr auto ten_million = 100'000'000;
+    static_assert(ten_million == 100000000, "");
+
+  }
+
+  namespace test_return_type_deduction
+  {
+
+    auto f(int& x) { return x; }
+    decltype(auto) g(int& x) { return x; }
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static constexpr auto value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static constexpr auto value = true;
+    };
+
+    int
+    test()
+    {
+      auto x = 0;
+      static_assert(is_same<int, decltype(f(x))>::value, "");
+      static_assert(is_same<int&, decltype(g(x))>::value, "");
+      return x;
+    }
+
+  }
+
+}  // namespace cxx14
+
+#endif  // __cplusplus >= 201402L
+
+]])
+
+
+dnl  Tests for new features in C++17
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
+
+// If the compiler admits that it is not ready for C++17, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201703L
+
+#error "This is not a C++17 compiler"
+
+#else
+
+#include <initializer_list>
+#include <utility>
+#include <type_traits>
+
+namespace cxx17
+{
+
+  namespace test_constexpr_lambdas
+  {
+
+    constexpr int foo = [](){return 42;}();
+
+  }
+
+  namespace test::nested_namespace::definitions
+  {
+
+  }
+
+  namespace test_fold_expression
+  {
+
+    template<typename... Args>
+    int multiply(Args... args)
+    {
+      return (args * ... * 1);
+    }
+
+    template<typename... Args>
+    bool all(Args... args)
+    {
+      return (args && ...);
+    }
+
+  }
+
+  namespace test_extended_static_assert
+  {
+
+    static_assert (true);
+
+  }
+
+  namespace test_auto_brace_init_list
+  {
+
+    auto foo = {5};
+    auto bar {5};
+
+    static_assert(std::is_same<std::initializer_list<int>, decltype(foo)>::value);
+    static_assert(std::is_same<int, decltype(bar)>::value);
+  }
+
+  namespace test_typename_in_template_template_parameter
+  {
+
+    template<template<typename> typename X> struct D;
+
+  }
+
+  namespace test_fallthrough_nodiscard_maybe_unused_attributes
+  {
+
+    int f1()
+    {
+      return 42;
+    }
+
+    [[nodiscard]] int f2()
+    {
+      [[maybe_unused]] auto unused = f1();
+
+      switch (f1())
+      {
+      case 17:
+        f1();
+        [[fallthrough]];
+      case 42:
+        f1();
+      }
+      return f1();
+    }
+
+  }
+
+  namespace test_extended_aggregate_initialization
+  {
+
+    struct base1
+    {
+      int b1, b2 = 42;
+    };
+
+    struct base2
+    {
+      base2() {
+        b3 = 42;
+      }
+      int b3;
+    };
+
+    struct derived : base1, base2
+    {
+        int d;
+    };
+
+    derived d1 {{1, 2}, {}, 4};  // full initialization
+    derived d2 {{}, {}, 4};      // value-initialized bases
+
+  }
+
+  namespace test_general_range_based_for_loop
+  {
+
+    struct iter
+    {
+      int i;
+
+      int& operator* ()
+      {
+        return i;
+      }
+
+      const int& operator* () const
+      {
+        return i;
+      }
+
+      iter& operator++()
+      {
+        ++i;
+        return *this;
+      }
+    };
+
+    struct sentinel
+    {
+      int i;
+    };
+
+    bool operator== (const iter& i, const sentinel& s)
+    {
+      return i.i == s.i;
+    }
+
+    bool operator!= (const iter& i, const sentinel& s)
+    {
+      return !(i == s);
+    }
+
+    struct range
+    {
+      iter begin() const
+      {
+        return {0};
+      }
+
+      sentinel end() const
+      {
+        return {5};
+      }
+    };
+
+    void f()
+    {
+      range r {};
+
+      for (auto i : r)
+      {
+        [[maybe_unused]] auto v = i;
+      }
+    }
+
+  }
+
+  namespace test_lambda_capture_asterisk_this_by_value
+  {
+
+    struct t
+    {
+      int i;
+      int foo()
+      {
+        return [*this]()
+        {
+          return i;
+        }();
+      }
+    };
+
+  }
+
+  namespace test_enum_class_construction
+  {
+
+    enum class byte : unsigned char
+    {};
+
+    byte foo {42};
+
+  }
+
+  namespace test_constexpr_if
+  {
+
+    template <bool cond>
+    int f ()
+    {
+      if constexpr(cond)
+      {
+        return 13;
+      }
+      else
+      {
+        return 42;
+      }
+    }
+
+  }
+
+  namespace test_selection_statement_with_initializer
+  {
+
+    int f()
+    {
+      return 13;
+    }
+
+    int f2()
+    {
+      if (auto i = f(); i > 0)
+      {
+        return 3;
+      }
+
+      switch (auto i = f(); i + 4)
+      {
+      case 17:
+        return 2;
+
+      default:
+        return 1;
+      }
+    }
+
+  }
+
+  namespace test_template_argument_deduction_for_class_templates
+  {
+
+    template <typename T1, typename T2>
+    struct pair
+    {
+      pair (T1 p1, T2 p2)
+        : m1 {p1},
+          m2 {p2}
+      {}
+
+      T1 m1;
+      T2 m2;
+    };
+
+    void f()
+    {
+      [[maybe_unused]] auto p = pair{13, 42u};
+    }
+
+  }
+
+  namespace test_non_type_auto_template_parameters
+  {
+
+    template <auto n>
+    struct B
+    {};
+
+    B<5> b1;
+    B<'a'> b2;
+
+  }
+
+  namespace test_structured_bindings
+  {
+
+    int arr[2] = { 1, 2 };
+    std::pair<int, int> pr = { 1, 2 };
+
+    auto f1() -> int(&)[2]
+    {
+      return arr;
+    }
+
+    auto f2() -> std::pair<int, int>&
+    {
+      return pr;
+    }
+
+    struct S
+    {
+      int x1 : 2;
+      volatile double y1;
+    };
+
+    S f3()
+    {
+      return {};
+    }
+
+    auto [ x1, y1 ] = f1();
+    auto& [ xr1, yr1 ] = f1();
+    auto [ x2, y2 ] = f2();
+    auto& [ xr2, yr2 ] = f2();
+    const auto [ x3, y3 ] = f3();
+
+  }
+
+  namespace test_exception_spec_type_system
+  {
+
+    struct Good {};
+    struct Bad {};
+
+    void g1() noexcept;
+    void g2();
+
+    template<typename T>
+    Bad
+    f(T*, T*);
+
+    template<typename T1, typename T2>
+    Good
+    f(T1*, T2*);
+
+    static_assert (std::is_same_v<Good, decltype(f(g1, g2))>);
+
+  }
+
+  namespace test_inline_variables
+  {
+
+    template<class T> void f(T)
+    {}
+
+    template<class T> inline T g(T)
+    {
+      return T{};
+    }
+
+    template<> inline void f<>(int)
+    {}
+
+    template<> int g<>(int)
+    {
+      return 5;
+    }
+
+  }
+
+}  // namespace cxx17
+
+#endif  // __cplusplus < 201703L
+
+]])

--- a/dists/autogen/m4/cmake.m4
+++ b/dists/autogen/m4/cmake.m4
@@ -1,0 +1,44 @@
+dnl Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+dnl file Copyright.txt or https://cmake.org/licensing for details.
+
+AC_DEFUN([CMAKE_FIND_BINARY],
+[AC_ARG_VAR([CMAKE_BINARY], [path to the cmake binary])dnl
+
+if test "x$ac_cv_env_CMAKE_BINARY_set" != "xset"; then
+    AC_PATH_TOOL([CMAKE_BINARY], [cmake])dnl
+fi
+])dnl
+
+# $1: package name
+# $2: language (e.g. C/CXX/Fortran)
+# $3: The compiler ID, defaults to GNU.
+#     Possible values are: GNU, Intel, Clang, SunPro, HP, XL, VisualAge, PGI,
+#     PathScale, Cray, SCO, MSVC
+# $4: optional extra arguments to cmake, e.g. "-DCMAKE_SIZEOF_VOID_P=8"
+# $5: optional path to cmake binary
+AC_DEFUN([CMAKE_FIND_PACKAGE], [
+AC_REQUIRE([CMAKE_FIND_BINARY])dnl
+
+AC_ARG_VAR([$1][_][$2][FLAGS], [$2 compiler flags for $1. This overrides the cmake output])dnl
+AC_ARG_VAR([$1][_LIBS], [linker flags for $1. This overrides the cmake output])dnl
+
+failed=false
+AC_MSG_CHECKING([for $1])
+if test -z "${$1[]_$2[]FLAGS}"; then
+    $1[]_$2[]FLAGS=`$CMAKE_BINARY --find-package "-DNAME=$1" "-DCOMPILER_ID=m4_default([$3], [GNU])" "-DLANGUAGE=$2" -DMODE=COMPILE $4` || failed=true
+fi
+if test -z "${$1[]_LIBS}"; then
+    $1[]_LIBS=`$CMAKE_BINARY --find-package "-DNAME=$1" "-DCOMPILER_ID=m4_default([$3], [GNU])" "-DLANGUAGE=$2" -DMODE=LINK $4` || failed=true
+fi
+
+if $failed; then
+    unset $1[]_$2[]FLAGS
+    unset $1[]_LIBS
+
+    AC_MSG_RESULT([no])
+    $6
+else
+    AC_MSG_RESULT([yes])
+    $5
+fi[]dnl
+])

--- a/dists/gentoo/ultrastardx-9999.ebuild
+++ b/dists/gentoo/ultrastardx-9999.ebuild
@@ -26,7 +26,7 @@ RDEPEND="virtual/opengl
 	dev-lang/lua
 	midi? ( media-libs/portmidi )
 	projectm? ( media-libs/libprojectm )
-	webcam? ( media-libs/opencv )"
+	webcam? ( >=media-libs/opencv-3.0.0 )"
 DEPEND="${RDEPEND}
 	dev-util/pkgconfig
 	>=dev-lang/fpc-3.0.0"
@@ -39,6 +39,7 @@ src_prepare() {
 src_configure() {
 	econf \
 		$(use_with projectm libprojectM) \
+		$(use_with webcam opencv-cxx-api) \
 		$(use_enable midi portmidi) \
 		$(use_enable debug) \
 		|| die "econf failed"

--- a/dists/linux/dl.sh
+++ b/dists/linux/dl.sh
@@ -35,7 +35,7 @@ for i in "${deps[@]}"; do
 		hashB="$(sha1sum "deps/dl/$bname" 2> /dev/null | awk '{print $1}')"
 		if [ ! -f "deps/dl/$bname" ] || [ "$hashA" != "$hashB" ]; then
 			echo "Downloading $name from $url"
-			curl --progress-bar -L "$url" -o "deps/dl/$bname"
+			curl -s -S -L "$url" -o "deps/dl/$bname"
 			hashB="$(sha1sum "deps/dl/$bname" 2> /dev/null | awk '{print $1}')"
 			if [ "$hashA" != "$hashB" ]; then
 				echo "Hashes doesn't match!" "$hashA" "$hashB"
@@ -64,7 +64,7 @@ for i in "${deps[@]}"; do
 		hashB="$(sha1sum "deps/dl/$bname" 2> /dev/null | awk '{print $1}')"
 		if [ ! -f "deps/dl/$bname" ] || [ "$hashA" != "$hashB" ]; then
 			echo "Downloading $name from $url"
-			curl --progress-bar -L "$url" -o "deps/dl/$bname"
+			curl -s -S -L "$url" -o "deps/dl/$bname"
 			hashB="$(sha1sum "deps/dl/$bname" 2> /dev/null | awk '{print $1}')"
 			if [ "$hashA" != "$hashB" ]; then
 				echo "Hashes doesn't match!" "$hashA" "$hashB"
@@ -82,7 +82,7 @@ for i in "${deps[@]}"; do
 		hashB="$(sha1sum "deps/$name" 2> /dev/null | awk '{print $1}')"
 		if [ ! -f "deps/$name" ] || [ "$hashA" != "$hashB" ]; then
 			echo "Downloading $name from $url"
-			curl --progress-bar -L "$url" -o "deps/$name"
+			curl -s -S -L "$url" -o "deps/$name"
 			hashB="$(sha1sum "deps/$name" 2> /dev/null | awk '{print $1}')"
 			if [ "$hashA" != "$hashB" ]; then
 				echo "Hashes doesn't match!" "$hashA" "$hashB"

--- a/dists/linux/dl.sh
+++ b/dists/linux/dl.sh
@@ -16,6 +16,7 @@ deps+=('libpng,https://download.sourceforge.net/libpng/libpng-1.6.36.tar.xz,aec9
 deps+=('zlib,https://zlib.net/zlib-1.2.11.tar.gz,e6d119755acdf9104d7ba236b1242696940ed6dd')
 # deps+=('libcwrap.h,https://raw.githubusercontent.com/wheybags/glibc_version_header/master/version_headers/force_link_glibc_2.10.2.h,aff0c46cf3005fe15c49688e74df62a9988855a5')
 deps+=('patchelf,https://github.com/NixOS/patchelf/archive/0.9.tar.gz,c068c60a67388fbf9267142516d3a8cd6ffc4397')
+deps+=('opencv,https://github.com/opencv/opencv/archive/4.1.1.tar.gz,a7beeaada9b6c45a389b9aee391e82c092537819')
 # if [ -f /.dockerenv ]; then
 # 	deps+=('fpc-x86_64,https://sourceforge.net/projects/freepascal/files/Linux/3.0.4/fpc-3.0.4.x86_64-linux.tar,0720e428eaea423423e1b76a7267d6749c3399f4')
 # 	deps+=('fpc-i686,https://sourceforge.net/projects/freepascal/files/Linux/3.0.4/fpc-3.0.4.i386-linux.tar,0a51364bd1a37f1e776df5357ab5bfca8cc7ddeb')

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -148,12 +148,24 @@ PROJECTM_CWRAPPER_LIB := $(PROJECTM_CWRAPPER_DIR)/libprojectM-cwrapper.a
 USE_PROJECTM_CWRAPPER := @USE_PROJECTM_CWRAPPER@
 
 #################################################
+# OpenCV
+#################################################
+
+OPENCV_CWRAPPER_DIR := $(USDX_LIB_DIR)/openCV3
+OPENCV_CWRAPPER_LIB := $(OPENCV_CWRAPPER_DIR)/libopenCV-cwrapper.a
+USE_OPENCV_CWRAPPER := @USE_OPENCV_CWRAPPER@
+
+#################################################
 # Static libs
 #################################################
 
 STATIC_LIBS := 
 ifeq ($(USE_PROJECTM_CWRAPPER), yes)
 STATIC_LIBS += $(PROJECTM_CWRAPPER_LIB)
+endif
+
+ifeq ($(USE_OPENCV_CWRAPPER), yes)
+STATIC_LIBS += $(OPENCV_CWRAPPER_LIB)
 endif
 
 #################################################

--- a/src/config.inc.in
+++ b/src/config.inc.in
@@ -94,3 +94,8 @@
 {$IF Defined(IncludeConstants)}
   porttime_lib_name = '@porttime_LIB_NAME@';
 {$IFEND}
+
+{$@DEFINE_USE_OPENCV_CWRAPPER@ UseOpenCVWrapper}
+{$@DEFINE_OPENCV_CORE_STANDALONE@ OpenCVCoreStandalone}
+{$@DEFINE_OPENCV_IMGPROC_STANDALONE@ OpenCVImgprocStandalone}
+{$@DEFINE_OPENCV_VIDEOIO_STANDALONE@ OpenCVVideoioStandalone}

--- a/src/lib/openCV3/ApiWrapper.cpp
+++ b/src/lib/openCV3/ApiWrapper.cpp
@@ -1,0 +1,414 @@
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/videoio.hpp>
+#include <cstdio>
+
+// OpenCV 4 no longer defines these by default
+#define CV_CANNY_L2_GRADIENT	(1 << 31)
+#define CV_BLUR			1
+#define CV_CHOLESKY		3
+#define CV_SVD			1
+#define CV_SVD_SYM		2
+
+// The idea is to use the UMat for all calculations while keeping the Mat empty.
+// Only when the Pascal code requests a pointer to the image data, we assign
+// getMat to the Mat to keep a reference to that buffer.
+struct UMatWrapper {
+	cv::UMat umat;
+	cv::Mat mat;
+};
+
+struct USDX_CvCapture {
+	USDX_CvCapture(int index) : cap(index) {}
+
+	cv::VideoCapture cap;
+	UMatWrapper frame;
+};
+
+extern "C" {
+
+int USDX_cvGetDimSize(UMatWrapper *w, int index);
+int Get_UMat_depth(UMatWrapper *);
+const void *Get_UMat_as_8UC3(UMatWrapper *w);
+UMatWrapper *USDX_cvCreateImage(int width, int height, int depth, int channels);
+UMatWrapper *USDX_cvCloneImage(UMatWrapper *src);
+void USDX_cvReleaseImage(UMatWrapper **w);
+void USDX_cvNot(UMatWrapper *src, UMatWrapper *dst);
+void USDX_cvAbsDiff(UMatWrapper *src1, UMatWrapper *src2, UMatWrapper *dst);
+void USDX_cvCvtColor(UMatWrapper *src, UMatWrapper *dst, int code);
+void USDX_cvEqualizeHist(UMatWrapper *src, UMatWrapper *dst);
+void USDX_cvCanny(UMatWrapper *src, UMatWrapper *dst, double threshold1, double threshold2, int aperture_size);
+void USDX_cvFlip(UMatWrapper *src, UMatWrapper *dst, int flip_mode);
+double USDX_cvThreshold(UMatWrapper *src, UMatWrapper *dst, double threshold, double max_value, int threshold_type);
+void USDX_cvSmooth(UMatWrapper *src, UMatWrapper *dst, int smooth_type, int param1, int param2, double param3, double param4);
+void USDX_cvDilate(UMatWrapper *src, UMatWrapper *dst, void *element, int iterations);
+void USDX_cvErode(UMatWrapper *src, UMatWrapper *dst, void *element, int iterations);
+void USDX_cvTransform(UMatWrapper *src, UMatWrapper *dst, cv::Mat *transmat, cv::Mat *shiftvec);
+void USDX_cvGEMM(cv::Mat *A, cv::Mat *B, double alpha, cv::Mat *C, double beta, cv::Mat *D, int flags);
+cv::Mat *USDX_cvCreateMat(int rows, int cols, int type);
+void USDX_cvReleaseMat(cv::Mat **mat);
+void USDX_cvSetZero(cv::Mat *mat);
+void USDX_cvSetReal2D(cv::Mat *mat, int y, int x, double value);
+double USDX_cvInvert(cv::Mat *src, cv::Mat *dst, int method);
+USDX_CvCapture *USDX_cvCreateCameraCapture(int index);
+void USDX_cvReleaseCapture(USDX_CvCapture **capture);
+UMatWrapper* USDX_cvQueryFrame(USDX_CvCapture *capture);
+int USDX_cvSetCaptureProperty(USDX_CvCapture* capture, int property_id, double value);
+
+}
+
+int USDX_cvGetDimSize(UMatWrapper *w, int index)
+{
+	if (!w)
+		return 0;
+	switch (index) {
+	case 0:
+		return w->umat.rows;
+	case 1:
+		return w->umat.cols;
+	default:
+		return 1;
+	}
+}
+
+int Get_UMat_depth(UMatWrapper *w)
+{
+	if (!w)
+		return CV_8U;
+	return w->umat.depth();
+}
+
+const void *Get_UMat_as_8UC3(UMatWrapper *w)
+{
+	if (!w)
+		return nullptr;
+	try {
+		if (w->umat.type() == CV_8UC3) {
+			w->mat = w->umat.getMat(cv::ACCESS_READ);
+		} else {
+			cv::UMat tmp, tmp2;
+			switch (w->umat.depth()) {
+			default:
+				tmp = w->umat;
+				break;
+			case CV_8S:
+				w->umat.convertTo(tmp, CV_8UC3, 255.0/127);
+				break;
+			case CV_16U:
+				w->umat.convertTo(tmp, CV_8UC3, 255.0/65535);
+				break;
+			case CV_16S:
+				w->umat.convertTo(tmp, CV_8UC3, 255.0/32767);
+				break;
+			case CV_32S:
+				w->umat.convertTo(tmp, CV_8UC3, 255.0/2147483647);
+				break;
+#if CV_VERSION_MAJOR >= 4
+			case CV_16F:
+#endif
+			case CV_32F:
+			case CV_64F:
+				w->umat.convertTo(tmp, CV_8UC3, 255.0);
+			}
+			switch (tmp.channels()) {
+			default:
+				tmp2 = tmp;
+				break;
+			case 1:
+				cv::cvtColor(tmp, tmp2, cv::COLOR_GRAY2RGB);
+			}
+			w->mat = tmp2.getMat(cv::ACCESS_READ);
+		}
+		return w->mat.data;
+	} catch (...) {
+		return nullptr;
+	}
+}
+
+UMatWrapper *USDX_cvCreateImage(int width, int height, int depth, int channels)
+{
+	UMatWrapper *w{nullptr};
+	try {
+		cv::UMat umat{height, width, CV_MAKETYPE(depth, channels)};
+		w = new UMatWrapper;
+		w->umat = umat;
+	} catch (...) {
+		if (w) {
+			try {
+				delete w;
+			} catch (...) {}
+			w = nullptr;
+		}
+	}
+	return w;
+}
+
+UMatWrapper *USDX_cvCloneImage(UMatWrapper *src)
+{
+	UMatWrapper *w{nullptr};
+	try {
+		w = new UMatWrapper;
+		w->umat = src->umat.clone();
+	} catch (...) {
+		if (w) {
+			try {
+				delete w;
+			} catch(...) {}
+			w = nullptr;
+		}
+	}
+	return w;
+}
+
+void USDX_cvReleaseImage(UMatWrapper **w)
+{
+	if (!w)
+		return;
+	try {
+		delete *w;
+	} catch (...) {}
+	*w = nullptr;
+}
+
+void USDX_cvNot(UMatWrapper *src, UMatWrapper *dst)
+{
+	if (!src || !dst)
+		return;
+	try {
+		cv::bitwise_not(src->umat, dst->umat);
+	} catch (...) {}
+}
+
+void USDX_cvAbsDiff(UMatWrapper *src1, UMatWrapper *src2, UMatWrapper *dst)
+{
+	if (!src2 || !src2 || !dst)
+		return;
+	try {
+		cv::absdiff(src1->umat, src2->umat, dst->umat);
+	} catch (...) {}
+}
+
+void USDX_cvCvtColor(UMatWrapper *src, UMatWrapper *dst, int code)
+{
+	if (!src || !dst)
+		return;
+	try {
+		cv::cvtColor(src->umat, dst->umat, code);
+	} catch (...) {}
+}
+
+void USDX_cvEqualizeHist(UMatWrapper *src, UMatWrapper *dst)
+{
+	if (!src || !dst)
+		return;
+	try {
+		cv::equalizeHist(src->umat, dst->umat);
+	} catch (...) {}
+}
+
+void USDX_cvCanny(UMatWrapper *src, UMatWrapper *dst, double threshold1, double threshold2, int aperture_size)
+{
+	if (!src || !dst)
+		return;
+	try {
+		cv::Canny(src->umat, dst->umat, threshold1, threshold2, aperture_size & 255, (aperture_size & CV_CANNY_L2_GRADIENT) != 0);
+	} catch (...) {}
+}
+
+void USDX_cvFlip(UMatWrapper *src, UMatWrapper *dst, int flip_mode)
+{
+	if (!src)
+		return;
+	try {
+		cv::flip(src->umat, dst ? dst->umat : src->umat, flip_mode);
+	} catch (...) {}
+}
+
+double USDX_cvThreshold(UMatWrapper *src, UMatWrapper *dst, double threshold, double max_value, int threshold_type)
+{
+	if (src && dst) {
+		try {
+			cv::UMat dst0{dst->umat};
+			double ret{cv::threshold(src->umat, dst->umat, threshold, max_value, threshold_type)};
+			if (dst0.type() != dst->umat.type()) {
+				dst->umat.convertTo(dst0, dst0.type());
+				dst->umat = dst0;
+			}
+			return ret;
+		} catch (...) {}
+	}
+	return 0;
+}
+
+void USDX_cvSmooth(UMatWrapper *src, UMatWrapper *dst, int smooth_type, int param1, int param2, double param3, double param4)
+{
+	if (!src || !dst)
+		return;
+	if (smooth_type != CV_BLUR) {
+		fprintf(stderr, "%s: Only CV_BLUR is implemented", __func__);
+		return;
+	}
+	try {
+		cv::boxFilter(src->umat, dst->umat, dst->umat.depth(), cv::Size(param1, param2), cv::Point(-1,-1), true, cv::BORDER_REPLICATE);
+	} catch (...) {}
+}
+
+void USDX_cvDilate(UMatWrapper *src, UMatWrapper *dst, void *element, int iterations)
+{
+	if (!src || !dst)
+		return;
+	if (element) {
+		fprintf(stderr, "%s: element != NULL is not implemented", __func__);
+		return;
+	}
+	try {
+		cv::dilate(src->umat, dst->umat, cv::Mat(), cv::Point(1,1), iterations, cv::BORDER_REPLICATE);
+	} catch (...) {}
+}
+
+void USDX_cvErode(UMatWrapper *src, UMatWrapper *dst, void *element, int iterations)
+{
+	if (!src || !dst)
+		return;
+	if (element) {
+		fprintf(stderr, "%s: element != NULL is not implemented", __func__);
+		return;
+	}
+	try {
+		cv::erode(src->umat, dst->umat, cv::Mat(), cv::Point(1,1), iterations, cv::BORDER_REPLICATE);
+	} catch (...) {}
+}
+
+void USDX_cvTransform(UMatWrapper *src, UMatWrapper *dst, cv::Mat *transmat, cv::Mat *shiftvec)
+{
+	if (!src || !dst || !transmat)
+		return;
+	if (shiftvec) {
+		fprintf(stderr, "%s: shiftvec != NULL is not implemented", __func__);
+		return;
+	}
+
+	try {
+		cv::transform(src->umat, dst->umat, *transmat);
+	} catch (...) {}
+}
+
+void USDX_cvGEMM(cv::Mat *A, cv::Mat *B, double alpha, cv::Mat *C, double beta, cv::Mat *D, int flags)
+{
+	if (!A || !B || !D)
+		return;
+	if (C) {
+		cv::gemm(*A, *B, alpha, *C, beta, *D, flags);
+	} else {
+		cv::Mat emptyC;
+		cv::gemm(*A, *B, alpha, emptyC, beta, *D, flags);
+	}
+}
+
+cv::Mat *USDX_cvCreateMat(int rows, int cols, int type)
+{
+	try {
+		return new cv::Mat(rows, cols, type);
+	} catch(...) {
+		return nullptr;
+	}
+}
+
+void USDX_cvReleaseMat(cv::Mat **mat)
+{
+	if (!mat)
+		return;
+	try {
+		delete *mat;
+	} catch(...) {}
+	*mat = nullptr;
+}
+
+void USDX_cvSetZero(cv::Mat *mat)
+{
+	if (!mat)
+		return;
+	*mat = cv::Scalar(0);
+}
+
+void USDX_cvSetReal2D(cv::Mat *mat, int y, int x, double value)
+{
+	if (!mat)
+		return;
+	try {
+		switch(mat->depth()) {
+		case CV_8U:  mat->at<uchar>(y, x)  = value; return;
+		case CV_8S:  mat->at<schar>(y, x)  = value; return;
+		case CV_16U: mat->at<ushort>(y, x) = value; return;
+		case CV_16S: mat->at<short>(y, x)  = value; return;
+#if CV_VERSION_MAJOR >= 4
+		case CV_16F: mat->at<cv::float16_t>(y, x) = cv::float16_t(value); return;
+#endif
+		case CV_32S: mat->at<int>(y, x)    = value; return;
+		case CV_32F: mat->at<float>(y, x)  = value; return;
+		case CV_64F: mat->at<double>(y, x) = value; return;
+		}
+	} catch(...) {}
+}
+
+double USDX_cvInvert(cv::Mat *src, cv::Mat *dst, int method)
+{
+	if (!src || !dst)
+		return 0;
+
+	cv::DecompTypes d = cv::DECOMP_LU;
+	switch (method) {
+	case CV_CHOLESKY: d = cv::DECOMP_CHOLESKY; break;
+	case CV_SVD:      d = cv::DECOMP_SVD; break;
+	case CV_SVD_SYM:  d = cv::DECOMP_EIG; break;
+	}
+
+	try {
+		return cv::invert(*src, *dst, d);
+	} catch(...) {
+		return 0;
+	}
+}
+
+USDX_CvCapture *USDX_cvCreateCameraCapture(int index)
+{
+	try {
+		USDX_CvCapture *c = new USDX_CvCapture(index);
+		if (c->cap.isOpened())
+			return c;
+		delete c;
+	} catch(...) {}
+	return nullptr;
+
+}
+
+void USDX_cvReleaseCapture(USDX_CvCapture **capture)
+{
+	if (!capture)
+		return;
+	try {
+		delete *capture;
+	} catch(...) {}
+	*capture = nullptr;
+}
+
+UMatWrapper* USDX_cvQueryFrame(USDX_CvCapture *capture)
+{
+	if (capture) {
+		try {
+			if (capture->cap.read(capture->frame.umat))
+				return &capture->frame;
+		} catch (...) {}
+	}
+	return nullptr;
+}
+
+int USDX_cvSetCaptureProperty(USDX_CvCapture* capture, int property_id, double value)
+{
+	if (capture) {
+		try {
+			return capture->cap.set(property_id, value);
+		} catch (...) {}
+	}
+	return 0;
+}

--- a/src/lib/openCV3/Makefile.in
+++ b/src/lib/openCV3/Makefile.in
@@ -1,0 +1,34 @@
+#################################################
+# projectM C-wrapper
+# @configure_input@
+#################################################
+
+@SET_MAKE@
+
+srcdir = @srcdir@
+top_srcdir = @top_srcdir@
+
+OBJECTS	= ApiWrapper.o
+LIBRARY = libopenCV-cwrapper.a
+
+CXX      = @CXX@
+CXXFLAGS += @CXXFLAGS@ @OpenCV_CXXFLAGS@
+RANLIB   = @RANLIB@
+
+.PHONY: all clean distclean
+
+all: $(LIBRARY)
+
+$(LIBRARY): $(OBJECTS)
+	ar ruv $(LIBRARY) $(OBJECTS)
+	$(RANLIB) $(LIBRARY)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c $(<) -o $@
+
+clean:
+	rm -f $(LIBRARY)
+	rm -f $(OBJECTS)
+
+distclean: clean
+	rm -rf Makefile

--- a/src/lib/openCV3/opencv_core.pas
+++ b/src/lib/openCV3/opencv_core.pas
@@ -1,0 +1,126 @@
+unit opencv_core;
+
+interface
+
+{$IFDEF FPC}
+  {$MODE Delphi}
+{$ENDIF}
+
+{$I switches.inc}
+
+{$L ApiWrapper.o}
+{$IFDEF OpenCVCoreStandalone}
+  {$LINKLIB opencv_core}
+{$ELSE}
+  {$LINKLIB opencv_world}
+{$ENDIF}
+
+uses
+  CTypes, SysUtils, opencv_types;
+
+function USDX_cvCreateImage(width: cint; height: cint; depth: cint; channels: cint): PUMatWrapper; cdecl; external;
+function cvCreateImage(size: CvSize; depth: integer; channels: integer): PIplImage;
+
+function USDX_cvCloneImage(img: PUMatWrapper): PUMatWrapper; cdecl; external;
+function cvCloneImage(img: PIplImage): PIplImage;
+
+procedure USDX_cvReleaseImage(image: PPUMatWrapper); cdecl; external;
+procedure cvReleaseImage(image: PPIplImage);
+
+function cvCreateMat(rows: cint; cols: cint; _type: cint): PCvMat; cdecl; external name 'USDX_cvCreateMat';
+procedure cvReleaseMat(mat: PPCvMat); cdecl; external name 'USDX_cvReleaseMat';
+procedure cvSetReal2D(arr: PCvMat; idx0: cint; idx1: cint; value: cdouble); cdecl; external name 'USDX_cvSetReal2D';
+procedure cvSetZero(arr: PCvMat); cdecl; external name 'USDX_cvSetZero';
+
+const
+ CV_GEMM_A_T = 1;
+ CV_GEMM_B_T = 2;
+ CV_GEMM_C_T = 4;
+
+procedure cvGEMM(src1: PCvMat; src2: PCvMat; alpha: cdouble; src3: PCvMat; beta: cdouble; dst: PCvMat; tABC: cint = 0); cdecl; external name 'USDX_cvGEMM';
+
+const
+  CV_LU = 0;
+  CV_SVD = 1;
+  CV_SVD_SYM = 2;
+  CV_CHOLESKY = 3;
+  CV_QR = 4;
+  CV_NORMAL = 16;
+
+function cvInvert(A: PCvMat; B: PCvMat; method: cint = CV_LU): cdouble; cdecl; external name 'USDX_cvInvert';
+
+procedure USDX_cvNot(src: PUMatWrapper; dst: PUMatWrapper); cdecl; external;
+procedure cvNot(src: PIplImage; dst: PIplImage); {$IFDEF HasInline}inline;{$ENDIF}
+procedure USDX_cvFlip(src: PUMatWrapper; dst: PUMatwrapper; flipmode: cint); cdecl; external;
+procedure cvFlip(src: PIplImage; dst: PIplImage = nil; flipmode: integer = 0); {$IFDEF HasInline}inline;{$ENDIF}
+procedure USDX_cvAbsDiff(src1: PUMatWrapper; src2: PUMatWrapper; dst: PUMatWrapper); cdecl; external;
+procedure cvAbsDiff(src1: PIplImage; src2: PIplImage; dst: PIplImage); {$IFDEF HasInline}inline;{$ENDIF}
+procedure USDX_cvTransform(src: PUMatWrapper; dst: PUMatWrapper; transmat: PCvMat; shiftvec: PCvMat); cdecl; external;
+procedure cvTransform(src: PIplImage; dst: PIplImage; transmat: PCvMat; shiftvec: PCvMat = nil); {$IFDEF HasInline}inline;{$ENDIF}
+
+function USDX_cvGetDimSize(w: PUMatWrapper; index: cint): cint; cdecl; external;
+function cvGetDimSize(img: PIplImage; index: integer): integer; {$IFDEF HasInline}inline;{$ENDIF}
+
+
+implementation
+
+function cvGetDimSize(img: PIplImage; index: integer): integer; {$IFDEF HasInline}inline;{$ENDIF}
+begin
+	Result := USDX_cvGetDimSize(img.CppObject, index);
+end;
+
+function cvCreateImage(size: CvSize; depth: integer; channels: integer): PIplImage;
+var
+	w: PUMatWrapper;
+begin
+	w := USDX_cvCreateImage(size.width, size.height, depth, channels);
+	Result := nil;
+	if w <> nil then
+		Result := PIplImage.Create(w);
+end;
+
+function cvCloneImage(img: PIplImage): PIplImage;
+var
+	w: PUMatWrapper;
+begin
+	w := USDX_cvCloneImage(img.CppObject);
+	Result := nil;
+	if w <> nil then
+		Result := PIplImage.Create(w);
+end;
+
+procedure cvReleaseImage(image: PPIplImage);
+begin
+	if (image <> nil) and (image^ <> nil) then
+	begin
+		image^.Free;
+		image^ := nil;
+	end;
+end;
+
+procedure cvNot(src: PIplImage; dst: PIplImage); {$IFDEF HasInline}inline;{$ENDIF}
+begin
+	USDX_cvNot(src.CppObject, dst.CppObject);
+end;
+
+procedure cvFlip(src: PIplImage; dst: PIplImage; flipmode: integer); {$IFDEF HasInline}inline;{$ENDIF}
+var
+	dstObj: PUMatWrapper;
+begin
+	dstObj := nil;
+	if dst <> nil then
+		dstObj := dst.CppObject;
+	USDX_cvFlip(src.CppObject, dstObj, flipmode);
+end;
+
+procedure cvAbsDiff(src1: PIplImage; src2: PIplImage; dst: PIplImage); {$IFDEF HasInline}inline;{$ENDIF}
+begin
+	USDX_cvAbsDiff(src1.CppObject, src2.CppObject, dst.CppObject);
+end;
+
+procedure cvTransform(src: PIplImage; dst: PIplImage; transmat: PCvMat; shiftvec: PCvMat); {$IFDEF HasInline}inline;{$ENDIF}
+begin
+	USDX_cvTransform(src.CppObject, dst.CppObject, transmat, shiftvec);
+end;
+
+end.

--- a/src/lib/openCV3/opencv_highgui.pas
+++ b/src/lib/openCV3/opencv_highgui.pas
@@ -1,0 +1,156 @@
+unit opencv_highgui;
+
+interface
+
+{$IFDEF FPC}
+  {$MODE Delphi}
+{$ENDIF}
+
+{$I switches.inc}
+
+{$L ApiWrapper.o}
+{$IFDEF OpenCVVideoioStandalone}
+  {$LINKLIB opencv_videoio}
+{$ELSE}
+  {$LINKLIB opencv_world}
+{$ENDIF}
+
+uses
+  CTypes, SysUtils, opencv_types;
+
+type
+  PPCvCapture = ^PCvCapture;
+  PCvCapture = pointer;
+
+const
+  CV_CAP_ANY   =   0  ;
+
+  CV_CAP_MIL   =   100;
+
+  CV_CAP_VFW   =   200;
+  CV_CAP_V4L   =   200;
+  CV_CAP_V4L2  =   200;
+
+  CV_CAP_FIREWARE= 300;
+  CV_CAP_FIREWIRE= 300;
+  CV_CAP_IEEE1394= 300;
+  CV_CAP_DC1394  = 300;
+  CV_CAP_CMU1394 = 300;
+
+  CV_CAP_STEREO  = 400;
+  CV_CAP_TYZX    = 400;
+  CV_TYZX_LEFT   = 400;
+  CV_TYZX_RIGHT  = 401;
+  CV_TYZX_COLOR  = 402;
+  CV_TYZX_Z      = 403;
+
+  CV_CAP_QT      = 500;
+
+  CV_CAP_UNICAP  = 600;
+
+  CV_CAP_DSHOW   = 700;
+
+function cvCreateCameraCapture(index: cint): PCvCapture; cdecl; external name 'USDX_cvCreateCameraCapture';
+function USDX_cvQueryFrame(capture: PCvCapture): PUMatWrapper; cdecl; external;
+function cvQueryFrame(capture: PCvCapture): PIplImage;
+procedure cvReleaseCapture(capture: PPCvCapture); cdecl; external name 'USDX_cvReleaseCapture';
+
+const
+    CV_CAP_PROP_DC1394_OFF         = -4;
+    CV_CAP_PROP_DC1394_MODE_MANUAL = -3;
+    CV_CAP_PROP_DC1394_MODE_AUTO = -2;
+    CV_CAP_PROP_DC1394_MODE_ONE_PUSH_AUTO = -1;
+    CV_CAP_PROP_POS_MSEC       =0;
+    CV_CAP_PROP_POS_FRAMES     =1;
+    CV_CAP_PROP_POS_AVI_RATIO  =2;
+    CV_CAP_PROP_FRAME_WIDTH    =3;
+    CV_CAP_PROP_FRAME_HEIGHT   =4;
+    CV_CAP_PROP_FPS            =5;
+    CV_CAP_PROP_FOURCC         =6;
+    CV_CAP_PROP_FRAME_COUNT    =7;
+    CV_CAP_PROP_FORMAT         =8;
+    CV_CAP_PROP_MODE           =9;
+    CV_CAP_PROP_BRIGHTNESS    =10;
+    CV_CAP_PROP_CONTRAST      =11;
+    CV_CAP_PROP_SATURATION    =12;
+    CV_CAP_PROP_HUE           =13;
+    CV_CAP_PROP_GAIN          =14;
+    CV_CAP_PROP_EXPOSURE      =15;
+    CV_CAP_PROP_CONVERT_RGB   =16;
+    CV_CAP_PROP_WHITE_BALANCE_BLUE_U =17;
+    CV_CAP_PROP_RECTIFICATION =18;
+    CV_CAP_PROP_MONOCROME     =19;
+    CV_CAP_PROP_SHARPNESS     =20;
+    CV_CAP_PROP_AUTO_EXPOSURE =21;
+
+
+    CV_CAP_PROP_GAMMA         =22;
+    CV_CAP_PROP_TEMPERATURE   =23;
+    CV_CAP_PROP_TRIGGER       =24;
+    CV_CAP_PROP_TRIGGER_DELAY =25;
+    CV_CAP_PROP_WHITE_BALANCE_RED_V =26;
+    CV_CAP_PROP_MAX_DC1394    =27;
+    CV_CAP_PROP_AUTOGRAB      =1024;
+    CV_CAP_PROP_SUPPORTED_PREVIEW_SIZES_STRING=1025;
+    CV_CAP_PROP_PREVIEW_FORMAT=1026;
+
+    CV_CAP_OPENNI_DEPTH_GENERATOR = 0;
+    CV_CAP_OPENNI_IMAGE_GENERATOR = 1 shl 31;
+    CV_CAP_OPENNI_GENERATORS_MASK = 1 shl 31;
+
+
+    CV_CAP_PROP_OPENNI_OUTPUT_MODE      = 100;
+    CV_CAP_PROP_OPENNI_FRAME_MAX_DEPTH  = 101;
+    CV_CAP_PROP_OPENNI_BASELINE         = 102;
+    CV_CAP_PROP_OPENNI_FOCAL_LENGTH     = 103;
+    CV_CAP_PROP_OPENNI_REGISTRATION_ON  = 104;
+    CV_CAP_PROP_OPENNI_REGISTRATION     = CV_CAP_PROP_OPENNI_REGISTRATION_ON;
+
+
+    CV_CAP_OPENNI_IMAGE_GENERATOR_OUTPUT_MODE = CV_CAP_OPENNI_IMAGE_GENERATOR + CV_CAP_PROP_OPENNI_OUTPUT_MODE;
+    CV_CAP_OPENNI_DEPTH_GENERATOR_BASELINE = CV_CAP_OPENNI_DEPTH_GENERATOR + CV_CAP_PROP_OPENNI_BASELINE;
+    CV_CAP_OPENNI_DEPTH_GENERATOR_FOCAL_LENGTH = CV_CAP_OPENNI_DEPTH_GENERATOR + CV_CAP_PROP_OPENNI_FOCAL_LENGTH;
+    CV_CAP_OPENNI_DEPTH_GENERATOR_REGISTRATION_ON = CV_CAP_OPENNI_DEPTH_GENERATOR + CV_CAP_PROP_OPENNI_REGISTRATION_ON;
+
+
+    CV_CAP_GSTREAMER_QUEUE_LENGTH   = 200;
+    CV_CAP_PROP_PVAPI_MULTICASTIP   = 300;
+
+
+    CV_CAP_PROP_XI_DOWNSAMPLING  = 400;
+    CV_CAP_PROP_XI_DATA_FORMAT   = 401;
+    CV_CAP_PROP_XI_OFFSET_X      = 402;
+    CV_CAP_PROP_XI_OFFSET_Y      = 403;
+    CV_CAP_PROP_XI_TRG_SOURCE    = 404;
+    CV_CAP_PROP_XI_TRG_SOFTWARE  = 405;
+    CV_CAP_PROP_XI_GPI_SELECTOR  = 406;
+    CV_CAP_PROP_XI_GPI_MODE      = 407;
+    CV_CAP_PROP_XI_GPI_LEVEL     = 408;
+    CV_CAP_PROP_XI_GPO_SELECTOR  = 409;
+    CV_CAP_PROP_XI_GPO_MODE      = 410;
+    CV_CAP_PROP_XI_LED_SELECTOR  = 411;
+    CV_CAP_PROP_XI_LED_MODE      = 412;
+    CV_CAP_PROP_XI_MANUAL_WB     = 413;
+    CV_CAP_PROP_XI_AUTO_WB       = 414;
+    CV_CAP_PROP_XI_AEAG          = 415;
+    CV_CAP_PROP_XI_EXP_PRIORITY  = 416;
+    CV_CAP_PROP_XI_AE_MAX_LIMIT  = 417;
+    CV_CAP_PROP_XI_AG_MAX_LIMIT  = 418;
+    CV_CAP_PROP_XI_AEAG_LEVEL    = 419;
+    CV_CAP_PROP_XI_TIMEOUT       = 420;
+
+function cvSetCaptureProperty(capture: PCvCapture; property_id: cint; value: cdouble): cint; cdecl; external name 'USDX_cvSetCaptureProperty';
+
+implementation
+
+function cvQueryFrame(capture: PCvCapture): PIplImage;
+var
+	w: PUMatWrapper;
+begin
+	w := USDX_cvQueryFrame(capture);
+	Result := nil;
+	if w <> nil then
+		Result := PIplImage.Create(w);
+end;
+
+end.

--- a/src/lib/openCV3/opencv_imgproc.pas
+++ b/src/lib/openCV3/opencv_imgproc.pas
@@ -1,0 +1,188 @@
+unit opencv_imgproc;
+
+interface
+
+{$IFDEF FPC}
+  {$MODE Delphi}
+{$ENDIF}
+
+{$I switches.inc}
+
+{$L ApiWrapper.o}
+{$IFDEF OpenCVImgprocStandalone}
+  {$LINKLIB opencv_imgproc}
+{$ELSE}
+  {$LINKLIB opencv_world}
+{$ENDIF}
+
+uses
+  CTypes, SysUtils, opencv_types;
+
+const
+ CV_BLUR_NO_SCALE =0;
+ CV_BLUR          =1;
+ CV_GAUSSIAN      =2;
+ CV_MEDIAN        =3;
+ CV_BILATERAL     =4;
+
+
+procedure USDX_cvSmooth(src, dst: PUMatWrapper; smoothtype: cint; size1: cint; size2: cint; sigma1: cdouble; sigma2: cdouble); cdecl; external;
+procedure cvSmooth(src, dst: PIplImage; smoothtype: integer = CV_GAUSSIAN; size1: integer = 3; size2: integer = 0; sigma1: double = 0; sigma2: double = 0); {$IFDEF HasInline}inline;{$ENDIF}
+
+const
+  CV_BGR2BGRA  =  0;
+  CV_RGB2RGBA  =  CV_BGR2BGRA;
+
+  CV_BGRA2BGR  =  1;
+  CV_RGBA2RGB  =  CV_BGRA2BGR;
+
+  CV_BGR2RGBA  =  2;
+  CV_RGB2BGRA  =  CV_BGR2RGBA;
+
+  CV_RGBA2BGR  =  3;
+  CV_BGRA2RGB  =  CV_RGBA2BGR;
+
+  CV_BGR2RGB   =  4;
+  CV_RGB2BGR   =  CV_BGR2RGB;
+
+  CV_BGRA2RGBA =  5;
+  CV_RGBA2BGRA =  CV_BGRA2RGBA;
+
+  CV_BGR2GRAY  =  6;
+  CV_RGB2GRAY  =  7;
+  CV_GRAY2BGR  =  8;
+  CV_GRAY2RGB  =  CV_GRAY2BGR;
+  CV_GRAY2BGRA =  9;
+  CV_GRAY2RGBA =  CV_GRAY2BGRA;
+  CV_BGRA2GRAY =  10;
+  CV_RGBA2GRAY =  11;
+
+  CV_BGR2BGR565 = 12;
+  CV_RGB2BGR565 = 13;
+  CV_BGR5652BGR = 14;
+  CV_BGR5652RGB = 15;
+  CV_BGRA2BGR565= 16;
+  CV_RGBA2BGR565 =17;
+  CV_BGR5652BGRA =18;
+  CV_BGR5652RGBA =19;
+
+  CV_GRAY2BGR565 =20;
+  CV_BGR5652GRAY =21;
+
+  CV_BGR2BGR555  =22;
+  CV_RGB2BGR555  =23;
+  CV_BGR5552BGR  =24;
+  CV_BGR5552RGB  =25;
+  CV_BGRA2BGR555 =26;
+  CV_RGBA2BGR555 =27;
+  CV_BGR5552BGRA =28;
+  CV_BGR5552RGBA =29;
+
+  CV_GRAY2BGR555 =30;
+  CV_BGR5552GRAY =31;
+
+  CV_BGR2XYZ     =32;
+  CV_RGB2XYZ     =33;
+  CV_XYZ2BGR     =34;
+  CV_XYZ2RGB     =35;
+
+  CV_BGR2YCrCb   =36;
+  CV_RGB2YCrCb   =37;
+  CV_YCrCb2BGR   =38;
+  CV_YCrCb2RGB   =39;
+
+  CV_BGR2HSV     =40;
+  CV_RGB2HSV     =41;
+
+  CV_BGR2Lab     =44;
+  CV_RGB2Lab     =45;
+
+  CV_BayerBG2BGR =46;
+  CV_BayerGB2BGR =47;
+  CV_BayerRG2BGR =48;
+  CV_BayerGR2BGR =49;
+
+  CV_BayerBG2RGB =CV_BayerRG2BGR;
+  CV_BayerGB2RGB =CV_BayerGR2BGR;
+  CV_BayerRG2RGB =CV_BayerBG2BGR;
+  CV_BayerGR2RGB =CV_BayerGB2BGR;
+
+  CV_BGR2Luv     =50;
+  CV_RGB2Luv     =51;
+  CV_BGR2HLS     =52;
+  CV_RGB2HLS     =53;
+
+  CV_HSV2BGR     =54;
+  CV_HSV2RGB     =55;
+
+  CV_Lab2BGR     =56;
+  CV_Lab2RGB     =57;
+  CV_Luv2BGR     =58;
+  CV_Luv2RGB     =59;
+  CV_HLS2BGR     =60;
+  CV_HLS2RGB     =61;
+
+  CV_COLORCVT_MAX  =100;
+
+procedure USDX_cvCvtColor(src: PUMatWrapper; dst: PUMatWrapper; code: cint); cdecl; external;
+procedure cvCvtColor(src: PIplImage; dst: PIplImage; code: integer); {$IFDEF HasInline}inline;{$ENDIF}
+procedure USDX_cvEqualizeHist(src: PUMatWrapper; dst: PUMatWrapper); cdecl; external;
+procedure cvEqualizeHist(src: PIplImage; dst: PIplImage); {$IFDEF HasInline}inline;{$ENDIF}
+procedure USDX_cvCanny(image: PUMatWrapper; edges: PUMatWrapper; threshold1: cdouble; threshold2: cdouble; aperture_size: cint); cdecl; external;
+procedure cvCanny(image: PIplImage; edges: PIplImage; threshold1: double; threshold2: double; aperture_size: integer = 3); {$IFDEF HasInline}inline;{$ENDIF}
+procedure USDX_cvDilate(src: PUMatWrapper; dst: PUMatWrapper; element: pointer; iterations: cint); cdecl; external;
+procedure cvDilate(src: PIplImage; dst: PIplImage; element: pointer = nil; iterations: integer = 1); {$IFDEF HasInline}inline;{$ENDIF}
+procedure USDX_cvErode(src: PUMatWrapper; dst: PUMatWrapper; element: pointer; iterations: cint); cdecl; external;
+procedure cvErode(src: PIplImage; dst: PIplImage; element: pointer = nil; iterations: integer = 1); {$IFDEF HasInline}inline;{$ENDIF}
+
+const
+ CV_THRESH_BINARY     = 0;
+ CV_THRESH_BINARY_INV = 1;
+ CV_THRESH_TRUNC      = 2;
+ CV_THRESH_TOZERO     = 3;
+ CV_THRESH_TOZERO_INV = 4;
+ CV_THRESH_MASK       = 7;
+ CV_THRESH_OTSU       = 8;
+
+procedure USDX_cvThreshold(src: PUMatWrapper; dst: PUMatWrapper; threshold: cdouble; max_value: cdouble; threshold_type: cint); cdecl; external;
+procedure cvThreshold(src: PIplImage; dst: PIplImage; threshold: double; max_value: double; threshold_type: integer); {$IFDEF HasInline}inline;{$ENDIF}
+
+implementation
+
+procedure cvSmooth(src, dst: PIplImage; smoothtype: integer; size1: integer; size2: integer; sigma1: double; sigma2: double); {$IFDEF HasInline}inline;{$ENDIF}
+begin
+	USDX_cvSmooth(src.CppObject, dst.CppObject, smoothtype, size1, size2, sigma1, sigma2);
+end;
+
+procedure cvCvtColor(src: PIplImage; dst: PIplImage; code: integer); {$IFDEF HasInline}inline;{$ENDIF}
+begin
+	USDX_cvCvtColor(src.CppObject, dst.CppObject, code);
+end;
+
+procedure cvEqualizeHist(src: PIplImage; dst: PIplImage); {$IFDEF HasInline}inline;{$ENDIF}
+begin
+	USDX_cvEqualizeHist(src.CppObject, dst.CppObject);
+end;
+
+procedure cvCanny(image: PIplImage; edges: PIplImage; threshold1: double; threshold2: double; aperture_size: integer); {$IFDEF HasInline}inline;{$ENDIF}
+begin
+	USDX_cvCanny(image.CppObject, edges.CppObject, threshold1, threshold2, aperture_size);
+end;
+
+procedure cvDilate(src: PIplImage; dst: PIplImage; element: pointer; iterations: integer); {$IFDEF HasInline}inline;{$ENDIF}
+begin
+	USDX_cvDilate(src.CppObject, dst.CppObject, element, iterations);
+end;
+
+procedure cvErode(src: PIplImage; dst: PIplImage; element: pointer; iterations: integer); {$IFDEF HasInline}inline;{$ENDIF}
+begin
+	USDX_cvErode(src.CppObject, dst.CppObject, element, iterations);
+end;
+
+procedure cvThreshold(src: PIplImage; dst: PIplImage; threshold: double; max_value: double; threshold_type: integer); cdecl; {$IFDEF HasInline}inline;{$ENDIF}
+begin
+	USDX_cvThreshold(src.CppObject, dst.CppObject, threshold, max_value, threshold_type);
+end;
+
+end.
+

--- a/src/lib/openCV3/opencv_types.pas
+++ b/src/lib/openCV3/opencv_types.pas
@@ -1,0 +1,134 @@
+unit opencv_types;
+
+interface
+{$IFDEF FPC}
+  {$MODE Delphi}
+{$ENDIF}
+
+{$I switches.inc}
+
+{$L ApiWrapper.o}
+{$IFDEF OpenCVCoreStandalone}
+  {$LINKLIB opencv_core}
+{$ELSE}
+  {$LINKLIB opencv_world}
+{$ENDIF}
+
+uses
+  CTypes;
+
+type
+  PPUMatWrapper = ^PUMatWrapper;
+  PUMatWrapper = pointer;
+
+  PPIplImage = ^PIplImage;
+  PIplImage = class
+    public
+      CppObject: PUMatWrapper;
+      constructor Create(_CppObject: PUMatWrapper);
+      destructor Destroy; override;
+      function imageData: pointer; {$IFDEF HasInline}inline;{$ENDIF}
+      function width: integer; {$IFDEF HasInline}inline;{$ENDIF}
+      function height: integer; {$IFDEF HasInline}inline;{$ENDIF}
+      function depth: integer; {$IFDEF HasInline}inline;{$ENDIF}
+  end;
+
+  PPCvMat = ^PCvMat;
+  PCvMat = pointer;
+
+  PCvSize = ^CvSize;
+  CvSize = record
+    width: integer;
+    height: integer;
+  end;
+
+function CvSizeV(p_width, p_height: integer):CvSize; overload;
+function CvSizeV(p_width, p_height: extended):CvSize; overload;
+
+function Get_UMat_depth(w: PUMatWrapper): cint; cdecl; external;
+function Get_UMat_as_8UC3(w: PUMatWrapper): pointer; cdecl; external;
+
+// The type casts needed for the old API are not needed/supported by this wrapper.
+// These functions pass through their parameter unchanged to allow the type casts
+// to stay in place without sacrificing the type checking.
+function PCvArr(a: PIplImage): PIplImage; overload; {$IFDEF HasInline}inline;{$ENDIF}
+function PCvArr(a: PCvMat): PCvMat; overload; {$IFDEF HasInline}inline;{$ENDIF}
+
+const
+  CV_CN_MAX     = 64;
+  CV_CN_SHIFT   = 3;
+  CV_DEPTH_MAX  = (1 shl CV_CN_SHIFT);
+
+  CV_8U   = 0;
+  CV_8S   = 1;
+  CV_16U  = 2;
+  CV_16S  = 3;
+  CV_32S  = 4;
+  CV_32F  = 5;
+  CV_64F  = 6;
+  CV_16F  = 7;
+
+  CV_MAT_DEPTH_MASK = CV_DEPTH_MAX - 1;
+
+  CV_32FC1 = ((CV_32F) and CV_MAT_DEPTH_MASK) + (((1)-1) shl CV_CN_SHIFT);
+
+implementation
+
+uses opencv_core;
+
+constructor PIplImage.Create(_CppObject: PUMatWrapper);
+begin
+  inherited Create;
+  CppObject := _CppObject;
+end;
+
+destructor PIplImage.Destroy;
+begin
+	USDX_cvReleaseImage(@CppObject);
+	inherited;
+end;
+
+function PIplImage.width: integer; {$IFDEF HasInline}inline;{$ENDIF}
+begin
+  Result := cvGetDimSize(self, 1);
+end;
+
+function PIplImage.height: integer; {$IFDEF HasInline}inline;{$ENDIF}
+begin
+  Result := cvGetDimSize(self, 0);
+end;
+
+function PIplImage.depth: integer; {$IFDEF HasInline}inline;{$ENDIF}
+begin
+  Result := Get_UMat_depth(CppObject);
+  // Result := cvIplDepth(cvGetElemType(self));
+end;
+
+function PIplImage.imageData: pointer; {$IFDEF HasInline}inline;{$ENDIF}
+begin
+  Result := Get_UMat_as_8UC3(CppObject);
+end;
+
+function CvSizeV(p_width,p_height: integer):CvSize;
+begin
+  result.width:=p_width;
+  Result.height:= p_height;
+end;
+
+function CvSizeV(p_width,p_height: extended):CvSize; overload;
+begin
+  result.width  := round(p_width);
+  Result.height := round(p_height);
+end;
+
+function PCvArr(a: PIplImage): PIplImage; overload; {$IFDEF HasInline}inline;{$ENDIF}
+begin
+	Result := a;
+end;
+
+function PCvArr(a: PCvMat): PCvMat; overload; {$IFDEF HasInline}inline;{$ENDIF}
+begin
+	Result := a;
+end;
+
+end.

--- a/src/ultrastardx.dpr
+++ b/src/ultrastardx.dpr
@@ -363,10 +363,17 @@ uses
   UWebSDK                 in 'webSDK\UWebSDK.pas',
   //curlobj                 in 'webSDK\cURL\src\curlobj.pas',
 
+{$IFDEF UseOpenCVWrapper}
+  opencv_highgui          in 'lib\openCV3\opencv_highgui.pas',
+  opencv_core             in 'lib\openCV3\opencv_core.pas',
+  opencv_imgproc          in 'lib\openCV3\opencv_imgproc.pas',
+  opencv_types            in 'lib\openCV3\opencv_types.pas',
+{$ELSE}
   opencv_highgui          in 'lib\openCV\opencv_highgui.pas',
   opencv_core             in 'lib\openCV\opencv_core.pas',
   opencv_imgproc          in 'lib\openCV\opencv_imgproc.pas',
   opencv_types            in 'lib\openCV\opencv_types.pas',
+{$ENDIF}
 
   //BassMIDI                in 'lib\bassmidi\bassmidi.pas',
 

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -9,7 +9,7 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     # OSX build
 
     ./autogen.sh
-    ./configure --enable-osx-brew
+    ./configure --enable-osx-brew --with-opencv-cxx-api
     make macosx-standalone-app
     make macosx-dmg
 

--- a/tools/travis/install.sh
+++ b/tools/travis/install.sh
@@ -14,7 +14,7 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     #brew cask install xquartz
 
     brew install sdl2 sdl2_gfx sdl2_image sdl2_mixer sdl2_net sdl2_ttf \
-        fpc portaudio binutils freetype libpng lua libtiff \
+        fpc portaudio binutils freetype libpng lua libtiff opencv \
         portmidi
 
     # This is from: https://github.com/Homebrew/homebrew-core


### PR DESCRIPTION
Fixes #478 
By default the old code that loads the libraries at runtime and uses the C API is used.
To use the new code, pass --with-opencv-cxx-api to configure.
In my opinion this should be used on all current systems if webcam support is desired.
Since the wrapper uses UMat objects, it will not work with OpenCV < 3.0.

The OS X Travis job builds without problems, but the OpenCV libraries from Homebrew use @rpath, which is not yet supported by Makefile.osx-helper.