### PR TITLE
Update deps for Linux builds

### DIFF
--- a/dists/flatpak/eu.usdx.UltraStarDeluxe.yaml
+++ b/dists/flatpak/eu.usdx.UltraStarDeluxe.yaml
@@ -49,8 +49,8 @@ modules:
 - name: opencv
   sources:
   - type: archive
-    url: https://github.com/opencv/opencv/archive/4.5.1.tar.gz
-    sha256: e27fe5b168918ab60d58d7ace2bd82dd14a4d0bd1d3ae182952c2113f5637513
+    url: https://github.com/opencv/opencv/archive/4.5.4.tar.gz
+    sha256: c20bb83dd790fc69df9f105477e24267706715a9d3c705ca1e7f613c7b3bad3d
   buildsystem: cmake-ninja
   builddir: true
   build-options:
@@ -119,13 +119,13 @@ modules:
 - name: lua
   sources:
   - type: archive
-    url: https://www.lua.org/ftp/lua-5.3.6.tar.gz
-    sha256: fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60
+    url: https://www.lua.org/ftp/lua-5.4.3.tar.gz
+    sha256: f8612276169e3bfcbcfb8f226195bfc6e466fe13042f1076cbde92b7ec96bbfb
   buildsystem: simple
   build-commands:
   - sed -i "s:\(#define LUA_ROOT\>\).*:\1 \"${FLATPAK_DEST}\":" src/luaconf.h
   - echo export V R >> Makefile
-  - make INSTALL_TOP=${FLATPAK_DEST} MYCFLAGS="-DLUA_COMPAT_5_2 -DLUA_COMPAT_5_1 ${CFLAGS} -fPIC" LUA_A='liblua.so.$(R)' AR='$(CC) -shared -ldl -lm -Wl,-soname,liblua.so.$(V) -o' RANLIB=true ALL='$(LUA_A)' linux
+  - make INSTALL_TOP=${FLATPAK_DEST} MYCFLAGS="-DLUA_COMPAT_5_3 -DLUA_COMPAT_5_2 -DLUA_COMPAT_5_1 ${CFLAGS} -fPIC" LUA_A='liblua.so.$(R)' AR='$(CC) -shared -ldl -lm -Wl,-soname,liblua.so.$(V) -o' RANLIB=true ALL='$(LUA_A)' linux
   - make INSTALL_TOP=${FLATPAK_DEST} TO_LIB='liblua.so.$(R)' INSTALL_EXEC=true INSTALL_BIN= install
   - cd ${FLATPAK_DEST}/lib && ln -s liblua.so.* liblua.so
   - ldconfig -l ${FLATPAK_DEST}/lib/liblua.so.*
@@ -174,8 +174,8 @@ modules:
   disabled: true # set to false for runtime < 19.08 or if you are unhappy with the version in runtime
   sources:
   - type: archive
-    url: https://downloads.videolan.org/pub/videolan/dav1d/0.8.1/dav1d-0.8.1.tar.xz
-    sha256: a4b503063d411dd129f5eb43616675e613b36ac0aa1e449976d645c05add21ea
+    url: https://downloads.videolan.org/pub/videolan/dav1d/0.9.2/dav1d-0.9.2.tar.xz
+    sha256: e3235ab6c43c0135b0db1d131e1923fad4c84db9d85683e30b91b33a52d61c71
   buildsystem: meson
   config-opts:
   - -Denable_tools=false
@@ -185,8 +185,8 @@ modules:
   disabled: false
   sources:
   - type: archive
-    url: http://ffmpeg.org/releases/ffmpeg-4.2.4.tar.xz
-    sha256: 0d5da81feba073ee78e0f18e0966bcaf91464ae75e18e9a0135186249e3d2a0b
+    url: http://ffmpeg.org/releases/ffmpeg-4.4.1.tar.xz
+    sha256: eadbad9e9ab30b25f5520fbfde99fae4a92a1ae3c0257a8d68569a4651e30e02
 # not really, but close enough:
   buildsystem: autotools
   config-opts:
@@ -216,47 +216,47 @@ modules:
   - type: archive
     only-arches:
     - i386
