### PR TITLE
add logging to portaudio setup

### DIFF
--- a/src/media/UAudioInput_Portaudio.pas
+++ b/src/media/UAudioInput_Portaudio.pas
@@ -375,6 +375,7 @@ begin
     // retrieve device-name
     deviceName := ConvertPaStringToUTF8(paDeviceInfo^.name);
     paDevice.Name := UnifyDeviceName(deviceName, deviceIndex);
+    Log.LogStatus('Attempting to configure InputDevice "' + paDevice.Name + '"', 'Portaudio.EnumDevices');
     paDevice.PaDeviceIndex := paDeviceIndex;
 
     sampleRate := paDeviceInfo^.defaultSampleRate;


### PR DESCRIPTION
In the past I've experienced EAccessViolation crashes during initial loading (there's also plenty of issues about it). These were quite hard to debug, since the Error.log only logs the name of a device if either:
- it fails to load in a way that is properly safeguarded against
- it succeeds

Particular device names this has happened with in the past were (alsa) things named `speexrate` or `vdownmix`, but it can probably happen with any device. Maybe it has bad drivers, or maybe USDX doesn't properly catch something, but either way, because the name never gets printed anywhere, it's near impossible to even make suggestions.

This PR adds an extra line of output in Error.log as soon as the device name is available, so that if the last line of Error.log is a line like that, we at least know which device is causing the problem. This PR only aims to make identifying the problematic device.

Example output:
```
STATUS: Attempting to configure InputDevice "Auna Mic CM900: USB Audio (hw:0,0)" [Portaudio.EnumDevices]
STATUS: InputDevice "Auna Mic CM900: USB Audio (hw:0,0)"@1x44100Hz (0.1sec) [Portaudio.EnumDevices]
STATUS: Attempting to configure InputDevice "HDA Intel PCH: VT1708S Analog (hw:1,0)" [Portaudio.EnumDevices]
STATUS: InputDevice "HDA Intel PCH: VT1708S Analog (hw:1,0)"@2x44100Hz (0.1sec) [Portaudio.EnumDevices]
STATUS: Attempting to configure InputDevice "HD Pro Webcam C920: USB Audio (hw:2,0)" [Portaudio.EnumDevices]
STATUS: InputDevice "HD Pro Webcam C920: USB Audio (hw:2,0)"@2x32000Hz (0.1sec) [Portaudio.EnumDevices]
```
The lines starting with `Attempting to configure` are the one this PR adds.

I should probably also do these for the other audio systems (Bass and SDL) but I'm currently not able to test those.