### PR TITLE
add some extra audio and video extensions to the editor

### DIFF
--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -4574,9 +4574,9 @@ end;
 
 procedure TScreenEditSub.OnShow;
 const
-  SUPPORTED_EXTS_AUDIO: array[0..2]  of string = ('.mp3', '.ogg', '.m4a');
+  SUPPORTED_EXTS_AUDIO: array[0..4]  of string = ('.mp3', '.flac', '.wav', '.ogg', '.m4a');
   SUPPORTED_EXTS_IMAGE: array[0..1]  of string = ('.jpg', '.png');
-  SUPPORTED_EXTS_VIDEO: array[0..10] of string = ('.avi', '.mov', '.divx', '.mkv', '.mpeg', '.mpg', '.mp4', '.mpeg', '.m2v', '.ts', '.wmv');
+  SUPPORTED_EXTS_VIDEO: array[0..11] of string = ('.avi', '.mov', '.divx', '.mkv', '.mpeg', '.mpg', '.mp4', '.mpeg', '.m2v', '.ts', '.webm', '.wmv');
 var
   FileExt:     IPath;
   Files:       TPathDynArray;


### PR DESCRIPTION
When I make songs, I mostly use flac and wav these days (because lossless). But because those extensions aren't in the array, it won't show the file when you're working on a song. Or worse, it shows a random file from the whitelisted extensions.
It's fine as long as you don't actually edit the field, but it's a bit annoying.

Same for videos really, most videos from youtube these days are webm.