### PR TITLE
make the rendering of the oscilloscope significantly less expensive

### DIFF
--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -363,6 +363,9 @@ var
   Sound:       TCaptureBuffer;
   MaxX, MaxY:  real;
   Col: TRGB;
+const
+  // arbitrarily chosen, but this makes it draw only 4096/SampleIndexStep line segments
+  SampleIndexStep = 32;
 begin;
   Sound := AudioInputProcessor.Sound[NrSound];
 
@@ -382,13 +385,16 @@ begin;
   MaxX := W-1;
   MaxY := (H-1) / 2;
 
+  SampleIndex := 0;
+
   Sound.LockAnalysisBuffer();
 
   glBegin(GL_LINE_STRIP);
-    for SampleIndex := 0 to High(Sound.AnalysisBuffer) do
+    while SampleIndex < High(Sound.AnalysisBuffer) do
     begin
       glVertex2f(X + MaxX * SampleIndex/High(Sound.AnalysisBuffer),
                  Y + MaxY * (1 - Sound.AnalysisBuffer[SampleIndex]/-Low(Smallint)));
+      SampleIndex := SampleIndex + SampleIndexStep;
     end;
   glEnd;
 


### PR DESCRIPTION
I played around a bit with gprof the other day, and noticed that especially when using six players, having oscilloscope enabled had a huge impact on performance.

This patch only renders 1/32 of the (4096) data points in the microphone data, which should be a close enough approximation for the oscilloscope to be useful. I didn't notice any negative side effects by doing this, perhaps the line is a bit thinner but that's about it.

The `32` is fairly arbitrarily chosen. I tried various powers of two, 64 was too unprecise/blocky at higher frequencies (it's possible this also happens with 32, but I can't reach those frequencies) whereas with 16 it looked pretty much the same as with 32.

An alternative (and probably even faster) approach would be to (also) only use only every nth sample when getting it from the microphone, but that also affects various other parts of the code, plus I don't know how 'long' those 4096 samples actually last. You'd also technically be throwing away some of the data.