-    url: https://sourceforge.net/projects/freepascal/files/Linux/3.2.0/fpc-3.2.0.i386-linux.tar
+    url: https://sourceforge.net/projects/freepascal/files/Linux/3.2.2/fpc-3.2.2.i386-linux.tar
     mirror-urls:
-    - ftp://ftp.hu.freepascal.org/pub/fpc/dist/3.2.0/i386-linux/fpc-3.2.0.i386-linux.tar
-    - ftp://mirror.freemirror.org/pub/fpc/dist/3.2.0/i386-linux/fpc-3.2.0.i386-linux.tar
-    sha256: 2110eb1d7a35311f587694f9b25dc2660e0116eafd9884c4c7ab2f2716080578
+    - ftp://ftp.hu.freepascal.org/pub/fpc/dist/3.2.2/i386-linux/fpc-3.2.2.i386-linux.tar
+    - ftp://mirror.freemirror.org/pub/fpc/dist/3.2.2/i386-linux/fpc-3.2.2.i386-linux.tar
+    sha256: f62980ac0b2861221f79fdbff67836aa6912a4256d4192cfa4dfa0ac5b419958
 
   - type: archive
     only-arches:
     - arm
-    url: https://sourceforge.net/projects/freepascal/files/Linux/3.2.0/fpc-3.2.0.arm-linux.tar
+    url: https://sourceforge.net/projects/freepascal/files/Linux/3.2.2/fpc-3.2.2.arm-linux.tar
     mirror-urls:
-    - ftp://ftp.hu.freepascal.org/pub/fpc/dist/3.2.0/arm-linux/fpc-3.2.0.arm-linux.tar
-    - ftp://mirror.freemirror.org/pub/fpc/dist/3.2.0/arm-linux/fpc-3.2.0.arm-linux.tar
-    sha256: b78c72859e1e147e33991e1bb1e937654859799ae2afc145257c834a8d52737e
+    - ftp://ftp.hu.freepascal.org/pub/fpc/dist/3.2.2/arm-linux/fpc-3.2.2.arm-linux.tar
+    - ftp://mirror.freemirror.org/pub/fpc/dist/3.2.2/arm-linux/fpc-3.2.2.arm-linux.tar
+    sha256: 971bbcaa1934286ccdaf3998d338afc19a33235e910f8881c75579ed5d6adefd
 
   - type: archive
     only-arches:
     - x86_64
-    url: https://sourceforge.net/projects/freepascal/files/Linux/3.2.0/fpc-3.2.0-x86_64-linux.tar
+    url: https://sourceforge.net/projects/freepascal/files/Linux/3.2.2/fpc-3.2.2.x86_64-linux.tar
     mirror-urls:
-    - ftp://ftp.hu.freepascal.org/pub/fpc/dist/3.2.0/x86_64-linux/fpc-3.2.0-x86_64-linux.tar
-    - ftp://mirror.freemirror.org/pub/fpc/dist/3.2.0/x86_64-linux/fpc-3.2.0-x86_64-linux.tar
-    sha256: d19252e6cfe52f1217f4822a548ee699eaa7e044807aaf8429a0532cb7e4cb3d
+    - ftp://ftp.hu.freepascal.org/pub/fpc/dist/3.2.2/x86_64-linux/fpc-3.2.2.x86_64-linux.tar
+    - ftp://mirror.freemirror.org/pub/fpc/dist/3.2.2/x86_64-linux/fpc-3.2.2.x86_64-linux.tar
+    sha256: 5adac308a5534b6a76446d8311fc340747cbb7edeaacfe6b651493ff3fe31e83
 
   - type: archive
     only-arches:
     - aarch64
-    url: https://sourceforge.net/projects/freepascal/files/Linux/3.2.0/fpc-3.2.0.aarch64-linux.tar
+    url: https://sourceforge.net/projects/freepascal/files/Linux/3.2.2/fpc-3.2.2.aarch64-linux.tar
     mirror-urls:
