### PR TITLE
make P1 and P2 use the same opacity/alpha in the info lyric bar

### DIFF
--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -1801,9 +1801,9 @@ begin
       Exit;
     //set color to player.color
     if (CurrentTrack = 0) then
-      glColor4f(GetLyricColor(Ini.SingColor[0]).R, GetLyricColor(Ini.SingColor[0]).G, GetLyricColor(Ini.SingColor[0]).B, 0.8)
+      glColor4f(GetLyricColor(Ini.SingColor[0]).R, GetLyricColor(Ini.SingColor[0]).G, GetLyricColor(Ini.SingColor[0]).B, 0.6)
     else
-      glColor4f(GetLyricColor(Ini.SingColor[CurrentTrack]).R, GetLyricColor(Ini.SingColor[CurrentTrack]).G, GetLyricColor(Ini.SingColor[CurrentTrack]).B, 0.4);
+      glColor4f(GetLyricColor(Ini.SingColor[CurrentTrack]).R, GetLyricColor(Ini.SingColor[CurrentTrack]).G, GetLyricColor(Ini.SingColor[CurrentTrack]).B, 0.6);
 
     glbegin(gl_quads);
     for LineIndex := 0 to numLines - 1 do


### PR DESCRIPTION
It has always annoyed me that if you're singing as P2 in a duet (as in, a player that gets the second track), the info lyric bar was pretty much useless. This PR fixes that by having both tracks use the same opacity/alpha.
The biggest issue this tries to address is P2 solo parts being near-invisible if P2 uses a darker color.

Before (P1 = 0.8 opacity, P2 = 0.4 opacity)
![out-screenshot0001](https://user-images.githubusercontent.com/5775429/233667553-8d83122b-295e-44e5-a289-9928ee427ebe.jpg)

After (P1 = 0.6 opacity, P2 = 0.6 opacity)
![out-screenshot0002](https://user-images.githubusercontent.com/5775429/233667610-0aaac140-5454-4632-9392-c62716c1666c.jpg)

The I tried other values like 0.7 and 0.65, but then the mixing becomes less good. The screenshots are about the worst case possible since yellow is very bright and blue is very dark, and they don't mix as good as, for example, red and green would. But blue is pretty much invisible on the grey background anyway.

The same colors in a custom theme that has a darker background (P1 = 0.6, P2 = 0.6)
![darkbg](https://user-images.githubusercontent.com/5775429/233669916-ca8765b9-998a-46b1-b68f-fc1d09e998ca.jpg)
