### PR TITLE
Lock surfaces and check success before use

### DIFF
--- a/src/base/UAvatars.pas
+++ b/src/base/UAvatars.pas
@@ -315,6 +315,13 @@ begin
   Thumbnail := CreateAvatarThumbnail(Filename, Info);
   if (Thumbnail = nil) then
     Exit;
+  SDL_LockSurface(Thumbnail);
+  if not assigned(Thumbnail^.pixels) then
+  begin
+    Log.LogError('Failed to lock surface', 'TAvatarDatabase.AddAvatar');
+    SDL_FreeSurface(Thumbnail);
+    Exit;
+  end;
 
   AvatarData := TBlobWrapper.Create;
   AvatarData.Write(Thumbnail^.pixels, Thumbnail^.h * Thumbnail^.pitch);

--- a/src/base/UCovers.pas
+++ b/src/base/UCovers.pas
@@ -336,6 +336,13 @@ begin
   Thumbnail := CreateThumbnail(Filename, Info);
   if not (assigned(Thumbnail)) or (Thumbnail = nil) then
     Exit;
+  SDL_LockSurface(Thumbnail);
+  if not assigned(Thumbnail^.pixels) then
+  begin
+    Log.LogError('Failed to lock surface', 'TCoverDatabase.AddCover');
+    SDL_FreeSurface(Thumbnail);
+    Exit;
+  end;
 
   CoverData := TBlobWrapper.Create;
   CoverData.Write(Thumbnail^.pixels, Thumbnail^.h * Thumbnail^.pitch);

--- a/src/base/UImage.pas
+++ b/src/base/UImage.pas
@@ -688,7 +688,15 @@ var
   Grey: byte;
 begin
 
+  SDL_LockSurface(ImgSurface);
   Pixel := ImgSurface^.Pixels;
+
+  if not assigned(Pixel) then
+  begin
+    Log.LogError('Failed to lock surface', 'ColorizeImage');
+    SDL_UnlockSurface(ImgSurface);
+    Exit;
+  end;
 
   // check of the size of a pixel in bytes.
   // It should be always 4, but this
@@ -805,6 +813,7 @@ begin
 
     Inc(Pixel, ImgSurface^.format.BytesPerPixel);
   end;
+  SDL_UnlockSurface(ImgSurface);
 end;
 
 end.

--- a/src/base/UTexture.pas
+++ b/src/base/UTexture.pas
@@ -274,6 +274,11 @@ begin
 
   // convert pixel format as needed
   AdjustPixelFormat(TexSurface, Typ);
+  if not assigned(TexSurface) then
+  begin
+    Log.LogError('Could not convert surface', 'TTextureUnit.LoadTexture');
+    Exit;
+  end;
 
   // adjust texture size (scale down, if necessary)
   newWidth   := TexSurface.W;                            //basisbit ToDo make images scale in size and keep ratio?
@@ -302,8 +307,16 @@ begin
   newWidth  := RoundPOT(newWidth);
   newHeight := RoundPOT(newHeight);
   if (newHeight <> oldHeight) or (newWidth <> oldWidth) then
+  begin
     FitImage(TexSurface, newWidth, newHeight);
+    if not assigned(TexSurface) then
+    begin
+      Log.LogError('Could not allocate POT surface', 'TTextureUnit.LoadTexture');
+      Exit;
+    end;
+  end;
   {end;}
+  SDL_LockSurface(TexSurface); // unlocked by SDL_FreeSurface
 
   // at this point we have the image in memory...
   // scaled so that dimensions are powers of 2
@@ -323,6 +336,9 @@ begin
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
   // load data into gl texture
+  if not assigned(TexSurface.pixels) then
+    Log.LogError('Failed to lock surface', 'TTextureUnit.LoadTexture')
+  else
   if (Typ = TEXTURE_TYPE_TRANSPARENT) or
      (Typ = TEXTURE_TYPE_COLORIZED) then
   begin


### PR DESCRIPTION
In some places SDL surfaces were used without checking if allocation succeeded.
Sometimes the pixels of a surface were accessed without locking it.

Avoided a crash in #680 when an allocation failed.