### PR TITLE
TAudioConverter: fix SWResample backend

### DIFF
--- a/src/media/UAudioPlayback_SoftMixer.pas
+++ b/src/media/UAudioPlayback_SoftMixer.pas
@@ -449,6 +449,8 @@ begin
   Converter := TAudioConverter_FFmpeg.Create();
   {$ELSEIF Defined(UseSRCResample)}
   Converter := TAudioConverter_SRC.Create();
+//  {$ELSEIF Defined(UseSWResample)}
+//  Converter := TAudioConverter_SWResample.Create();
   {$ELSE}
   Converter := TAudioConverter_SDL.Create();
   {$IFEND}


### PR DESCRIPTION
I tried to build UltraStar Deluxe for MacOS X 10.3.9. This old version can't use recent SDL versions. But when trying to use SDL 2.0.3, some files didn't play correctly, because the resampler in that SDL version supported only a few sample rate combinations. So I switched to the resampler of FFmpeg after fixing some bugs in our code.

I am not yet sure if we should prefer the FFmpeg resampler over the one from SDL in all cases. Flexibility, quality, speed, and delay should be compared first.