### PR TITLE
Use LetterBox aspect ratio instead of Crop. Toggle video aspect ratio in SingScreen via ’A’.

### DIFF
--- a/src/media/UVideo.pas
+++ b/src/media/UVideo.pas
@@ -885,7 +885,7 @@ begin
 
   fPboId := 0;
 
-  fAspectCorrection := acoCrop;
+  fAspectCorrection := acoLetterBox;
 
   fScreen := 1;
 

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -5196,7 +5196,7 @@ begin
     fCurrentVideo.Width := theme.EditSub.BackgroundImage.W;
     fCurrentVideo.Height := theme.EditSub.BackgroundImage.H;
     fCurrentVideo.ReflectionSpacing := 1;
-    fCurrentVideo.AspectCorrection := acoCrop;
+    fCurrentVideo.AspectCorrection := acoLetterBox;
     fCurrentVideo.Draw;
   end;
 

--- a/src/screens/UScreenJukebox.pas
+++ b/src/screens/UScreenJukebox.pas
@@ -2297,7 +2297,7 @@ begin
       end;
     end;
 
-    fCurrentVideo.AspectCorrection := acoCrop;
+    fCurrentVideo.AspectCorrection := acoLetterBox;
     fCurrentVideo.SetScreen(ScreenAct);
     fCurrentVideo.Draw;
     //DrawBlackBars();
@@ -2555,7 +2555,7 @@ begin
   fVideoClip := nil;
   fCurrentVideo := nil;
 
-  AspectCorrection := acoCrop;
+  AspectCorrection := acoLetterBox;
 
   fTimebarMode := TTimebarMode(Ini.JukeboxTimebarMode);
 

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -460,6 +460,11 @@ begin
 
           ScreenSing.Settings.AvatarsVisible := not ScreenSing.Settings.AvatarsVisible;
           Exit;
+        end
+        else
+        begin
+          if (Assigned(fCurrentVideo)) then
+             fCurrentVideo.SetAspectCorrection(TAspectCorrection((Ord(fCurrentVideo.GetAspectCorrection())+1) mod (Ord(High(TAspectCorrection))+1)));
         end;
       end;
 


### PR DESCRIPTION
Default to acoLetterBox instead of acoCrop in SingScreen and Jukebox. Toggle video aspect ratio via ’A’ in SingScreen.