### PR TITLE
slightly speed up oscilloscope drawing

### DIFF
--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -556,17 +556,23 @@ begin;
   MaxX := Position.W-1;
   MaxY := (Position.H-1) / 2;
 
+  glMatrixMode(GL_MODELVIEW);
+  glPushMatrix();
+  glTranslatef(Position.X, Position.Y + MaxY, 0);
+  glScalef(MaxX/High(Sound.AnalysisBuffer), MaxY/Low(Smallint), 1);
+
   Sound.LockAnalysisBuffer();
 
   glBegin(GL_LINE_STRIP);
     for SampleIndex := 0 to High(Sound.AnalysisBuffer) do
     begin
-      glVertex2f(Position.X + MaxX * SampleIndex/High(Sound.AnalysisBuffer),
-                 Position.Y + MaxY * (1 - Sound.AnalysisBuffer[SampleIndex]/-Low(Smallint)));
+      glVertex2s(SampleIndex, Sound.AnalysisBuffer[SampleIndex]);
     end;
   glEnd;
 
   Sound.UnlockAnalysisBuffer();
+
+  glPopMatrix();
 end;
 
 procedure SingDrawNoteLines(Left, Top, Right: real; LineSpacing: integer);


### PR DESCRIPTION
This commit implements the idea I mentioned in https://github.com/UltraStar-Deluxe/USDX/pull/619#issuecomment-1304618924 to move all calculations done on the vertices to the matrix. According to gprof the time spent in SingDrawOscilloscope dropped by 90%.

On my computer using glVertex2f would be slightly faster that glVertex2s, but I guess that depends on the GPU and its driver.