-    - ftp://ftp.hu.freepascal.org/pub/fpc/dist/3.2.0/aarch64-linux/fpc-3.2.0.aarch64-linux.tar
-    - ftp://mirror.freemirror.org/pub/fpc/dist/3.2.0/aarch64-linux/fpc-3.2.0-aarch64-linux.tar
-    sha256: e16411a8ca6cf7817d5fc95bfc39919a306157c8f9f09a9ea616d5f19e0d88c0
+    - ftp://ftp.hu.freepascal.org/pub/fpc/dist/3.2.2/aarch64-linux/fpc-3.2.2.aarch64-linux.tar
+    - ftp://mirror.freemirror.org/pub/fpc/dist/3.2.2/aarch64-linux/fpc-3.2.2.aarch64-linux.tar
+    sha256: b39470f9b6b5b82f50fc8680a5da37d2834f2129c65c24c5628a80894d565451
 
   - type: archive
     only-arches:
     - ppc64le
-    url: https://sourceforge.net/projects/freepascal/files/Linux/3.2.0/fpc-3.2.0.powerpc64le-linux.tar
+    url: https://sourceforge.net/projects/freepascal/files/Linux/3.2.2/fpc-3.2.2.powerpc64le-linux.tar
     mirror-urls:
-    - ftp://ftp.hu.freepascal.org/pub/fpc/dist/3.2.0/powerpc64le-linux/fpc-3.2.0.powerpc64le-linux.tar
-    - ftp://mirror.freemirror.org/pub/fpc/dist/3.2.0/powerpc64le-linux/fpc-3.2.0-powerpc64le-linux.tar
-    sha256: 9bf59ae3d336f0de4624c63e4e892ea95de4be2ca66182d185defc50b69b65f3
+    - ftp://ftp.hu.freepascal.org/pub/fpc/dist/3.2.2/powerpc64le-linux/fpc-3.2.2.powerpc64le-linux.tar
+    - ftp://mirror.freemirror.org/pub/fpc/dist/3.2.2/powerpc64le-linux/fpc-3.2.2.powerpc64le-linux.tar
+    sha256: 83c57d7caecfaa69fe817f6d26750aa3a08c5436f7c64bf87dead81d62a5e38a
 
   - type: shell
     commands:

--- a/dists/linux/dl.sh
+++ b/dists/linux/dl.sh
@@ -36,7 +36,7 @@ fi
 
 if [ $needossl = yes ] ; then
 	if older 1.0.2 pkg-config --modversion libssl ; then
-		deps+=('openssl,https://www.openssl.org/source/openssl-1.1.1j.tar.gz,04c340b086828eecff9df06dceff196790bb9268')
+		deps+=('openssl,https://www.openssl.org/source/openssl-1.1.1l.tar.gz,f8819dd31642eebea6cc1fa5c256fc9a4f40809b')
 	fi
 fi
 
@@ -45,20 +45,20 @@ if older 1.8 wayland-scanner --version ; then
 fi
 
 deps+=('wayland-protocols,https://wayland.freedesktop.org/releases/wayland-protocols-1.20.tar.xz,e78c739a3a85477ed524b81e8bb75efe7f8bf4df')
-deps+=('SDL2,https://www.libsdl.org/release/SDL2-2.0.14.tar.gz,212b17d988c417a1a905ab09c50d1845cc48ddb7')
+deps+=('SDL2,https://www.libsdl.org/release/SDL2-2.0.16.tar.gz,57825428174adb2ac947e4014080c262505aa972')
 deps+=('SDL2_image,https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.5.tar.gz,c0aed07994f670a3758f6b8b93d9034a58df5781')
-deps+=('sqlite,https://www.sqlite.org/2021/sqlite-autoconf-3340100.tar.gz,c20286e11fe5c2e3712ce74890e1692417de6890')
+deps+=('sqlite,https://www.sqlite.org/2021/sqlite-autoconf-3360000.tar.gz,a4bcf9e951bfb9745214241ba08476299fc2dc1e')
 
 if older 2.14 nasm --version ; then
 	deps+=('nasm,https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz,d338409a03fc6d1508102881a675a00275fcb879')
 fi
 
