### PR TITLE
remove dependencies on Lazarus-specific packages

### DIFF
--- a/src/base/UFilesystem.pas
+++ b/src/base/UFilesystem.pas
@@ -38,8 +38,6 @@ uses
   Classes,
   {$IFDEF MSWINDOWS}
   Windows,
-  LazUTF8Classes,
-  LazFileUtils,
   {$ENDIF}
   UPath;
 
@@ -293,7 +291,7 @@ end;
 
 function TFileSystemImpl.FileExists(const Name: IPath): boolean;
 begin
-  Result := FileExistsUTF8(Name.ToUTF8());//SysUtils.FileExists(Name.ToWide());
+  Result := SysUtils.FileExists(Name.ToWide());
 end;
 
 function TFileSystemImpl.FileGetAttr(const FileName: IPath): Cardinal;

--- a/src/base/UFont.pas
+++ b/src/base/UFont.pas
@@ -45,10 +45,6 @@ interface
 {$DEFINE ENABLE_FT_FACE_CACHE}
 
 uses
-  {$IF Defined(MSWINDOWS)}
-  LazUTF8,
-  LazUTF8Classes,
-  {$IFEND}
   FreeType,
   dglOpenGL,
   sdl2,
@@ -1513,37 +1509,20 @@ end;
 
  constructor TFTFontFace.Create(const Filename: IPath; Size: integer);
  var
-   {$IF Defined(MSWINDOWS)}
-   SourceFile: TFileStreamUTF8;
-   {$IFEND}
    lengthvar: Integer;
    b1: Integer;
    arraylength: Int64;
  begin
    inherited Create();
-   {$IF Defined(MSWINDOWS)}
-   SourceFile := nil;
-   {$IFEND}
    b1:=3;
 
    fFilename := Filename;
    fSize := Size;
    try
-     {$IF Defined(MSWINDOWS)}
-     SourceFile := TFileStreamUTF8.Create(Filename.ToUTF8(true), fmOpenRead);
-     arraylength:=SourceFile.Size;
-     SetLength(byarr1, arraylength+1);
-     SourceFile.Read(byarr1[0], arraylength);
-     b1 := FT_New_Memory_Face(TFreeType.GetLibrary(),@byarr1[0],arraylength,0,fFace);
-     {$ELSE}
      b1 := FT_New_Face(TFreeType.GetLibrary(), PChar(Filename.ToNative), 0, fFace);
-     {$IFEND}
    except
      raise EFontError.Create('FT_New_Face: Error - Could not load font file to memory on Windows '''  + Filename.ToNative + '''');
    end;
-   {$IF Defined(MSWINDOWS)}
-   SourceFile.Destroy;
-   {$IFEND}
    // load font information
    if (b1 <> 0) then
      raise EFontError.Create('FT_New_Face: Could not load font '''  + Filename.ToNative + '''');

--- a/src/base/UPath.pas
+++ b/src/base/UPath.pas
@@ -38,11 +38,6 @@ uses
   SysUtils,
   Classes,
   IniFiles,
-  {$IFDEF MSWINDOWS}
-  LazFileUtils,
-  LazUTF8,
-  LazUTF8Classes,
-  {$ENDIF}
   UConfig,
   UUnicodeStringHelper,
   SDL2;
@@ -1110,14 +1105,7 @@ end;
 
 constructor TBinaryFileStream.Create(const FileName: IPath; Mode: word);
 begin
-{$IFDEF MSWINDOWS}
-if FileExistsUTF8(FileName.ToUTF8()) or (Mode = fmCreate) then
-  inherited Create(Utf8ToAnsi(FileName.ToUTF8()), Mode)
-else
-  raise EInOutError.Create('File does not exist and Open-action is read, not create: ' + FileName.ToNative() + ' in UPath.TBinaryFileStream.Create');
-{$ELSE}
   inherited Create(FileName.ToNative(), Mode);
-{$ENDIF}
 end;
 
 { TTextStream }

--- a/src/base/USongs.pas
+++ b/src/base/USongs.pas
@@ -44,7 +44,6 @@ uses
   Classes,
   {$IFDEF MSWINDOWS}
     Windows,
-    LazUTF8Classes,
   {$ELSE}
     {$IFNDEF DARWIN}
     syscall,

--- a/src/menu/UMenuText.pas
+++ b/src/menu/UMenuText.pas
@@ -99,11 +99,7 @@ uses
   UGraphic,
   UDisplay,
   UUnicodeStringHelper,
-  {$IFDEF MSWINDOWS}
-    LazUTF8,
-  {$ELSE}
-    UUnicodeUtils,
-  {$ENDIF}
+  UUnicodeUtils,
   StrUtils;
 
 procedure TText.SetSelect(Value: boolean);
@@ -282,11 +278,7 @@ end;
 
 procedure TText.DeleteLastLetter;
 begin
-  {$IFDEF MSWINDOWS}
-  SetText(UTF8Copy(TextString, 1, UTF8Length(TextString)-1));
-  {$ELSE}
   SetText(UTF8Copy(TextString, 1, LengthUTF8(TextString)-1));
-  {$ENDIF}
 end;
 
 procedure TText.Draw;

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -52,10 +52,6 @@ uses
   UThemes,
   UTime,
   UUnicodeStringHelper,
-  {$IFDEF MSWINDOWS}
-  LazUTF8Classes,
-  LazUTF8,
-  {$ENDIF}
   sdl2,
   SysUtils;
 


### PR DESCRIPTION
FPC 3.x can handle these by itself. From how I understand it, `configure.ac` already requires a minimum version of 3.

My Windows machine can still read my variety of test songs in a multitude of encodings and weird file names, but _ideally_:

- [ ] someone with lots of Japanese / Chinese / Cyrillic stuff checks it still loads the same number of songs for them (alternatively: can someone point me towards a couple dozen real-world txt's?)
- [ ] someone that does use the Lazarus IDE verifies that it's still happy about these changes (still compiles + the IDE still understands these files wrt syntax highlighting etc)

Reason for wanting to get rid of the Lazarus packages is that it is actually possible (through MSYS at least) to follow the same compilation instructions as those for other platforms (this aside from me having _no idea_ how Lazarus IDE works)