### PR TITLE
Allow audio recording using SDL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,11 @@ AC_ARG_WITH([cfg-dummy1], [
 External Libraries:])
 
 # add portmixer option
+AC_ARG_WITH([portaudio],
+    [AS_HELP_STRING([--with-portaudio],
+      [enable audio capture with PortAudio @<:@default=check@:>@])],
+    [with_portmixer=$withval], [with_portaudio="check"])
+
 AC_ARG_WITH([portmixer],
     [AS_HELP_STRING([--with-portmixer],
       [enable portmixer audio-mixer support @<:@default=check@:>@])],
@@ -441,7 +446,7 @@ if [[ "$use_cxx" = yes ]] ; then
 fi
 
 # find portaudio
-PKG_HAVE([portaudio], [portaudio-2.0], yes)
+PKG_HAVE([portaudio], [portaudio-2.0], no)
 PKG_VERSION([portaudio], [portaudio-2.0])
 AC_SUBST_DEFINE(HAVE_PORTAUDIO, $portaudio_HAVE)
 

--- a/dists/gentoo/ultrastardx-9999.ebuild
+++ b/dists/gentoo/ultrastardx-9999.ebuild
@@ -13,14 +13,14 @@ EGIT_REPO_URI="https://github.com/UltraStar-Deluxe/USDX/"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="midi projectm debug webcam"
+IUSE="midi projectm debug webcam portaudio"
 
 RDEPEND="virtual/opengl
 	virtual/glu
 	media-libs/libsdl2[opengl]
 	media-libs/sdl2-image[png,jpeg]
 	media-libs/freetype
-	=media-libs/portaudio-19*
+	portaudio? ( =media-libs/portaudio-19* )
 	media-video/ffmpeg
 	dev-db/sqlite
 	dev-lang/lua
@@ -38,6 +38,7 @@ src_prepare() {
 
 src_configure() {
 	econf \
+		$(use_with portaudio) \
 		$(use_with projectm libprojectM) \
 		$(use_with webcam opencv-cxx-api) \
 		$(use_enable midi portmidi) \

--- a/src/media/UAudioInput_SDL.pas
+++ b/src/media/UAudioInput_SDL.pas
@@ -1,0 +1,228 @@
+// UltraStar Deluxe - Karaoke Game
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+unit UAudioInput_SDL;
+
+interface
+
+{$IFDEF FPC}
+  {$MODE Delphi}
+{$ENDIF}
+
+{$I ../switches.inc}
+
+uses
+  Classes,
+  SysUtils,
+  UMusic;
+
+implementation
+
+uses
+  sdl2,
+  ctypes,
+  math,
+  UIni,
+  ULog,
+  URecord;
+
+type
+  TAudioInput_SDL = class(TAudioInputBase)
+    private
+      Initialized: boolean;
+      function EnumDevices(): boolean;
+    public
+      function GetName: string; override;
+      function InitializeRecord: boolean; override;
+      function FinalizeRecord: boolean; override;
+  end;
+
+  TSDLInputDevice = class(TAudioInputDevice)
+    private
+      DevID:   TSDL_AudioDeviceID;
+      UseName: boolean;
+    public
+      function Start(): boolean; override;
+      function Stop():  boolean; override;
+
+      function GetVolume(): single;        override;
+      procedure SetVolume(Volume: single); override;
+  end;
+
+procedure MicrophoneCallback(inputDevice: TSDLInputDevice; input: pointer; len: cint); cdecl;
+begin
+  AudioInputProcessor.HandleMicrophoneData(input, len, inputDevice);
+end;
+
+function TSDLInputDevice.Start(): boolean;
+var
+  devName: PChar;
+  spec:    TSDL_AudioSpec;
+begin
+  Result := false;
+
+  if DevID <= 0 then
+  begin
+    FillChar(spec, SizeOf(spec), 0);
+    with spec do
+    begin
+      freq := Round(AudioFormat.SampleRate);
+      format := AUDIO_S16SYS;
+      channels := AudioFormat.Channels;
+      callback := @MicrophoneCallback;
+      userdata := pointer(Self);
+
+      samples := 0;
+      if Ini.InputDeviceConfig[CfgIndex].Latency > 0 then
+        samples := 1 shl Round(Max(Log2(freq / 1000 * Ini.InputDeviceConfig[CfgIndex].Latency), 0));
+    end;
+
+    devName := nil;
+    if UseName then
+      devName := PChar(Name);
+
+    DevID := SDL_OpenAudioDevice(devName, 1, @spec, @spec, 0);
+    if DevID > 0 then
+    begin
+      if Ini.InputDeviceConfig[CfgIndex].Latency > 0 then
+        Log.LogStatus('InputDevice "' + Name + '" opened with ' +
+                      IntToStr(spec.samples) + ' samples (' +
+                      IntToStr(round(spec.samples * 1000 / spec.freq)) +
+                      'ms) buffer', 'SDL');
+      SDL_PauseAudioDevice(DevID, 0);
+    end;
+  end;
+
+  Result := (DevID > 0);
+end;
+
+function TSDLInputDevice.Stop(): boolean;
+begin
+  SDL_CloseAudioDevice(DevID);
+  DevID := 0;
+  Result := true;
+end;
+
+function TSDLInputDevice.GetVolume(): single;
+begin
+  Result := 0;
+end;
+
+procedure TSDLInputDevice.SetVolume(Volume: single);
+begin
+end;
+
+function TAudioInput_SDL.GetName: String;
+begin
+  Result := 'SDL';
+  if SDL_WasInit(SDL_INIT_AUDIO) <> 0 then
+    Result := Result + ' (' + SDL_GetCurrentAudioDriver + ')';
+end;
+
+function TAudioInput_SDL.EnumDevices(): boolean;
+var
+  i:            integer;
+  deviceIndex:  integer;
+  maxDevices:   integer;
+  name:         PChar;
+  device:       TSDLInputDevice;
+  spec:         TSDL_AudioSpec;
+  dev:          TSDL_AudioDeviceID;
+begin
+  Result := false;
+
+  Log.LogInfo('Using ' + SDL_GetCurrentAudioDriver + ' driver', 'SDL');
+
+  maxDevices := SDL_GetNumAudioDevices(1);
+  if maxDevices < 1 then
+    maxDevices := 1;
+
+  // init array-size to max. input-devices count
+  SetLength(AudioInputProcessor.DeviceList, maxDevices);
+
+  deviceIndex := 0;
+  for i := 0 to High(AudioInputProcessor.DeviceList) do
+  begin
+    name := SDL_GetAudioDeviceName(i, 1);
+    if (name = nil) and (i > 0) then
+      break;
+
+    FillChar(spec, SizeOf(spec), 0);
+    with spec do
+    begin
+      freq := 44100;
+      format := AUDIO_S16SYS;
+      channels := 0; // override with SDL_AUDIO_CHANNELS
+      samples := 0;
+    end;
+
+    dev := SDL_OpenAudioDevice(name, 1, @spec, @spec, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE or SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
+    if dev < 1 then
+      continue;
+
+    SDL_CloseAudioDevice(dev);
+
+    device := TSDLInputDevice.Create();
+    device.Name := DEFAULT_SOURCE_NAME;
+    device.UseName := false;
+    if name <> nil then
+    begin
+      device.Name := name;
+      device.UseName := true;
+    end;
+
+    device.MicSource := -1;
+    device.SourceRestore := -1;
+    SetLength(device.Source, 1);
+    device.Source[0].Name := DEFAULT_SOURCE_NAME;
+
+    // create audio-format info and resize capture-buffer array
+    device.AudioFormat := TAudioFormatInfo.Create(
+        spec.channels,
+        spec.freq,
+        asfS16
+    );
+    SetLength(device.CaptureChannel, device.AudioFormat.Channels);
+
+    Log.LogStatus('InputDevice "' + device.Name + '"@' +
+        IntToStr(device.AudioFormat.Channels) + 'x' +
+        FloatToStr(device.AudioFormat.SampleRate) + 'Hz ' +
+        'defaults to ' + IntToStr(spec.samples) + ' samples buffer',
+        'SDL');
+
+    AudioInputProcessor.DeviceList[deviceIndex] := device;
+    Inc(deviceIndex);
+  end;
+
+  // adjust size to actual input-device count
+  SetLength(AudioInputProcessor.DeviceList, deviceIndex);
+  Log.LogStatus('#Input-Devices: ' + IntToStr(deviceIndex), 'SDL');
+  Result := (deviceIndex > 0);
+end;
+
+function TAudioInput_SDL.InitializeRecord(): boolean;
+begin
+  Result := false;
+
+  if SDL_InitSubSystem(SDL_INIT_AUDIO) = -1 then
+    Exit;
+
+  Initialized := true;
+  Result := EnumDevices();
+end;
+
+function TAudioInput_SDL.FinalizeRecord: boolean;
+begin
+  CaptureStop;
+  if Initialized then
+  begin
+    SDL_QuitSubSystem(SDL_INIT_AUDIO);
+    Initialized := false;
+  end;
+  Result := inherited FinalizeRecord();
+end;
+
+initialization
+  MediaManager.add(TAudioInput_SDL.Create);
+
+end.

--- a/src/switches.inc
+++ b/src/switches.inc
@@ -90,6 +90,9 @@
   {$IFDEF HavePortmixer}
     {$DEFINE UsePortmixer}
   {$ENDIF}
+{$ELSE}
+  {$DEFINE UseSDLPlayback}
+  {$DEFINE UseSDLInput}
 {$IFEND}
 
 // ffmpeg config

--- a/src/ultrastardx.dpr
+++ b/src/ultrastardx.dpr
@@ -300,6 +300,9 @@ uses
 {$IFDEF UseBASSPlayback}
   UAudioPlayback_Bass       in 'media\UAudioPlayback_Bass.pas',
 {$ENDIF}
+{$IFDEF UseSDLInput}
+  UAudioInput_SDL           in 'media\UAudioInput_SDL.pas',
+{$ENDIF}
 {$IFDEF UseSDLPlayback}
   UAudioPlayback_SDL        in 'media\UAudioPlayback_SDL.pas',
 {$ENDIF}


### PR DESCRIPTION
This PR makes PortAudio optional by allowing audio to be recorded using SDL.

Benefits:
 - less dependencies on external libraries
 - SDL knows how to talk to PulseAudio

Drawbacks:
 - SDL might not use the native sampling rate and channel count of the device. In case of PulseAudio the daemon will convert the data to the sampling rate and channel count we request (or to 22050 stereo if we tell SDL to use default values). I will try to file a bug in SDL. SDL has an environment variable that users can user to override the channel count if two channels per device is not enough. We request 44100Hz sampling rate.
 - This triggers a race condition in SDL on Linux if SDL fails to open the session or system D-Bus. Audio threads created by SDL try to raise their priority by asking rtkit over D-Bus and if opening a D-Bus fails, SDL clears the libdbus function pointers. Now imagine two audio threads going through this D-Bus initialization code in parallel. We have at least one thread for playback and one for the microphone.

The buffer size is the default 2048 samples (per channel) and SDL also has an environment variable to override this parameter. This parameter is the number of samples passed to the callback. The whole buffer is at least twice as big.

Tested on Linux with SDL talking to ALSA and on Linux with SDL talking to PulseAudio, the latter both in and outside of a Flatpak.