### PR TITLE
Fix leak fix

### DIFF
--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -1016,12 +1016,13 @@ begin
       end;
 
       if (Packet.stream_index = fAudioStreamIndex) then
-        fPacketQueue.Put(@Packet);
-      {$IF (LIBAVFORMAT_VERSION < 59000000)}
-      av_free_packet(@Packet);
-      {$ELSE}
-      av_packet_unref(@Packet);
-      {$ENDIF}
+        fPacketQueue.Put(@Packet)
+      else
+        {$IF (LIBAVFORMAT_VERSION < 59000000)}
+        av_free_packet(@Packet);
+        {$ELSE}
+        av_packet_unref(@Packet);
+        {$ENDIF}
 
     finally
       SDL_LockMutex(fStateLock);

--- a/src/media/UMediaCore_FFmpeg.pas
+++ b/src/media/UMediaCore_FFmpeg.pas
@@ -642,27 +642,17 @@ begin
   if (CurrentListEntry = nil) then
     Exit;
 
-  {$IF LIBAVFORMAT_VERSION < 59000000}
   CurrentListEntry^.pkt := Packet^;
+  {$IF LIBAVFORMAT_VERSION < 59000000}
   if (PChar(Packet^.data) <> STATUS_PACKET) then
   begin
+    // duplicate data if not valid beyond next av_read_frame
     if (av_dup_packet(@(CurrentListEntry^.pkt)) < 0) then
     begin
       av_free(CurrentListEntry);
       Exit;
     end;
   end;
-  {$ELSE}
-  if (PChar(Packet^.data) <> STATUS_PACKET) then
-    begin
-      if (av_packet_ref(@CurrentListEntry^.pkt, Packet) < 0) then
-      begin
-        av_free(CurrentListEntry);
-        Exit;
-      end;
-    end
-  else
-    CurrentListEntry^.pkt := Packet^;
   {$ENDIF}
 
   CurrentListEntry^.next := nil;


### PR DESCRIPTION
Reverts botched attempt to fix audio packets accumulating in memory (which only ever happened with FFmpeg >= 5.0) and fixes it properly.

Fixes #700 