### PR TITLE
Fix Autotools issues

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -7,4 +7,9 @@ test -n "$srcdir" && cd "$srcdir"
 
 echo "Updating build configuration files for USDX, please wait..."
 
-autoreconf -isf
+autoreconf -isfv
+if ! [ -e dists/autogen/config.sub ] ; then
+	# autoreconf < 2.70 relied on automake to install aux files
+	# but didn't run it in projects that don't use automake macros
+	automake -a 2>&1 | grep installing || true
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -41,8 +41,6 @@ AC_PRESERVE_HELP_ORDER
 
 # options for make command
 AC_PROG_MAKE_SET
-# find tool for ln -s (e.g. uses cp -p for FAT-filesystems)
-AC_LN_S
 # find a program for recursive dir creation
 AC_PROG_MKDIR_P
 # find the best install tool


### PR DESCRIPTION
This PR fixes #643 by calling automake if autoreconf (an old one) didn't install the auxiliary files. The warnings emitted by automake (since this is not an automake project) are suppressed.

While at it avoid a warning emitted by autoconf by dropping the useless test that caused it.