### PR TITLE
Fixed fixing line breaks

### DIFF
--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -2988,7 +2988,7 @@ begin
           2:    LineStart := MaxLineStart - 1;
           3:    LineStart := MaxLineStart - 2;
           else
-            if ((MaxLineStart - MinLineStart) > 4) then
+            if ((MaxLineStart - MinLineStart) >= 4) then
               LineStart := MinLineStart + 2
             else
               LineStart := MaxLineStart;


### PR DESCRIPTION
The case when the difference between the end of the current line and the start of the next line was erroneously handled by the last else, setting the line break to the start of the next line, while it should be handled just like the cases where the gap is greater than 4, namely 2 beats after the end of the current line.