### PR TITLE
make the timebar display correctly when using START values

### DIFF
--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -50,9 +50,6 @@ procedure SingDrawLine(Left, Top, Right: real; Track, PlayerNumber: integer; Lin
 procedure SingDrawPlayerLine(X, Y, W: real; Track, PlayerIndex: integer; LineSpacing: integer = 15);
 procedure SingDrawPlayerBGLine(Left, Top, Right: real; Track, PlayerIndex: integer; LineSpacing: integer = 15);
 
-// TimeBar
-procedure SingDrawTimeBar();
-
 //Draw Editor NoteLines
 procedure EditDrawLine(X, YBaseNote, W, H: real; Track: integer; NumLines: integer = 10);
 procedure EditDrawBorderedBox(X, Y, W, H: integer; FillR: real = 0.9; FillG: real = 0.9; FillB: real = 0.9; FillAlpha: real = 0.5);
@@ -1176,10 +1173,6 @@ begin
   else
     LyricEngine := ScreenSing.Lyrics;
 
-  // draw time-bar
-  if (ScreenSing.Settings.TimeBarVisible) then
-    SingDrawTimeBar();
-
   // draw lyrics
   if (ScreenSing.Settings.LyricsVisible) then
   begin
@@ -1960,68 +1953,6 @@ begin
   end;
   glEnd;
   glDisable(GL_BLEND);
-end;
-
-procedure SingDrawTimeBar();
-var
-  x, y:           real;
-  width, height:  real;
-  LyricsProgress: real;
-  CurLyricsTime:  real;
-  TotalTime:      real;
-
-begin
-  x := Theme.Sing.StaticTimeProgress.x;
-  y := Theme.Sing.StaticTimeProgress.y;
-
-  width  := Theme.Sing.StaticTimeProgress.w;
-  height := Theme.Sing.StaticTimeProgress.h;
-
-  glColor4f(Theme.Sing.StaticTimeProgress.ColR,
-            Theme.Sing.StaticTimeProgress.ColG,
-            Theme.Sing.StaticTimeProgress.ColB, 1); //Set Color
-
-  glEnable(GL_TEXTURE_2D);
-  glEnable(GL_BLEND);
-
-  glBindTexture(GL_TEXTURE_2D, Tex_TimeProgress.TexNum);
-
-  glBegin(GL_QUADS);
-    glTexCoord2f(0, 0);
-    glVertex2f(x, y);
-
-    if ScreenSong.Mode = smMedley then
-    begin
-      CurLyricsTime := LyricsState.GetCurrentTime() - ScreenSing.MedleyStart;
-      TotalTime := ScreenSing.MedleyEnd - ScreenSing.MedleyStart;
-    end
-    else
-    begin
-      CurLyricsTime := LyricsState.GetCurrentTime();
-      TotalTime := LyricsState.TotalTime;
-    end;
-
-    if (CurLyricsTime > 0) and
-       (TotalTime > 0) then
-    begin
-      LyricsProgress := CurLyricsTime / TotalTime;
-      // avoid that the bar "overflows" for inaccurate song lengths
-      if LyricsProgress > 1.0 then
-        LyricsProgress := 1.0;
-      glTexCoord2f((width * LyricsProgress) / 8, 0);
-      glVertex2f(x + width * LyricsProgress, y);
-
-      glTexCoord2f((width * LyricsProgress) / 8, 1);
-      glVertex2f(x + width * LyricsProgress, y + height);
-    end;
-
-    glTexCoord2f(0, 1);
-    glVertex2f(x, y + height);
-  glEnd;
-
- glDisable(GL_TEXTURE_2D);
- glDisable(GL_BLEND);
- glcolor4f(1, 1, 1, 1);
 end;
 
 procedure SingDrawJukeboxTimeBar();

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -1506,7 +1506,7 @@ begin
   end;
 
   // draw info lyric bar if not medley
-  if (ScreenSong.Mode <> smMedley) and (ScreenSing.Settings.TimeBarVisible) then
+  if (ScreenSing.Settings.TimeBarVisible) then
     DrawInfoLyricBar;
 
   // always draw custom items
@@ -1776,10 +1776,22 @@ begin
   h := Theme.Sing.StaticTimeProgress.h;
 
   //calculate total singing beats of song
-  SongStart := CurrentSong.BPM[0].BPM*CurrentSong.Start/60;
-  SongEnd := CurrentSong.BPM[0].BPM*TotalTime/60;
-  SongDuration := SongEnd - SongStart;
-  gapInBeats := CurrentSong.BPM[0].BPM*CurrentSong.GAP/1000/60;
+  if ScreenSong.Mode = smMedley then
+  begin
+    SongStart := CurrentSong.Medley.StartBeat - CurrentSong.BPM[0].BPM*CurrentSong.Medley.FadeIn_time/60;
+    if SongStart < 0 then
+      SongStart := 0;
+    SongEnd := CurrentSong.Medley.EndBeat + CurrentSong.BPM[0].BPM*CurrentSong.Medley.FadeOut_time/60;
+    SongDuration := SongEnd - SongStart;
+    gapInBeats := 0;
+  end
+  else
+  begin
+    SongStart := CurrentSong.BPM[0].BPM*CurrentSong.Start/60;
+    SongEnd := CurrentSong.BPM[0].BPM*TotalTime/60;
+    SongDuration := SongEnd - SongStart;
+    gapInBeats := CurrentSong.BPM[0].BPM*CurrentSong.GAP/1000/60;
+  end;
 
   // draw sentence boxes
   for CurrentTrack := 0 to High(Tracks) do //for P1 of duet or solo lyrics, P2 of duet,..
@@ -1797,6 +1809,7 @@ begin
     for LineIndex := 0 to numLines - 1 do
     begin
       if (Tracks[CurrentTrack].Lines[LineIndex].Notes = nil) then Continue;
+      if (ScreenSong.Mode = smMedley) and (Tracks[CurrentTrack].Lines[LineIndex].Notes[0].StartBeat < SongStart) then Continue;
       pos := (gapInBeats + Tracks[CurrentTrack].Lines[LineIndex].Notes[0].StartBeat - SongStart) / SongDuration*w;
       br := (Tracks[CurrentTrack].Lines[LineIndex].Notes[Tracks[CurrentTrack].Lines[LineIndex].HighNote].StartBeat +
                 Tracks[CurrentTrack].Lines[LineIndex].Notes[Tracks[CurrentTrack].Lines[LineIndex].HighNote].Duration -

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -1758,6 +1758,7 @@ var
   SongStart:       real;
   SongEnd:         real;
   SongDuration:    real;
+  gapInBeats:      real;
 
   pos:             real;
   br:              real;
@@ -1778,6 +1779,7 @@ begin
   SongStart := CurrentSong.BPM[0].BPM*CurrentSong.Start/60;
   SongEnd := CurrentSong.BPM[0].BPM*TotalTime/60;
   SongDuration := SongEnd - SongStart;
+  gapInBeats := CurrentSong.BPM[0].BPM*CurrentSong.GAP/1000/60;
 
   // draw sentence boxes
   for CurrentTrack := 0 to High(Tracks) do //for P1 of duet or solo lyrics, P2 of duet,..
@@ -1795,7 +1797,7 @@ begin
     for LineIndex := 0 to numLines - 1 do
     begin
       if (Tracks[CurrentTrack].Lines[LineIndex].Notes = nil) then Continue;
-      pos := (Tracks[CurrentTrack].Lines[LineIndex].Notes[0].StartBeat - SongStart) / SongDuration*w;
+      pos := (gapInBeats + Tracks[CurrentTrack].Lines[LineIndex].Notes[0].StartBeat - SongStart) / SongDuration*w;
       br := (Tracks[CurrentTrack].Lines[LineIndex].Notes[Tracks[CurrentTrack].Lines[LineIndex].HighNote].StartBeat +
                 Tracks[CurrentTrack].Lines[LineIndex].Notes[Tracks[CurrentTrack].Lines[LineIndex].HighNote].Duration -
                 Tracks[CurrentTrack].Lines[LineIndex].Notes[0].StartBeat) / SongDuration*w; //br = last note of sentence position + its duration - first note of sentence position
@@ -1810,7 +1812,7 @@ begin
   end;
 
   // draw progress indicator
-  br := (LyricsState.CurrentBeat - SongStart) / SongDuration*w;
+  br := (gapInBeats + LyricsState.CurrentBeat - SongStart) / SongDuration*w;
   glColor4f(Theme.Sing.StaticTimeProgress.ColR,
              Theme.Sing.StaticTimeProgress.ColG,
              Theme.Sing.StaticTimeProgress.ColB, 1); //Set Color


### PR DESCRIPTION
fixes #610

I moved all the timebar-drawing logic to `UScreenSingView` and made it use less variables. It should also properly respect the START value now.

Some edge cases and other things that someone should check on a current USDX before merging:
- if someone Ctrl^Left's a lot during a song with a high START value, the progress bar starts going 'negative'. I consider this more as a bug of being able to Ctrl^Left there in the first place, but it might be a regression compared to current behaviour.
- the progress bar will overflow into the time left (or whatever is in the bottom right) if the song doesn't properly end for some reason. See #600. This is a regression compared to current drawing behaviour.
- running a Medley doesn't draw anything (no progress, no note blocks) but did that ever work in the first place? IIRC only the progress bar but not the note blocks (can someone check?) and if so, not sure how useful/critical it is for this PR.