### PR TITLE
S skips more

### DIFF
--- a/game/languages/English.ini
+++ b/game/languages/English.ini
@@ -1471,7 +1471,7 @@ K = Toggle karaoke playback (removes vocals)
 V = Toggle video/visualization/background (if available)
 W = Toggle webcam on/off (if available)
 T = Toggle running time/remaining time/total time display
-S = Skip intro
+S = Skip intro/long break
 CTRL_TAB = Change visualization style (if visualization is enabled)
 CTRL_TAB = Change webcam filter (if webcam is enabled)
 ;PAGEUPDOWN Adjust song volume

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -410,8 +410,6 @@ begin
           if (AudioPlayback.Position < CurrentSong.gap / 1000 - 6) then
           begin
             AudioPlayback.SetPosition(CurrentSong.gap / 1000.0 - 5.0);
-              if (Assigned(fCurrentVideo)) then
-                 fCurrentVideo.Position := CurrentSong.VideoGAP + CurrentSong.Start + (CurrentSong.gap / 1000.0 - 5.0);
           end;
           Exit;
         end;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -407,9 +407,13 @@ begin
         end
         else
         begin
-          if (AudioPlayback.Position < CurrentSong.gap / 1000 - 6) then
+          if (not CurrentSong.isDuet and (GetTimeFromBeat(Lyrics.GetUpperLine().StartNote) - AudioPlayback.Position > 6)) then
           begin
-            AudioPlayback.SetPosition(CurrentSong.gap / 1000.0 - 5.0);
+            AudioPlayback.SetPosition(GetTimeFromBeat(Lyrics.GetUpperLine().StartNote) - 5);
+          end
+          else if (CurrentSong.isDuet and (GetTimeFromBeat(min(LyricsDuetP1.GetUpperLine().StartNote, LyricsDuetP2.GetUpperLine().StartNote)) - AudioPlayback.Position > 6)) then
+          begin
+            AudioPlayback.SetPosition(GetTimeFromBeat(min(LyricsDuetP1.GetUpperLine().StartNote, LyricsDuetP2.GetUpperLine().StartNote)) - 5);
           end;
           Exit;
         end;


### PR DESCRIPTION
fixes #747 

Current functionality: `S` can skip the _intro_ of a song (but only if the GAP is properly set and the first note is at or near beat 0).

This PR enhances that functionality in the following ways:
- Skip intro on any song: it is now timed relative to the start of the first _note_
- Skip long breaks in songs (this one only works if the linebreak has already occured -- ie it doesn't work if the linebreak is at the _end_ of the long break)

I've also removed explicitly setting the video time because that appears to resync to the audio anyway.

A video to show how OP this is:

https://github.com/UltraStar-Deluxe/USDX/assets/5775429/de804c5e-5893-4b07-a05c-be3fb55e711e

I press `S` at 4.3 and 27.8. The jump at 14.2 is because I paused the recording while I was skipping ahead in the song, so ignore that.

I tested both duets and non-duets, songs with proper GAP and GAP:0, and also a song that had GAP:0 + a big `#START` value (it was one chapter of a multi-chapter song). In all these cases it worked fine, and at the very least it doesn't appear to break the only existing previous behaviour.