### PR TITLE
less warnings about players without microphone

### DIFF
--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -409,6 +409,8 @@ begin
 
           if GoTo_SingScreen then
           begin
+            // if we've been in the player screen, we need to show the warning again
+            ScreenSing.CheckPlayerConfigOnNextSong := true;
             FadeTo(@ScreenSing);
             GoTo_SingScreen := false;
           end

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -81,6 +81,7 @@ type
 
     procedure SongError();
   public
+    CheckPlayerConfigOnNextSong: boolean;
     eSongLoaded: THookableEvent; //< event is called after lyrics of a song are loaded on OnShow
     Paused:     boolean; //pause Mod
     NumEmptySentences: array [0..1] of integer;
@@ -646,6 +647,7 @@ begin
   inherited Create;
   ScreenSing := self;
   screenSingViewRef := TScreenSingView.Create();
+  CheckPlayerConfigOnNextSong := true;
   // for now: default to letterbox but preserve aspect between songs
   BackgroundAspectCorrection := acoLetterBox;
 
@@ -703,11 +705,13 @@ begin
   Text[screenSingViewRef.SongNameText].Visible := false;
 
   BadPlayer := AudioInputProcessor.CheckPlayersConfig(PlayersPlay);
-  if (BadPlayer <> 0) then
+  if (BadPlayer <> 0) and CheckPlayerConfigOnNextSong then
   begin
     ScreenPopupError.ShowPopup(
         Format(Language.Translate('ERROR_PLAYER_NO_DEVICE_ASSIGNMENT'),
         [BadPlayer]));
+    // do not show the warning again, unless something sets this to true again
+    CheckPlayerConfigOnNextSong := false;
   end;
 
   if (CurrentSong.isDuet) then


### PR DESCRIPTION
See also #732 
This is by no means a complete fix, but if you're currently using players that don't have a microphone and start a song:

old behaviour:
- show the warning _every time_ a song is started

new behaviour:
- show the warning _once_ if you've been on the player selection screen. this covers both routes (from the main menu or through `M` -> Change Players on the song selection screen).

Because unless you've been through the player setup screen, there is absolutely no way this will have suddenly been fixed between songs. Not sure if this also survives disconnecting microphones, but the game doesn't like that anyway. Plus, if the game _does_ handle it gracefully _and_ you haven't had the warning yet, you should actually still get it!

Obviously it will also still show it again if you go through the screen but don't change anything, but it'll only be _once_ which is still an improvement.