### PR TITLE
add some basic logging to bass audio

### DIFF
--- a/src/media/UAudioInput_Bass.pas
+++ b/src/media/UAudioInput_Bass.pas
@@ -398,6 +398,7 @@ begin
       Descr := DecodeStringUTF8(DeviceInfo.name, encAuto);
 
       BassDevice.Name := UnifyDeviceName(Descr, DeviceIndex);
+      Log.LogStatus('Attempting to configure InputDevice "' + BassDevice.Name + '"', 'Bass.EnumDevices');
 
       // zero info-struct as some fields might not be set (e.g. freq is just set on Vista and MacOSX)
       FillChar(RecordInfo, SizeOf(RecordInfo), 0);
@@ -430,6 +431,11 @@ begin
 
       // init list for capture buffers per channel
       SetLength(BassDevice.CaptureChannel, BassDevice.AudioFormat.Channels);
+
+      Log.LogStatus('InputDevice "'+BassDevice.Name+'"@' +
+      IntToStr(BassDevice.AudioFormat.Channels)+'x'+
+      FloatToStr(BassDevice.AudioFormat.SampleRate)+'Hz' ,
+                     'Bass.EnumDevices');
 
       BassDevice.MicSource := -1;
       BassDevice.SourceRestore := -1;


### PR DESCRIPTION
similar to #637, this adds some very basic logging when using Bass as AudioInput.

Log entries look like this:
```
STATUS: Attempting to configure InputDevice "Microphone (Steam Streaming Microphone)" [Bass.EnumDevices]
STATUS: InputDevice "Microphone (Steam Streaming Microphone)"@1x44100Hz [Bass.EnumDevices]
STATUS: Attempting to configure InputDevice "Microphone (USB Audio Device)" [Bass.EnumDevices]
STATUS: InputDevice "Microphone (USB Audio Device)"@1x48000Hz [Bass.EnumDevices]
```

I could not find if this had a similar thing for latency like PortAudio does, so I left that out. There's also more code (that could potentially cause issues) after it compared to PortAudio, but regardless, it's still better than _no_ logging at all.