### PR TITLE
on the highscores/top5 screen, only show the highest score per player

### DIFF
--- a/src/base/UDataBase.pas
+++ b/src/base/UDataBase.pas
@@ -514,12 +514,15 @@ begin
   TableData := nil;
   try
     // Search Song in DB
+    // TODO: isn't the whole filter completely unnecessary with the GROUP BY?
+    //   if yes, why not just do a much simpler query for each difficulty? can also add LIMIT that way?
     TableData := ScoreDB.GetUniTable(
       'SELECT [Difficulty], [Player], [Score], [Date] FROM [' + cUS_Scores + '] ' +
       'WHERE [SongID] = (' +
         'SELECT [ID] FROM [' + cUS_Songs + '] ' +
         'WHERE [Artist] = ? AND [Title] = ? ' +
         'LIMIT 1) ' +
+      'GROUP BY [Difficulty], [Player] HAVING MAX([Score]) ' +
       'ORDER BY [Score] DESC;', //no LIMIT! see filter below!
       [Song.Artist, Song.Title]);
 


### PR DESCRIPTION
…. and also adds a TODO because the filter is useless now? (not that it did anything to begin with...)
I'm not interest in seeing _how often_ a certain player has set a good score, I'm interested in seeing how it compares to _other_ players. I've been using this since August 2022 and is really nice.

what this PR does in pictures:
before:
![screenshot0046](https://github.com/UltraStar-Deluxe/USDX/assets/5775429/5aa1140e-7c16-44d8-9524-1cca7174b3c9)

after:
![screenshot0048](https://github.com/UltraStar-Deluxe/USDX/assets/5775429/4fe4577c-267f-4f49-8909-19a176d3e65b)
