### PR TITLE
Add more info to appdata file

### DIFF
--- a/dists/ultrastardx.appdata.xml
+++ b/dists/ultrastardx.appdata.xml
@@ -20,4 +20,25 @@
     </screenshot>
   </screenshots>
   <launchable type="desktop-id">ultrastardx.desktop</launchable>
+  <content_rating type="oars-1.0" />
+  <requires>
+    <control>voice</control>
+  </requires>
+  <supports>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <control>gamepad</control>
+  </supports>
+  <recommended>
+    <control>keyboard</control>
+  </recommended>
+  <releases>
+    <release version="2023.5.0" date="2023-5-2" />
+    <release version="2023.4.0" date="2023-4-1" />
+    <release version="2023.3.0" date="2023-3-5" />
+    <release version="2020.4.0" date="2020-4-29" />
+    <release version="2017.8.0" date="2017-8-8" />
+    <release version="1.3.5~beta" date="2016-12-2" />
+    <release version="1.3.2~beta" date="2016-8-5" />
+  </releases>
 </component>


### PR DESCRIPTION
This xml file contains information displayed in app stores like [Flathub](https://flathub.org/apps/eu.usdx.UltraStarDeluxe). If this additional information is not kept here, I have to patch the file for every release. This PR assumes the next release will be done today.