### PR TITLE
play background music at the preview volume level

### DIFF
--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -1043,6 +1043,7 @@ begin
   if (TBackgroundMusicOption(Ini.BackgroundMusicOption) = bmoOn) and
     (Soundlib.BGMusic <> nil) and not (Soundlib.BGMusic.Status = ssPlaying) then
   begin
+    SoundLib.BGMusic.SetVolume(IPreviewVolumeVals[Ini.PreviewVolume]);
     AudioPlayback.PlaySound(Soundlib.BGMusic);
   end;
 end;

--- a/src/screens/UScreenOptionsSound.pas
+++ b/src/screens/UScreenOptionsSound.pas
@@ -136,6 +136,12 @@ begin
       SoundLib.StartBgMusic
     else
       SoundLib.PauseBgMusic;
+  end
+  else if (SelInteraction = 5) then
+  begin
+    // preview volume, restart the background music so it uses the new volume
+    SoundLib.PauseBgMusic;
+    SoundLib.StartBgMusic;
   end;
   
 end;


### PR DESCRIPTION
fixes #497

the pause/starting on SelInteraction is a bit of a hack, but not worse than what the on/off toggle was already doing a few lines up.