### PR TITLE
Refactor singdraw

### DIFF
--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -48,7 +48,7 @@ procedure SingDrawOscilloscope(Position: TThemePosition; NrSound: integer);
 procedure SingDrawNoteLines(Left, Top, Right: real; LineSpacing: integer = 15);
 procedure SingDrawLyricHelper(CP: integer; Left, LyricsMid: real);
 procedure SingDrawLine(Left, Top, Right: real; Track, PlayerIndex: integer; LineSpacing: integer = 15);
-procedure SingDrawPlayerLine(X, Y, W: real; Track, PlayerIndex: integer; LineSpacing: integer = 15);
+procedure SingDrawPlayerLine(Left, Top, W: real; Track, PlayerIndex: integer; LineSpacing: integer = 15);
 procedure SingDrawPlayerBGLine(Left, Top, Right: real; Track, PlayerIndex: integer; LineSpacing: integer = 15);
 
 //Draw Editor NoteLines
@@ -657,7 +657,7 @@ begin
 end;
 
 // draw sung notes
-procedure SingDrawPlayerLine(X, Y, W: real; Track, PlayerIndex: integer; LineSpacing: integer);
+procedure SingDrawPlayerLine(Left, Top, W: real; Track, PlayerIndex: integer; LineSpacing: integer);
 var
   TempR:      real;
   Rec:        TRecR;
@@ -684,7 +684,7 @@ begin
         with Player[PlayerIndex].Note[N] do
         begin
           // Left part of note
-          Rec.Left  := X + (Start - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + 0.5 + 10*ScreenX;
+          Rec.Left  := Left + (Start - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + 0.5 + 10*ScreenX;
           Rec.Right := Rec.Left + NotesW[PlayerIndex];
 
           // Draw it in half size, if not hit
@@ -697,7 +697,7 @@ begin
             NotesH2 := int(NotesH[PlayerIndex] * 0.65);
           end;
 
-          Rec.Top    := Y - (Tone-Tracks[Track].Lines[Tracks[Track].CurrentLine].BaseNote)*LineSpacing/2 - NotesH2;
+          Rec.Top    := Top - (Tone-Tracks[Track].Lines[Tracks[Track].CurrentLine].BaseNote)*LineSpacing/2 - NotesH2;
           Rec.Bottom := Rec.Top + 2 * NotesH2;
 
           // draw the left part
@@ -719,7 +719,7 @@ begin
 
           // Middle part of the note
           Rec.Left  := Rec.Right;
-          Rec.Right := X + (Start + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR - NotesW[PlayerIndex] - 0.5  + 10*ScreenX;
+          Rec.Right := Left + (Start + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR - NotesW[PlayerIndex] - 0.5  + 10*ScreenX;
 
           // new
           if (Start + Duration - 1 = LyricsState.CurrentBeatD) then


### PR DESCRIPTION
Part 2 of ??? (part 1: #627)

Context: I want to make a helper function that calls the group of three functions (later on maybe more things can be put into this, like the stave lines) and for that, it would be useful if they all share the same parameters.

I eventually ran into a problem with `W` vs `Right` (see #671 for that), which needs to be dealt with before this can continue further.

What this PR already does is the following (in this commit order):
1. move oscilloscope drawing to a separate function
2. pass 1 parameter instead of 4 separate ones for oscilloscope drawing
3. a no-op commit that groups some function calls together per player instead of per function
4. make everything 0-based
5. replace X/Y with Left/Top

Once this is merged, I'll create a new branch to remove the Graphics.SingWindow option. Then once _that's_ also merged, it should be possible to continue simplifying this area.

Long-term goal: there's a lot of duplication when it comes to offsets, whereas in reality, it's just "draw notes for player 3 in this specific area". And it also paves the way for hiding the notes during long breaks.

If someone wants to review I recommend going per-commit, otherwise I'll just double-check them in 1-2 weeks time that they're all essentially no-ops.