### PR TITLE
Disable FPU exceptions in audio callback

### DIFF
--- a/src/media/UAudioPlayback_SoftMixer.pas
+++ b/src/media/UAudioPlayback_SoftMixer.pas
@@ -1128,8 +1128,13 @@ begin
 end;
 
 procedure TAudioPlayback_SoftMixer.AudioCallback(Buffer: PByteArray; Size: integer);
+var
+  OldMask: TFPUExceptionMask;
 begin
+  OldMask := GetExceptionMask;
+  SetExceptionMask([exInvalidOp, exDenormalized, exZeroDivide, exOverflow, exUnderflow, exPrecision]);
   MixerStream.ReadData(Buffer, Size);
+  SetExceptionMask(OldMask);
 end;
 
 function TAudioPlayback_SoftMixer.GetMixer(): TAudioMixerStream;


### PR DESCRIPTION
On ARM64 macOS floating point exceptions appear to be enabled when the audio callback is called. This causes crashes, e.g. when FFmpeg uses the fcvtzs instruction to convert floating point samples > 1 to integers.

I chose to disable exceptions only temporarily since I assume the overhead is negligible.

Fixes #699