### PR TITLE
use better default colors

### DIFF
--- a/game/config.ini
+++ b/game/config.ini
@@ -141,12 +141,12 @@ Name11=Template11
 Name12=Template12
 
 [PlayerColor]
-P1=10
+P1=1
 P2=4
-P3=4
-P4=6
-P5=8
-P6=7
+P3=3
+P4=2
+P5=5
+P6=6
 P7=7
 P8=8
 P9=9


### PR DESCRIPTION
while testing something I noticed that the default config doesn't really use 'nice' colors:
1. the P1 Dark Blue is _very_ hard to see in the timebar. While #678 makes this worse, this was always an issue
2. the P1 Dark Blue is missing some lighter/even-lighter color variations (as does every color above either 6 or 8 iirc)

This causes great visuals like these:
![screenshot0003](https://github.com/UltraStar-Deluxe/USDX/assets/5775429/d916ef63-323b-4bc0-bd94-421236cd43e2)
![screenshot0004](https://github.com/UltraStar-Deluxe/USDX/assets/5775429/a30355ad-98b0-4674-b753-b3594d76e6b5)
(I didn't bother getting any points, but it would also show up in those vertical bar things)

This PR aims to solve item number 1 and _sort of_ solve number 2 by changing the default colors for P1-P6 to all be in the first six colors. These are still fairly distinct, result in a functioning timebar, and all of them all colors necessary for the score screen. Some screenshots:
![screenshot0005](https://github.com/UltraStar-Deluxe/USDX/assets/5775429/4ab84830-f046-41c2-8468-923ea5438afb)
![screenshot0007](https://github.com/UltraStar-Deluxe/USDX/assets/5775429/088ab36a-3866-474b-83c9-6e2974523152)

Off-topic 1: I do have an actual fix for the second item in my local builds, but that uses modified colors, so I can't just port it 1:1.

Off-topic 2: _why_ is 6 players the default? Wouldn't 1 or 2 players make more sense, especially since you can't select colors that are already used by other players (as in, if you have six players and want to modify the color of P1, you can't set it to anything currently used by P2...P6)

As far as I'm aware, the default config will only affect _new_ installations/portables, and maybe it can be improved further in the future, but I'd argue that it's _better_ than what it was.