### PR TITLE
Fix mac os screen initialization

### DIFF
--- a/src/base/UGraphic.pas
+++ b/src/base/UGraphic.pas
@@ -547,6 +547,11 @@ begin
   SDL_SetWindowTitle(Screen, PChar(Title));
   Display.CurrentScreen^.FadeTo( @ScreenMain );
 
+  // work around to force a good screen initialization on MacOS
+  {$IFDEF MACOS}
+  UGraphic.UpdateVideoMode();
+  {$IFEND}
+
   Log.BenchmarkEnd(2);
   Log.LogBenchmark('--> Loading Screens', 2);
 

--- a/src/base/UGraphic.pas
+++ b/src/base/UGraphic.pas
@@ -549,7 +549,7 @@ begin
 
   // work around to force a good screen initialization on MacOS
   {$IFDEF MACOS}
-  UGraphic.UpdateVideoMode();
+  UpdateVideoMode();
   {$IFEND}
 
   Log.BenchmarkEnd(2);


### PR DESCRIPTION
Applying the work around from [issue 500](https://github.com/UltraStar-Deluxe/USDX/issues/500) in code form.

The work around forces a video mode update after screen initialization.
Local tests on a MacBook Pro 2019 MacOS 10.15.3, shows the screen no longer shows shifted up in full screen mode, in window mode the screen fills the window instead of 1/4th of the screen.