### PR TITLE
Improve background aspect ratio

### DIFF
--- a/game/languages/English.ini
+++ b/game/languages/English.ini
@@ -1476,7 +1476,7 @@ CTRL_TAB = Change visualization style (if visualization is enabled)
 CTRL_TAB = Change webcam filter (if webcam is enabled)
 ;PAGEUPDOWN Adjust song volume
 ;N Toggle notes on/off
-A = Toggle video aspect ratio: Letter Box/Crop/Stretch (if available)
+A = Toggle video/background aspect ratio: Letter Box/Crop/Stretch (if available)
 ;S Toggle display under score: score bars/max. achievable score/player names/off
 ;-------------------------------------------------------;
 ; ID_023: UScreenScore                                  ;

--- a/game/themes/Deluxe.ini
+++ b/game/themes/Deluxe.ini
@@ -451,9 +451,9 @@ Texts = 1
 
 [SingBackground]
 Type=color
-ColR=1
-ColB=1
-ColG=1
+ColR=0
+ColB=0
+ColG=0
 
 [SingTimeLabelText]
 Text = SING_TIME

--- a/game/themes/Modern.ini
+++ b/game/themes/Modern.ini
@@ -451,9 +451,9 @@ Texts = 1
 
 [SingBackground]
 Type=color
-ColR=1
-ColB=1
-ColG=1
+ColR=0
+ColB=0
+ColG=0
 
 [SingTimeLabelText]
 Text = SING_TIME

--- a/src/base/UTexture.pas
+++ b/src/base/UTexture.pas
@@ -259,6 +259,7 @@ var
   newWidth, newHeight: integer;
   oldWidth, oldHeight: integer;
   ActTex: GLuint;
+  ScaleBy: real;
 begin
   // zero texture data
   FillChar(Result, SizeOf(Result), 0);
@@ -280,15 +281,15 @@ begin
     Exit;
   end;
 
-  // adjust texture size (scale down, if necessary)
-  newWidth   := TexSurface.W;                            //basisbit ToDo make images scale in size and keep ratio?
-  newHeight  := TexSurface.H;
+  // adjust texture size (scale down, if necessary) while keeping aspect ratio
+  ScaleBy := 1;
+  if (Max(TexSurface.W, TexSurface.H) > Limit) then
+  begin
+    ScaleBy := Max(TexSurface.W, TexSurface.H) / Limit;
+  end;
 
-  if (newWidth > Limit) then
-    newWidth := Limit;
-
-  if (newHeight > Limit) then
-    newHeight := Limit;
+  newWidth   := Floor(TexSurface.W / ScaleBy);
+  newHeight  := Floor(TexSurface.H / ScaleBy);
 
   if (TexSurface.W > newWidth) or (TexSurface.H > newHeight) then
     ScaleImage(TexSurface, newWidth, newHeight);

--- a/src/media/UVideo.pas
+++ b/src/media/UVideo.pas
@@ -925,8 +925,6 @@ begin
 
   fPboId := 0;
 
-  fAspectCorrection := acoLetterBox;
-
   fScreen := 1;
 
   fPosX := 0;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -155,6 +155,7 @@ type
     PlayerDuetNames:array [1..IMaxPlayerCount] of UTF8String;
 
     Tex_Background: TTexture;
+    BackgroundAspectCorrection: TAspectCorrection;
     FadeOut: boolean;
 
     procedure ClearSettings;
@@ -464,7 +465,16 @@ begin
         else
         begin
           if (Assigned(fCurrentVideo)) then
+          begin
              fCurrentVideo.SetAspectCorrection(TAspectCorrection((Ord(fCurrentVideo.GetAspectCorrection())+1) mod (Ord(High(TAspectCorrection))+1)));
+          end
+          else
+          begin
+            if (fShowBackground and CurrentSong.Background.IsSet()) then
+            begin
+              BackgroundAspectCorrection := TAspectCorrection((Ord(BackgroundAspectCorrection)+1) mod (Ord(High(TAspectCorrection))+1));
+            end;
+          end;
         end;
       end;
 
@@ -1091,10 +1101,12 @@ begin
     BgFile := CurrentSong.Path.Append(CurrentSong.Background);
     try
       Tex_Background := Texture.LoadTexture(BgFile);
+      fShowBackground := fCurrentVideo = nil;
+      BackgroundAspectCorrection := acoLetterBox;
     except
       Log.LogError('Background could not be loaded: ' + BgFile.ToNative);
       Tex_Background.TexNum := 0;
-    end
+    end;
   end
   else
   begin


### PR DESCRIPTION
This is essentially #689 but for the static background images

The additional commits are to:
- change theme `[SingBackground]` color to black (instead of white) because white letter/pillarboxes look really weird
- if a texture is deemed "too large", scale it down in a way that keeps the aspect ratio. this technically loses (a little bit) of information if the texture is only too large in one dimension, but there's (currently) no way of getting the _original_ aspect ratio/dimensions from a resized texture.

EDIT: when merging this, also check if this is on the wiki and if yes, update the text there