### PR TITLE
Add PopUpFG to themes

### DIFF
--- a/game/themes/Deluxe/Blue.ini
+++ b/game/themes/Deluxe/Blue.ini
@@ -209,6 +209,7 @@ JumpToBG    = [menu]jumpToBg.png
 SongMenuBG  = [menu]songMenuBg.png
 SongMenuSelectBG  = [menu]songMenuSelectBg.png
 PopUpBG     = [menu]popUpBG.png
+PopUpFG     = [menu]popUpFG.png
 
 
 # # # N O T E S # # #

--- a/game/themes/Deluxe/Blue.ini
+++ b/game/themes/Deluxe/Blue.ini
@@ -208,6 +208,7 @@ Leiste2     = [special]bar2.png
 JumpToBG    = [menu]jumpToBg.png
 SongMenuBG  = [menu]songMenuBg.png
 SongMenuSelectBG  = [menu]songMenuSelectBg.png
+
 PopUpBG     = [menu]popUpBG.png
 PopUpFG     = [menu]popUpFG.png
 

--- a/game/themes/Deluxe/Blue.ini
+++ b/game/themes/Deluxe/Blue.ini
@@ -88,7 +88,7 @@ TimeBar1      = [sing]timeBarBG.png
 
 #the time progress bar  (not skinned in this theme :P )
 TimeBar      = [sing]timeBar.jpg
-  
+
 #linebonus, the thing that pop ups at the score
 LineBonusBack  = [sing]lineBonusPopUp.png
 

--- a/game/themes/Deluxe/Fall.ini
+++ b/game/themes/Deluxe/Fall.ini
@@ -209,6 +209,7 @@ JumpToBG    = [menu]jumpToBg.png
 SongMenuBG  = [menu]songMenuBg.png
 SongMenuSelectBG  = [menu]songMenuSelectBg.png
 PopUpBG     = [menu]popUpBG.png
+PopUpFG     = [menu]popUpFG.png
 
 
 # # # N O T E S # # #

--- a/game/themes/Deluxe/Fall.ini
+++ b/game/themes/Deluxe/Fall.ini
@@ -208,6 +208,7 @@ Leiste2     = [special]bar2.png
 JumpToBG    = [menu]jumpToBg.png
 SongMenuBG  = [menu]songMenuBg.png
 SongMenuSelectBG  = [menu]songMenuSelectBg.png
+
 PopUpBG     = [menu]popUpBG.png
 PopUpFG     = [menu]popUpFG.png
 

--- a/game/themes/Deluxe/Ocean.ini
+++ b/game/themes/Deluxe/Ocean.ini
@@ -209,6 +209,7 @@ JumpToBG    = [menu]jumpToBg.png
 SongMenuBG  = [menu]songMenuBg.png
 SongMenuSelectBG  = [menu]songMenuSelectBg.png
 PopUpBG     = [menu]popUpBG.png
+PopUpFG     = [menu]popUpFG.png
 
 
 # # # N O T E S # # #

--- a/game/themes/Deluxe/Ocean.ini
+++ b/game/themes/Deluxe/Ocean.ini
@@ -112,7 +112,7 @@ SongName       = [sing]SongName.png
 
 # # # S C O R E / T O P 5 # # #
 ScoreBox        = [score]box.png
-ScoreGlassBox   = [score]glass_box.png 
+ScoreGlassBox   = [score]glass_box.png
 ScoreLevel      = [score]level.png
 ScoreLevelRound = [score]levelRound.png
 

--- a/game/themes/Deluxe/Ocean.ini
+++ b/game/themes/Deluxe/Ocean.ini
@@ -208,6 +208,7 @@ Leiste2     = [special]bar2.png
 JumpToBG    = [menu]jumpToBg.png
 SongMenuBG  = [menu]songMenuBg.png
 SongMenuSelectBG  = [menu]songMenuSelectBg.png
+
 PopUpBG     = [menu]popUpBG.png
 PopUpFG     = [menu]popUpFG.png
 
@@ -236,7 +237,6 @@ NotePlainRightRap = [rap]notesPlainRight.png
 NoteBGLeftRap     = [rap]notesBgLeft.png
 NoteBGMidRap      = [rap]notesBgMid.png
 NoteBGRightRap    = [rap]notesBgRight.png
-
 
 # # # E F F E C T S # # #
 NoteStar        = [effect]goldenNoteStar.png

--- a/game/themes/Deluxe/Ribbon.ini
+++ b/game/themes/Deluxe/Ribbon.ini
@@ -209,6 +209,7 @@ JumpToBG    = [menu]jumpToBg.png
 SongMenuBG  = [menu]songMenuBg.png
 SongMenuSelectBG  = [menu]songMenuSelectBg.png
 PopUpBG     = [menu]popUpBG.png
+PopUpFG     = [menu]popUpFG.png
 
 
 # # # N O T E S # # #

