### PR TITLE
Fix macOS crackling/stuttering related to SDL buffer, use Portaudio for playback instead of SDL

### DIFF
--- a/src/switches.inc
+++ b/src/switches.inc
@@ -84,8 +84,8 @@
   {$DEFINE UseBASSDecoder}
   {$DEFINE UseBASSInput}
 {$ELSEIF Defined(HavePortaudio)}
-  {$DEFINE UseSDLPlayback}
-  {.$DEFINE UsePortaudioPlayback}
+  {.$DEFINE UseSDLPlayback}
+  {$DEFINE UsePortaudioPlayback}
   {$DEFINE UsePortaudioInput}
   {$IFDEF HavePortmixer}
     {$DEFINE UsePortmixer}


### PR DESCRIPTION
For some reason the use of SDLPlayback in combination with PortaudioInput causes weird playback issues on my Mac.
The issue can be partly resolved by using an extremely large buffer size for the SDL playback (8196 and above).

If I use 
PortaudioPlayback + PortaudioInput -> no issues (low latency < 2ms possible with a few code changes)
SDLPlayback + SDLInput -> no issues (low latency <2ms possible with a few code changes)

Therefore the following commit fixes all my issues. What was the reason for using SDLPlayback when Portaudio is available?

Fixes #573 
