### PR TITLE
UVideo: Fix looping of videos starting at time 0

### DIFF
--- a/src/media/UVideo.pas
+++ b/src/media/UVideo.pas
@@ -1427,6 +1427,7 @@ begin
   SeekFlags := AVSEEK_FLAG_BACKWARD;
 
   fFrameTime := Time;
+  fNextFrameTime := Time;
   fEOF := false;
   fFrameTexValid := false;
 


### PR DESCRIPTION
Looping videos starting at 0s were broken since f186fc5bffabce4406d1897c8ef667117ecd11d4.
It is unfortunate that nobody tested this in the 13 months before the release and then someone came along within 14 hours after a release and reported it. Maybe we should upload release candidates next time.

When the first frame of the loop has no PTS or a PTS of zero, the value of fNetFrameTime will be used instead. But that value still was beyond the end of the loop.

Fixes #520