--- a/game/themes/Deluxe/Ribbon.ini
+++ b/game/themes/Deluxe/Ribbon.ini
@@ -208,6 +208,7 @@ Leiste2     = [special]bar2.png
 JumpToBG    = [menu]jumpToBg.png
 SongMenuBG  = [menu]songMenuBg.png
 SongMenuSelectBG  = [menu]songMenuSelectBg.png
+
 PopUpBG     = [menu]popUpBG.png
 PopUpFG     = [menu]popUpFG.png
 
@@ -236,7 +237,6 @@ NotePlainRightRap = [rap]notesPlainRight.png
 NoteBGLeftRap     = [rap]notesBgLeft.png
 NoteBGMidRap      = [rap]notesBgMid.png
 NoteBGRightRap    = [rap]notesBgRight.png
-
 
 # # # E F F E C T S # # #
 NoteStar        = [effect]goldenNoteStar.png

--- a/game/themes/Deluxe/Summer.ini
+++ b/game/themes/Deluxe/Summer.ini
@@ -209,6 +209,7 @@ JumpToBG    = [menu]jumpToBg.png
 SongMenuBG  = [menu]songMenuBg.png
 SongMenuSelectBG  = [menu]songMenuSelectBg.png
 PopUpBG     = [menu]popUpBG.png
+PopUpFG     = [menu]popUpFG.png
 
 
 # # # N O T E S # # #

--- a/game/themes/Deluxe/Summer.ini
+++ b/game/themes/Deluxe/Summer.ini
@@ -208,6 +208,7 @@ Leiste2     = [special]bar2.png
 JumpToBG    = [menu]jumpToBg.png
 SongMenuBG  = [menu]songMenuBg.png
 SongMenuSelectBG  = [menu]songMenuSelectBg.png
+
 PopUpBG     = [menu]popUpBG.png
 PopUpFG     = [menu]popUpFG.png
 
@@ -236,7 +237,6 @@ NotePlainRightRap = [rap]notesPlainRight.png
 NoteBGLeftRap     = [rap]notesBgLeft.png
 NoteBGMidRap      = [rap]notesBgMid.png
 NoteBGRightRap    = [rap]notesBgRight.png
-
 
 # # # E F F E C T S # # #
 NoteStar        = [effect]goldenNoteStar.png

--- a/game/themes/Deluxe/Winter.ini
+++ b/game/themes/Deluxe/Winter.ini
@@ -209,6 +209,7 @@ JumpToBG    = [menu]jumpToBg.png
 SongMenuBG  = [menu]songMenuBg.png
 SongMenuSelectBG  = [menu]songMenuSelectBg.png
 PopUpBG     = [menu]popUpBG.png
+PopUpFG     = [menu]popUpFG.png
 
 
 # # # N O T E S # # #

--- a/game/themes/Deluxe/Winter.ini
+++ b/game/themes/Deluxe/Winter.ini
@@ -208,6 +208,7 @@ Leiste2     = [special]bar2.png
 JumpToBG    = [menu]jumpToBg.png
 SongMenuBG  = [menu]songMenuBg.png
 SongMenuSelectBG  = [menu]songMenuSelectBg.png
+
 PopUpBG     = [menu]popUpBG.png
 PopUpFG     = [menu]popUpFG.png
 
@@ -236,7 +237,6 @@ NotePlainRightRap = [rap]notesPlainRight.png
 NoteBGLeftRap     = [rap]notesBgLeft.png
 NoteBGMidRap      = [rap]notesBgMid.png
 NoteBGRightRap    = [rap]notesBgRight.png
-
 
 # # # E F F E C T S # # #
 NoteStar        = [effect]goldenNoteStar.png

--- a/game/themes/Modern/Blue.ini
+++ b/game/themes/Modern/Blue.ini
@@ -88,7 +88,7 @@ TimeBar1      = [sing]timeBarBG.png
 
 #the time progress bar  (not skinned in this theme :P )
 TimeBar      = [sing]timeBar.jpg
-  
+
 #linebonus, the thing that pop ups at the score
 LineBonusBack  = [sing]lineBonusPopUp.png
 

--- a/game/themes/Modern/Winter.ini
+++ b/game/themes/Modern/Winter.ini
@@ -208,7 +208,9 @@ Leiste2     = [special]bar2.png
 JumpToBG    = [menu]jumpToBg.png
 SongMenuBG  = [menu]songMenuBg.png
 SongMenuSelectBG  = [menu]songMenuSelectBg.png
+
 PopUpBG     = [menu]popUpBG.png
+PopUpFG     = [menu]popUpFG.png
 
 
 # # # N O T E S # # #


### PR DESCRIPTION
This should fix #602

Only the theme `Modern/Blue.ini` had the property `PopUpFG` set, leading to crashes for other themes when entering Options / Record. This sets this value everywhere to the same image as in the working theme since `PopUpBG` is identical, too, and this seems a sensible default accordingly.