### PR TITLE
attempt to only exclude x86-32 Ubuntu2004

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ image:
 
 configuration:
   - x86-64
-  # (commented ot until someone fixes tis) - x86-32
+  - x86-32
 
 cache:
   - dists/linux/prefix -> dists/linux/dl.sh, dists/linux/tasks.sh
@@ -17,6 +17,9 @@ matrix:
   exclude:
     - image: Visual Studio 2015
       configuration: x86-64
+    # originally disabled on 2022-11-26 by basisbit, this just excludes it in a different way
+    - image: Ubuntu2004
+      configuration: x86-32
 
 for:
   # Windows


### PR DESCRIPTION
towards the end of 2022, b7f4de6 implemented a bit of a brute-force solution to the _one_ failing job (Ubuntu2004 x86-32)

this PR attempts to reenable all of them, except very specifically that one job

**DO NOT MERGE THIS YET,** this PR is here so I can find the CI jobs back later, because the flatpak one(s) take like half an hour (I'll create an issue about that later)
EDIT: it works (and the installer, too!)