### PR TITLE
remove Graphics.SingWindow option

### DIFF
--- a/game/config.ini
+++ b/game/config.ini
@@ -18,7 +18,6 @@ Visualization=Off
 Resolution=1024x768
 Depth=32 bit
 TextureSize=256
-SingWindow=Big
 Oscilloscope=On
 MovieSize=Full [BG+Vid]
 VideoPreview=On

--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -1164,16 +1164,11 @@ var
   LyricEngineDuet: TLyricEngine;
 begin
   // positions
-  if Ini.SingWindow = 0 then
-    NR.Left := 120
-  else
-    NR.Left := 20;
-
+  NR.Left := 20;
   NR.Right := 780;
-
-  NR.Width := NR.Right - NR.Left;
-  NR.WMid  := NR.Width / 2;
-  NR.Mid   := NR.Left + NR.WMid;
+  NR.Width := 760; //NR.Right - NR.Left;
+  NR.WMid  := 380;//NR.Width / 2;
+  NR.Mid   := 400;//NR.Left + NR.WMid;
 
   // draw note-lines
 
@@ -1280,16 +1275,11 @@ const
   TopThreeRows3 = 370+95;
 begin
   // positions
-  if Ini.SingWindow = 0 then
-    NR.Left := 120
-  else
-    NR.Left := 20;
-
+  NR.Left := 20;
   NR.Right := 780;
-
-  NR.Width := NR.Right - NR.Left;
-  NR.WMid  := NR.Width / 2;
-  NR.Mid   := NR.Left + NR.WMid;
+  NR.Width := 760; //NR.Right - NR.Left;
+  NR.WMid  := 380; //NR.Width / 2;
+  NR.Mid   := 400; //NR.Left + NR.WMid;
 
   TrackP1 := 0;
   TrackP2 := 0;
@@ -1541,16 +1531,11 @@ var
   LyricEngine: TLyricEngine;
 begin
   // positions
-  if Ini.SingWindow = 0 then
-    NR.Left := 120
-  else
-    NR.Left := 20;
-
+  NR.Left := 20;
   NR.Right := 780;
-
-  NR.Width := NR.Right - NR.Left;
-  NR.WMid  := NR.Width / 2;
-  NR.Mid   := NR.Left + NR.WMid;
+  NR.Width := 760; //NR.Right - NR.Left;
+  NR.WMid  := 380; //NR.Width / 2;
+  NR.Mid   := 400; //NR.Left + NR.WMid;
 
   // FIXME: accessing ScreenJukebox is not that generic
   LyricEngine := ScreenJukebox.Lyrics;

--- a/src/base/UGraphicClasses.pas
+++ b/src/base/UGraphicClasses.pas
@@ -670,14 +670,7 @@ begin
 // calculation of coordinates done with hardcoded values like in UDraw.pas
 // might need to be adjusted if drawing of SingScreen is modified
 // coordinates may still be a bit weird and need adjustment
-  if Ini.SingWindow = 0 then
-  begin
-    Left := 130;
-  end
-  else
-  begin
-    Left := 30;
-  end;
+  Left := 30;
   Right := 770;
 
   // spawn effect for every player with a perfect line

--- a/src/base/UIni.pas
+++ b/src/base/UIni.pas
@@ -150,7 +150,6 @@ type
       VisualizerOption: integer;
       FullScreen:     integer;
       TextureSize:    integer;
-      SingWindow:     integer;
       Oscilloscope:   integer;
       // not used
       //Spectrum:       integer;
@@ -352,8 +351,6 @@ const
   ITextureSize:      array[0..3] of UTF8String  = ('64', '128', '256', '512');
   ITextureSizeVals:  array[0..3] of integer     = ( 64,   128,   256,   512);
 
-  ISingWindow:       array[0..1] of UTF8String  = ('Small', 'Big');
-
   // SingBar Mod
   IOscilloscope:     array[0..1] of UTF8String  = ('Off', 'On');
 
@@ -482,7 +479,6 @@ var
   IVisualizerTranslated:       array[0..3] of UTF8String  = ('Off', 'WhenNoVideo', 'WhenNoVideoAndImage','On');
 
   IBackgroundMusicTranslated:  array[0..1] of UTF8String  = ('Off', 'On');
-  ISingWindowTranslated:       array[0..1] of UTF8String  = ('Small', 'Big');
 
   // SingBar Mod
   IOscilloscopeTranslated:     array[0..1] of UTF8String  = ('Off', 'On');
@@ -653,9 +649,6 @@ begin
 
   IBackgroundMusicTranslated[0]       := ULanguage.Language.Translate('OPTION_VALUE_OFF');
   IBackgroundMusicTranslated[1]       := ULanguage.Language.Translate('OPTION_VALUE_ON');
-
-  ISingWindowTranslated[0]            := ULanguage.Language.Translate('OPTION_VALUE_SMALL');
-  ISingWindowTranslated[1]            := ULanguage.Language.Translate('OPTION_VALUE_BIG');
 
   IOscilloscopeTranslated[0]          := ULanguage.Language.Translate('OPTION_VALUE_OFF');
   IOscilloscopeTranslated[1]          := ULanguage.Language.Translate('OPTION_VALUE_ON');
@@ -1479,9 +1472,6 @@ begin
   // TextureSize (aka CachedCoverSize)
   TextureSize := ReadArrayIndex(ITextureSize, IniFile, 'Graphics', 'TextureSize', IGNORE_INDEX, '256');
 
-  // SingWindow
-  SingWindow := ReadArrayIndex(ISingWindow, IniFile, 'Graphics', 'SingWindow', IGNORE_INDEX, 'Big');
-
   // Oscilloscope
   Oscilloscope := ReadArrayIndex(IOscilloscope, IniFile, 'Graphics', 'Oscilloscope', 0);
 
@@ -1790,9 +1780,6 @@ begin
 
     // TextureSize
     IniFile.WriteString('Graphics', 'TextureSize', ITextureSize[TextureSize]);
-
-    // Sing Window
-    IniFile.WriteString('Graphics', 'SingWindow', ISingWindow[SingWindow]);
 
     // Oscilloscope
     IniFile.WriteString('Graphics', 'Oscilloscope', IOscilloscope[Oscilloscope]);


### PR DESCRIPTION
When merged, this PR will close #671.

I'm going to assume this used to be an option, but considering the screenshot in the above mentioned issue, it looks like it's pretty much abandoned. Considering it's essentially unusable in the current state anyway, I propose to remove it altogether.

This has the side benefit of opening up more refactoring/simplification possibilities in the functions this was used in.