### PR TITLE
optimize the CircularAverageMagnitudeDifference method

### DIFF
--- a/src/base/URecord.pas
+++ b/src/base/URecord.pas
@@ -489,17 +489,22 @@ var
   ToneIndex:   integer;
   Correlation: TCorrelationArray;
   SampleIndex: integer; // index of sample to analyze
+const
+  // the value is fairly arbitrarily chosen, but this makes it analyze only 4096/SampleIndexStep samples
+  SampleIndexStep = 16;
 begin
   // accumulate the magnitude differences for samples in AnalysisBuffer
   for ToneIndex := 0 to NumHalftones-1 do
   begin
     Correlation[ToneIndex] := 0;
-    for SampleIndex := 0 to (AnalysisBufferSize-1) do
+    SampleIndex := 0;
+    while SampleIndex < AnalysisBufferSize - 1 do
     begin
       // Suggestion for calculation efficiency improvement from deuteragenie:
       // Replacing 'i mod buffersize' by 'i & (buffersize-1)' when i is positive and buffersize is a power of two should speed the modulo compuation by 5x-10x
       //Correlation[ToneIndex] += Abs(AnalysisBuffer[(SampleIndex+Delays[ToneIndex]) mod AnalysisBufferSize] - AnalysisBuffer[SampleIndex]);
       Correlation[ToneIndex] := Correlation[ToneIndex] + Abs(AnalysisBuffer[(SampleIndex+Delays[ToneIndex]) and (AnalysisBufferSize-1)] - AnalysisBuffer[SampleIndex]);
+      SampleIndex := SampleIndex + SampleIndexStep;
     end;
     Correlation[ToneIndex] := Correlation[ToneIndex] / AnalysisBufferSize;
   end;


### PR DESCRIPTION
This is very similar to #619 but checks 1/16 instead of 1/32 of the (4096) samples. Especially when using six players, this gave me a significant improvement in performance.
The `16` was established mostly by a bit of trial and error but is ultimately just some arbitrary value.

**WARNING:** This isn't as tested as the optimization in 619. Unlike 619, this one also actually influences what ultimately gets detected. It could be that this has more impact on very low or very high frequencies which I cannot reach. If that is the case however, it's fairly trivial to split out how many samples it uses for every entry in the `Correlation` array. Perhaps it only really needs more samples for very high frequencies, but this gets looped so often, it's worth having the code do as little as possible.