-deps+=('dav1d,https://downloads.videolan.org/pub/videolan/dav1d/0.8.1/dav1d-0.8.1.tar.xz,508f2314488c6e0f7927a56b2554e760abcd12cd')
-deps+=('ffmpeg,https://www.ffmpeg.org/releases/ffmpeg-4.2.4.tar.xz,eca62adfdda5cbb5fc3af9dd236c058c046201a1')
+deps+=('dav1d,https://downloads.videolan.org/pub/videolan/dav1d/0.9.2/dav1d-0.9.2.tar.xz,869bd31adb740a95a2b8df0317b3bc28f8ffdadd')
+deps+=('ffmpeg,https://ffmpeg.org/releases/ffmpeg-4.4.1.tar.xz,17c3fb69d79163281bb60279f9fe66785b1ce793')
 deps+=('portmidi,https://sourceforge.net/projects/portmedia/files/portmidi/217/portmidi-src-217.zip,f45bf4e247c0d7617deacd6a65d23d9fddae6117')
 deps+=('portmidi-debian,http://http.debian.net/debian/pool/main/p/portmidi/portmidi_217-6.debian.tar.xz,02e4c6dcfbd35a75913de2acd39be8f0cfd0b244')
-deps+=('lua,https://www.lua.org/ftp/lua-5.3.6.tar.gz,f27d20d6c81292149bc4308525a9d6733c224fa5')
-deps+=('libjpeg-turbo,https://download.sourceforge.net/libjpeg-turbo/libjpeg-turbo-2.0.6.tar.gz,5406c7676d7df89fb4da791ad5af51202910fb25')
+deps+=('lua,https://www.lua.org/ftp/lua-5.4.3.tar.gz,1dda2ef23a9828492b4595c0197766de6e784bc7')
+deps+=('libjpeg-turbo,https://download.sourceforge.net/libjpeg-turbo/libjpeg-turbo-2.1.2.tar.gz,65c51c543b1fbba6db9ff5bee474ccb0b52a929f')
 deps+=('libpng,https://download.sourceforge.net/libpng/libpng-1.6.37.tar.xz,3ab93fabbf4c27e1c4724371df408d9a1bd3f656')
 # deps+=('libcwrap.h,https://raw.githubusercontent.com/wheybags/glibc_version_header/master/version_headers/force_link_glibc_2.10.2.h,aff0c46cf3005fe15c49688e74df62a9988855a5')
 
@@ -66,7 +66,7 @@ if ! patchelf 2>&1 | grep -q syntax ; then
 	deps+=('patchelf,https://github.com/NixOS/patchelf/releases/download/0.12/patchelf-0.12.tar.bz2,58cf949052cc63cdd52e9ab347dcafc6c6c36f33')
 fi
 
-deps+=('opencv,https://github.com/opencv/opencv/archive/4.5.1.tar.gz,3e464886dc9907e879e2fc7097364427e96861f6')
+deps+=('opencv,https://github.com/opencv/opencv/archive/4.5.4.tar.gz,db7943672bca1baeb08bf3290b1fddd2fd96e5c3')
 deps+=('projectm,https://github.com/projectM-visualizer/projectm/releases/download/v2.2.1/projectM-2.2.1.tar.gz,bfd0cb09797384a814c3585b7b0369fc1c8b04fe')
 # if [ -f /.dockerenv ]; then
 # 	deps+=('fpc-x86_64,https://sourceforge.net/projects/freepascal/files/Linux/3.0.4/fpc-3.0.4.x86_64-linux.tar,0720e428eaea423423e1b76a7267d6749c3399f4')

--- a/dists/linux/dockerenv.sh
+++ b/dists/linux/dockerenv.sh
@@ -13,13 +13,13 @@ targetarch="${ARCH-$(uname -m)}"
 if [ "$targetarch" == "x86_64" ]; then
 	imagename="usdx/buildenv:centos7"
 	from="centos:7"
-	fpcpackage="https://sourceforge.net/projects/freepascal/files/Linux/3.2.0/fpc-3.2.0-x86_64-linux.tar"
+	fpcpackage="https://sourceforge.net/projects/freepascal/files/Linux/3.2.2/fpc-3.2.2.x86_64-linux.tar"
 	prefixcmd="linux64"
 	epelpkgs="cmake3 meson ninja-build patchelf"
 elif [ "$targetarch" == "i386" ] || [ "$targetarch" == "i686" ]; then
 	imagename="usdx/buildenv:centos7-i386"
 	from="i386/centos:7"
