### PR TITLE
default avatar if saved avatar no longer exists

### DIFF
--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -871,6 +871,12 @@ begin
     PlayerNames[I] := Ini.Name[I];
     PlayerLevel[I] := Ini.PlayerLevel[I];
     PlayerAvatars[I] := GetArrayIndex(PlayerAvatarButtonMD5, Ini.PlayerAvatar[I]);
+    // if it is -1 then the current saved md5 does not exist anymore (file has changed or was deleted entirely)
+    // setting it to 0 just resets it to the colorized default avatar
+    if (PlayerAvatars[I] = -1) then
+    begin
+      PlayerAvatars[I] := 0;
+    end;
   end;
 
   AvatarTarget := PlayerAvatars[PlayerIndex];


### PR DESCRIPTION
reset players back to the (colorized) default avatar if the previously saved md5 hash can't be found anymore. fixes #630 