### PR TITLE
WIP #621 actually use multithreaded decoding

### DIFF
--- a/src/lib/ffmpeg-4.0/avcodec.pas
+++ b/src/lib/ffmpeg-4.0/avcodec.pas
@@ -273,7 +273,7 @@ type
     we_do_not_use_bits_per_raw_sample: cint;
     we_do_not_use_lowres: cint;
     we_do_not_use_coded_frame: PAVFrame;
-    we_do_not_use_thread_count: cint;
+    thread_count: cint;
     we_do_not_use_thread_type: cint;
     we_do_not_use_active_thread_type: cint;
     we_do_not_use_thread_safe_callbacks: cint;

--- a/src/lib/ffmpeg-5.0/avcodec.pas
+++ b/src/lib/ffmpeg-5.0/avcodec.pas
@@ -239,7 +239,7 @@ type
     we_do_not_use_bits_per_coded_sample: cint;
     we_do_not_use_bits_per_raw_sample: cint;
     we_do_not_use_lowres: cint;
-    we_do_not_use_thread_count: cint;
+    thread_count: cint;
     we_do_not_use_thread_type: cint;
     we_do_not_use_active_thread_type: cint;
     we_do_not_use_thread_safe_callbacks: cint;

--- a/src/media/UVideo.pas
+++ b/src/media/UVideo.pas
@@ -701,8 +701,10 @@ begin
     // fail if called concurrently by different threads.
     FFmpegCore.LockAVCodec();
     try
+        {$IF LIBAVCODEC_VERSION >= 54023000}
         // by setting this explicitly to 0, it won't default to a single thread
         fCodecContext^.thread_count := 0;
+        {$IFEND}
 
         {$IF LIBAVCODEC_VERSION >= 53005000}
         errnum := avcodec_open2(fCodecContext, fCodec, nil);

--- a/src/media/UVideo.pas
+++ b/src/media/UVideo.pas
@@ -701,6 +701,9 @@ begin
     // fail if called concurrently by different threads.
     FFmpegCore.LockAVCodec();
     try
+        // by setting this explicitly to 0, it won't default to a single thread
+        fCodecContext^.thread_count := 0;
+
         {$IF LIBAVCODEC_VERSION >= 53005000}
         errnum := avcodec_open2(fCodecContext, fCodec, nil);
         {$ELSE}


### PR DESCRIPTION
These are the two line changes for #621 that on my local machines, more or less double the framerate when using 4k videos, and makes seeking in 1080p much faster. Obviously this comes at higher CPU usage, but it uses CPU that wasn't doing anything anyway.

I can't test this for ffmpeg < 5 (because I don't have it). I don't know since which version this is even supported. Simplest solution would probably some some kind of `{$IF...}` around the statement. The branch is open for maintainers because no idea how to do that.