-	fpcpackage="https://sourceforge.net/projects/freepascal/files/Linux/3.2.0/fpc-3.2.0.i386-linux.tar"
+	fpcpackage="https://sourceforge.net/projects/freepascal/files/Linux/3.2.2/fpc-3.2.2.i386-linux.tar"
 	prefixcmd="linux32"
 	epelpkgs=""
 else

--- a/dists/linux/lua-relocatable.patch
+++ b/dists/linux/lua-relocatable.patch
@@ -1,8 +1,8 @@
 diff --git a/src/loadlib.c b/src/loadlib.c
-index 45f44d3..952a974 100644
+index 6f9fa37..7e210ce 100644
 --- a/src/loadlib.c
 +++ b/src/loadlib.c
-@@ -64,7 +64,9 @@ static const int CLIBS = 0;
+@@ -64,7 +64,9 @@ static const char *const CLIBS = "_CLIBS";
  #define LIB_FAIL	"open"
  
  
@@ -12,7 +12,7 @@ index 45f44d3..952a974 100644
  
  
  /*
-@@ -136,6 +138,40 @@ static lua_CFunction lsys_sym (lua_State *L, void *lib, const char *sym) {
+@@ -145,6 +147,40 @@ static lua_CFunction lsys_sym (lua_State *L, void *lib, const char *sym) {
    return f;
  }
  
@@ -54,10 +54,10 @@ index 45f44d3..952a974 100644
  
  
 diff --git a/src/luaconf.h b/src/luaconf.h
-index 9eeeea6..eb07c81 100644
+index e64d2ee..f56bc88 100644
 --- a/src/luaconf.h
 +++ b/src/luaconf.h
-@@ -200,7 +200,11 @@
+@@ -217,7 +217,11 @@
  
  #else			/* }{ */
  
@@ -68,4 +68,4 @@ index 9eeeea6..eb07c81 100644
 +#endif
  #define LUA_LDIR	LUA_ROOT "share/lua/" LUA_VDIR "/"
  #define LUA_CDIR	LUA_ROOT "lib/lua/" LUA_VDIR "/"
- #define LUA_PATH_DEFAULT  \
+ 

--- a/dists/linux/tasks.sh
+++ b/dists/linux/tasks.sh
@@ -165,7 +165,7 @@ task_sdl2() {
 		--enable-video-kmsdrm --enable-kmsdrm-shared \
 		--disable-video-vulkan \
 		--enable-x11-shared --disable-ibus --disable-fcitx --disable-ime \
-		--disable-rpath --disable-input-tslib
+		--disable-rpath
 	make $makearg
 	make install
 	hide make distclean
@@ -376,9 +376,6 @@ task_patchelf() {
 
 task_lua() {
 	start_build lua Lua || return 0
-	if fgrep -q 'This is Lua 5.3.5,' README ; then
-		sed -i '/^R=/s/4/5/' Makefile
-	fi
 	eval `make pc | grep ^version=`
 	patch -p1 < $root/lua-relocatable.patch
 	make INSTALL_TOP="$PREFIX" MYCFLAGS="-DLUA_COMPAT_5_3 -DLUA_COMPAT_5_2 -DLUA_COMPAT_5_1 $CFLAGS -fPIC" LUA_A="liblua.so.$version" AR="\$(CC) -shared -ldl -lm -Wl,-soname,liblua.so.${version%.*} -o" RANLIB=true ALL='$(LUA_A)' linux $makearg


### PR DESCRIPTION
As suggested in #565 here some updates for the AppImage and Flatpak builds:
FFmpeg 4.2.4 -> 4.4.1
dav1d 0.8.1 -> 0.9.2
Lua 5.3.6 -> 5.4.3
SDL 2.0.14 -> 2.0.16
SQLite 3.34.1 -> 3.36.0
libjpeg-turbo 2.0.6 -> 2.1.2
OpenCV 4.5.1 -> 4.5.4
Free Pascal 3.2.0 -> 3.2.2
OpenSSL 1.1.1j -> 1.1.1l (only used at build time)