### PR TITLE
more detailed release steps

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -77,3 +77,12 @@ Optional libraries:
   * `flatpak-builder --user --install-deps-from=flathub --install build $USDX_SOURCE_TREE/dists/flatpak/eu.usdx.UltraStarDeluxe.yaml`
 - The `.flatpak-builder` and `build` directories can be removed afterwards.
 - Songs must be placed in `~/.var/app/eu.usdx.UltraStarDeluxe/.ultrastardx/songs`
+
+# Windows installer
+The CI does this for you, but if you need to do it manually:
+- Create Windows portable version: zip the contents of the `game` directory
+- Create Windows installer:
+  * Install NSIS (also install the Graphics and Language components during setup)
+  * Copy the DLLs from `game` to `installer/dependencies/dll`
+  * `C:\...\makensis "installer/UltraStar Deluxe.nsi"` (this will take a while)
+  * The .exe will be placed in `installer/dist`

--- a/README.md
+++ b/README.md
@@ -65,11 +65,3 @@ For extended information, dependencies, OS-specific notes and configure flags, s
   * VERSION
   * UConfig.pas (also recompile the game after this)
   * variables.nsh (update both blocks when making the release and swap the comments, then after the release you only have to swap the comments back)
-- Create Windows portable version: zip the contents of the `game` directory
-- Create Windows installer:
-  * Install NSIS (also install the Graphics and Language components during setup)
-  * Copy the DLLs from `game` to `installer/dependencies/dll`
-  * `C:\...\makensis "installer/UltraStar Deluxe.nsi"` (this will take a while)
-  * The .exe will be placed in `installer/dist`
-
-Feel free to fork this project, modify it to your hearts content and maybe also do pull requests to this repository for additional features, improvements or clean-ups.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,22 @@ The executable will be `game/ultrastardx[.exe]`.
 For extended information, dependencies, OS-specific notes and configure flags, see [COMPILING.md](COMPILING.md).
 
 ### 6. Making a release
-- Find and replace the contents of `VERSION` everywhere throughout the code
-  This should be three places:
-  * VERSION
-  * UConfig.pas (also recompile the game after this)
-  * variables.nsh (update both blocks when making the release and swap the comments, then after the release you only have to swap the comments back)
+1. Find the contents of `VERSION` (strip the `+dev`) throughout the code.
+    This should result in four places:
+    * VERSION
+    * UConfig.pas
+    * variables.nsh
+    * ultrastardx.appdata.xml
+2. Make the release:
+    * in the first two files, update it to the new version _without_ the `+dev` bit
+    * in `variables.nsh` update both blocks immediately and swap the comments
+    * in `ultrastardx.appdata.xml` add a new entry
+3. Commit, `git tag v<the-new-version>` and then `git push origin master v<the-new-version>`\
+    __It is important that these two get pushed together__ otherwise Flatpak gets confused.
+4. Wait and get the artifacts from the CI.
+    If any of them fail, just add an extra `;` on one of the already commented lines in `variables.nsh`, commit, and then push only `master`.
+5. Add `+dev` to the version in the first two files and swap the comments in `variables.nsh` again, commit, push.
+    This is just to set the dev version again.
+6. Attach the artifacts to the release page and publish it.
+    Don't forget to also create a PR for this release in
+    https://github.com/UltraStar-Deluxe/ultrastar-deluxe.github.io


### PR DESCRIPTION
this moves the less-used manual Windows package building (because the CI does that for us already) to a new section at the bottom of COMPILING.md

and then adds more details on how to actually do a release since that's something that has to be done manually. it's not that difficult and most of the time is spent waiting on the CI actually, but it makes life a lot easier.