### PR TITLE
improve skip to random song in chessboard/tile mode

### DIFF
--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -3823,21 +3823,17 @@ begin
   end
   else
   begin
+    // it's still off by one in certain cases, will select the first or last overall song
     if TargetInteraction = -1 then
     begin
-      if Target = 0 then
-        TargetInteraction := 0
-      else
+      i := 0;
+      for TargetInteraction := 0 to High(CatSongs.Song) do
       begin
-        i := 0;
-        for TargetInteraction := 0 to High(CatSongs.Song) do
+        if CatSongs.Song[TargetInteraction].Visible then
         begin
-          if CatSongs.Song[i].Visible then
-          begin
-            Inc(i);
-            if Target = i then
-              break;
-          end;
+          Inc(i);
+          if Target = i then
+            break;
         end;
       end;
     end;


### PR DESCRIPTION
I'm pretty sure the entirety of chessboard/tile is off-by-one somewhere, but at least this patch makes it so that if you're going to a random song within a selection (eg playlist or search), it will at least be _somewhat_ usable.

known bugs:
* it will still sometimes select the overall first or last song (even if outside the selection). this is especially noticeable if your selection is limited to only 1 or 2 results.

overall though, considering the current behaviour is _completely_ broken, I'd be in favour of getting this merged (been using it in local builds for well over half a year already).
I'll probably eventually end up redoing the entire class this is in anyway, for there's _so_ many other bugs (covers not spawning deselected in most cases, off-by-ones, it not correctly computing which row an image is on, etc) and in general a lot of duplication, so this is more of a temporary measure.

see also #490. this isn't a 100% fix, and I don't know about playlist usage (it shouldn't be too big of an issue as long as your playlist contains more songs than there are rounds, statistically speaking) but at least in normal song menu usage, if you seach for something and get only a handful of results, chances are you're not going to random anyway.