### PR TITLE
Error handling fixes

### DIFF
--- a/src/base/UCommon.pas
+++ b/src/base/UCommon.pas
@@ -470,6 +470,7 @@ end;
 
 procedure InitConsoleOutput();
 begin
+  Log := TLog.Create;
   {$IFDEF FPC}
   // init thread-safe output
   MessageList := TStringList.Create();
@@ -496,6 +497,7 @@ begin
   RTLeventDestroy(ConsoleEvent);
   MessageList.Free();
   {$ENDIF}
+  Log.Free;
 end;
 
 {*

--- a/src/base/ULog.pas
+++ b/src/base/ULog.pas
@@ -160,7 +160,7 @@ uses
 procedure DebugWriteln(const aString: string);
 begin
   {$IFNDEF DEBUG}
-  if Params.Debug then
+  if not assigned(Params) or Params.Debug then
   begin
   {$ENDIF}
     ConsoleWriteLn(aString);

--- a/src/base/ULog.pas
+++ b/src/base/ULog.pas
@@ -176,7 +176,7 @@ begin
   inherited;
   LogLevel := LOG_LEVEL_DEFAULT;
   LogFileLevel := LOG_FILE_LEVEL_DEFAULT;
-  FileOutputEnabled := true;
+  FileOutputEnabled := false;
   InitCriticalSection(Lock);
 end;
 

--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -113,14 +113,11 @@ begin
     WindowTitle := USDXVersionStr;
 
     Platform.Init;
+    Log.Title := WindowTitle;
+    Log.FileOutputEnabled := true;
     
     // Commandline Parameter Parser
     Params := TCMDParams.Create;
-
-    // Log + Benchmark
-    Log := TLog.Create;
-    Log.Title := WindowTitle;
-    //Log.FileOutputEnabled := not Params.NoLog;
 
     if Platform.TerminateIfAlreadyRunning(WindowTitle) then
       Exit;
@@ -297,7 +294,6 @@ begin
     SDL_Quit();
 
     Log.LogStatus('Finalize Log', 'Finalization');
-    Log.Free;
   {$IFNDEF Debug}
   end;
   {$ENDIF}

--- a/src/media/UAudioInput_Portaudio.pas
+++ b/src/media/UAudioInput_Portaudio.pas
@@ -499,7 +499,8 @@ end;
 function TAudioInput_Portaudio.FinalizeRecord: boolean;
 begin
   CaptureStop;
-  AudioCore.Terminate();
+  if assigned(AudioCore) then
+     AudioCore.Terminate();
   Result := inherited FinalizeRecord();
 end;
 

--- a/src/media/UAudioPlayback_Portaudio.pas
+++ b/src/media/UAudioPlayback_Portaudio.pas
@@ -370,7 +370,9 @@ end;
 function TAudioPlayback_Portaudio.FinalizeAudioPlaybackEngine(): boolean;
 begin
   StopAudioPlaybackEngine();
-  Result := AudioCore.Terminate();
+  Result := true;
+  if assigned(AudioCore) then
+     Result := AudioCore.Terminate();
 end;
 
 function TAudioPlayback_Portaudio.GetLatency(): double;


### PR DESCRIPTION
When an exception happens in the finally block of our Main procedure while it was cleaning up another exception, Free Pascal will not report the exception that triggered the finally block to run but only the exception inside the finally block. These commits fix various exceptions inside or after the finally block observed after causing an exception in TPlatformLinux.Init. It should help to uncover the real reason for the premature termination in #505 (which is currently hidden by the exception in the ConsoleHandlerFunc thread). I would not be surprised if the backtrace in #502 also shows this red herring.
