### PR TITLE
Song Editor: change BPM value via F5

### DIFF
--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -2963,8 +2963,8 @@ begin
         for NoteIndex := 0 to Tracks[TrackIndex].Lines[LineIndex].HighNote do
           Tracks[TrackIndex].Lines[LineIndex].Notes[NoteIndex].StartBeat := Tracks[TrackIndex].Lines[LineIndex].Notes[NoteIndex].StartBeat - FirstBeat;
 
-    // adjust GAP accordingly
-    CurrentSong.GAP := round((CurrentSong.GAP + (FirstBeat * 15000) / CurrentSong.BPM[0].BPM) * 100) / 100;
+    // adjust GAP accordingly, round to nearest integer value (fractional GAPs make no sense)
+    CurrentSong.GAP := round((CurrentSong.GAP + (FirstBeat * 15000) / (CurrentSong.BPM[0].BPM / 4)));
 
     // adjust medley tags accordingly
     if (MedleyNotes.isStart) then


### PR DESCRIPTION
Changing the BPM in this way will cause a recalculation of all note timings (start + duration). This differs from adapting the BPM value via +/- which does not change any not timings. The use case for this is to correct wrong BPMs of songs that are otherwise synchronous. A note’s start beat is always rounded up (potentially starting a little later than what would be exact), a note’s duration is always rounded down (potentially lasting a little shorter than what would be exact).