### PR TITLE
UGraphics: free window icon after it has been set

### DIFF
--- a/src/base/UGraphic.pas
+++ b/src/base/UGraphic.pas
@@ -482,7 +482,10 @@ begin
   // load icon image (must be 32x32 for win32)
   Icon := LoadImage(ResourcesPath.Append(WINDOW_ICON));
   if (Icon <> nil) then
+  begin
     SDL_SetWindowIcon(Screen, Icon);
+    SDL_FreeSurface(Icon);
+  end;
 
   SDL_SetWindowTitle(Screen, PChar(Title));
 


### PR DESCRIPTION
SDL_SetWindowIcon creates a copy of the icon before it returns, so we should free the image when we don't need it anymore.