### PR TITLE
nicer fading

### DIFF
--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -1267,6 +1267,10 @@ end;
 
 procedure TScreenSingController.OnHide;
 begin
+  // close video files
+  fVideoClip := nil;
+  fCurrentVideo := nil;
+
   // background texture
   if Tex_Background.TexNum > 0 then
   begin
@@ -1496,10 +1500,6 @@ begin
 
   LyricsState.Stop();
   LyricsState.SetSyncSource(nil);
-
-  // close video files
-  fVideoClip := nil;
-  fCurrentVideo := nil;
 
   // kill all stars and effects
   GoldenRec.KillAll;


### PR DESCRIPTION
fixes #86 
make fading from sing screen to score screen much nicer by unloading the video later

maybe it'll still show the background image for a fraction of a second if you disabled both the background + video by pressing `V` during a song. did not test visualizations.

demo video:

https://github.com/UltraStar-Deluxe/USDX/assets/5775429/060711de-4092-4337-be92-e8a1ff4073ef

for at least videos or background images it will just use whatever was on the last frame.