### PR TITLE
use Ord(CharCode) instead of SDLK_*. fixes #721

### DIFF
--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -497,14 +497,14 @@ begin
   if (PressedDown) then  // Key Down
   begin
     // check normal keys
-    case PressedKey of
-      SDLK_Q:
+    case UCS4UpperCase(CharCode) of
+      Ord('Q'):
         begin
           Result := false;
           Exit;
         end;
       {
-      SDLK_S:
+      Ord('S'):
         begin
           if SDL_ModState = KMOD_LSHIFT then
           begin
@@ -536,7 +536,7 @@ begin
 
         end;
       }
-      SDLK_S:
+      Ord('S'):
         begin
           // handle medley tags first
           if CurrentSong.isDuet then
@@ -608,7 +608,7 @@ begin
         end;
 
       // set PreviewStart tag
-      SDLK_I:
+      Ord('I'):
         begin
           CopyToUndo;
           if SDL_ModState and KMOD_SHIFT <> 0 then
@@ -699,7 +699,7 @@ begin
         end;
 
       // set Medley tags
-      SDLK_A:
+      Ord('A'):
         begin
           CopyToUndo;
           if CurrentSong.Relative then
@@ -798,7 +798,7 @@ begin
         end;
 
       // jump to Medley tags
-      SDLK_J:
+      Ord('J'):
         begin
           if CurrentSong.Relative then
           begin
@@ -894,7 +894,7 @@ begin
           Exit;
         end;
 
-      SDLK_R:   //reload
+      Ord('R'):   //reload
         begin
           AudioPlayback.Stop;
           {$IFDEF UseMIDIPort}
@@ -906,7 +906,7 @@ begin
           Text[TextInfo].Text := Language.Translate('EDIT_INFO_SONG_RELOADED');
         end;
 
-      SDLK_D:
+      Ord('D'):
         begin
           // Divide lengths by 2
           if (SDL_ModState = KMOD_LSHIFT) then
@@ -935,7 +935,7 @@ begin
           end;
         end;
 
-      SDLK_M:
+      Ord('M'):
         begin
           // Multiply lengths by 2
           if (SDL_ModState = KMOD_LSHIFT) then
@@ -948,7 +948,7 @@ begin
           end;
         end;
 
-      SDLK_C:
+      Ord('C'):
         begin
           // Capitalize letter at the beginning of line
           if SDL_ModState = 0 then
@@ -978,7 +978,7 @@ begin
           Exit;
         end;
 
-      SDLK_V:
+      Ord('V'):
         begin
           if (SDL_ModState = 0) or (SDL_ModState = KMOD_LALT) then // play current line/remainder of song with video
           begin
@@ -1047,7 +1047,7 @@ begin
           ShowInteractiveBackground;
         end;
 
-      SDLK_T:
+      Ord('T'):
         begin
           // Fixes timings between sentences
           CopyToUndo;
@@ -1056,7 +1056,7 @@ begin
           Exit;
         end;
 
-      SDLK_P:
+      Ord('P'):
         begin
           if SDL_ModState = 0 then
           begin
@@ -1118,7 +1118,7 @@ begin
         end;
 
       // Golden Note
-      SDLK_G:
+      Ord('G'):
         begin
           CopyToUndo;
           if (Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].NoteType = ntGolden) then
@@ -1141,7 +1141,7 @@ begin
         end;
 
       // Freestyle Note
-      SDLK_F:
+      Ord('F'):
         begin
           CopyToUndo;
           if (Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].NoteType = ntFreestyle) then
@@ -1168,7 +1168,7 @@ begin
         end;
 
       // undo
-      SDLK_Z:
+      Ord('Z'):
         begin
           if SDL_ModState = KMOD_LCTRL then
           begin


### PR DESCRIPTION
fixes #721.
The `SDLK_*` form was always fine under Linux and Mac. Changing it to use `Ord(CharCode)` makes it still work on those platforms, but also fixes it Windows (though I don't know _why_ this fixes it)

I went through the code and also looked into where else this was used, it's only in two places: `UScreenJukebox` and `UScreenJukeboxOptions`. The former shows up as 85% comment in my editor, making it really hard to figure out what's going on. The latter is easier but if I change only that one it seems to break in really weird ways again. But there are a lot of other things wrong with the Jukebox (just going into it appears to have reset microphone assignments?) that I'm not very motivated to fix the keybinds there.

So this PR only fixes the editor.