### PR TITLE
actually save all player scores in modes with more than 6 players

### DIFF
--- a/src/screens/UScreenTop5.pas
+++ b/src/screens/UScreenTop5.pas
@@ -177,7 +177,6 @@ end;
 procedure TScreenTop5.OnShow;
 var
   I:    integer;
-  PMax: integer;
   sung: boolean; //score added? otherwise in wasn't sung!
   Report: string;
 begin
@@ -192,10 +191,7 @@ begin
 
   //ReadScore(CurrentSong);
 
-  PMax := Ini.Players;
-  if PMax = 4 then
-    PMax := 5;
-  for I := 0 to PMax do
+  for I := 0 to PlayersPlay - 1 do
   begin
     if (Round(Player[I].ScoreTotalInt) > 0) and (ScreenSing.SungToEnd) then
     begin


### PR DESCRIPTION
While playing with a 9-player hack, I noticed that scores for the last one or two players were not saving. I'm going to assume it has also _never_ saved any scores for the people that are using the already existing 8 or 12-player modes across two screens.

I'm not sure if the `[Game].Players` ini value is the actual number of players, or the index in the array of possible player numbers, but that's something for another day. Long-term that should be the actual number, and any code references to `PlayersPlay` should be replaced with directly referencing the `Ini` class.

The PR'd way of looping through them exists in a few other places as well, so it's probably correct. On my local build, it does now save scores for all 9 players at least.