### PR TITLE
Video aspect ratios

### DIFF
--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -64,7 +64,7 @@ type
    *   - borders at top and bottom
    *   o top/bottom is cropped if width < height (unusual)
    *}
-  TAspectCorrection = (acoStretch, acoCrop, acoLetterBox);
+  TAspectCorrection = (acoStretch, acoLetterBox, acoHalfway, acoCrop);
 
   TRectCoords = record
     Left, Right:  double;

--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -51,10 +51,6 @@ type
   end;
 
   {**
-   * acoStretch: Stretch to screen width and height
-   *   - ignores aspect
-   *   + no borders
-   *   + no image data loss
    * acoCrop: Stretch to screen width or height, crop the other dimension
    *   + keeps aspect
    *   + no borders
@@ -65,7 +61,7 @@ type
    *   o top/bottom is cropped if width < height (unusual)
    * acoHalfway: a compromise between crop and letterbox
    *}
-  TAspectCorrection = (acoStretch, acoLetterBox, acoHalfway, acoCrop);
+  TAspectCorrection = (acoLetterBox, acoHalfway, acoCrop);
 
   TRectCoords = record
     Left, Right:  double;

--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -63,6 +63,7 @@ type
    *   + keeps aspect
    *   - borders at top and bottom
    *   o top/bottom is cropped if width < height (unusual)
+   * acoHalfway: a compromise between crop and letterbox
    *}
   TAspectCorrection = (acoStretch, acoLetterBox, acoHalfway, acoCrop);
 

--- a/src/media/UMedia_dummy.pas
+++ b/src/media/UMedia_dummy.pas
@@ -436,7 +436,7 @@ end;
 
 function TVideo_Dummy.GetAspectCorrection(): TAspectCorrection;
 begin
-  Result := acoStretch;
+  Result := acoLetterbox;
 end;
 
 procedure TVideo_Dummy.SetAlpha(Alpha: double);

--- a/src/media/UVideo.pas
+++ b/src/media/UVideo.pas
@@ -1442,6 +1442,11 @@ begin
       end;
     end;
 
+    acoHalfway: begin
+      ScaledVideoWidth  := (fWidth + fWidth * fAspect/ScreenAspect)/2;
+      ScaledVideoHeight := (fHeight + fHeight * ScreenAspect/fAspect)/2;
+    end;
+
     acoLetterBox: begin
       if (ScreenAspect <= fAspect) then
       begin

--- a/src/media/UVideo.pas
+++ b/src/media/UVideo.pas
@@ -1425,11 +1425,6 @@ begin
   ScreenAspect := fWidth*((ScreenW/Screens)/RenderW)/(fHeight*(ScreenH/RenderH));
 
   case fAspectCorrection of
-    acoStretch: begin
-      ScaledVideoWidth  := fWidth;
-      ScaledVideoHeight := fHeight;
-    end;
-
     acoCrop: begin
       if (ScreenAspect >= fAspect) then
       begin

--- a/src/media/UVisualizer.pas
+++ b/src/media/UVisualizer.pas
@@ -359,7 +359,7 @@ end;
 
 function TVideo_ProjectM.GetAspectCorrection(): TAspectCorrection;
 begin
-  Result := acoStretch;
+  Result := acoLetterbox;
 end;
 
 procedure TVideo_ProjectM.SetAlpha(Alpha: double);

--- a/src/screens/UScreenJukebox.pas
+++ b/src/screens/UScreenJukebox.pas
@@ -1542,15 +1542,15 @@ begin
           if (SDL_ModState = KMOD_LSHIFT) then
           begin
             if (AspectCorrection = acoCrop) then
-              AspectCorrection := acoStretch
+              AspectCorrection := acoLetterBox
             else
             begin
-              if (AspectCorrection = acoStretch) then
-                AspectCorrection := acoLetterBox
+              if (AspectCorrection = acoHalfway) then
+                AspectCorrection := acoCrop
               else
               begin
                 if (AspectCorrection = acoLetterBox) then
-                  AspectCorrection := acoCrop;
+                  AspectCorrection := acoHalfway;
               end;
             end;
           end;


### PR DESCRIPTION
* delete `acoStretch` option
* add a `acoHalfway` option that's a compromise between `acoLetterBox` and `acoCrop`
* loop through them with `A` in this order: letterbox (default) -> halfway -> crop

sample video where I'm pressing `A` a bunch of times.

https://github.com/UltraStar-Deluxe/USDX/assets/5775429/9c753640-4d96-440a-a7b6-5067e557e273

I want to add this for the static backgrounds too but I'll wait until this is in.