### PR TITLE
Remove k voiceremoval

### DIFF
--- a/game/languages/English.ini
+++ b/game/languages/English.ini
@@ -1155,12 +1155,6 @@ BACKSPACE = Leave filtered song selection (if active) / Back to main menu
 ESC = Leave filtered song selection (if active) / Back to main menu
 Q = Quit UltraStar Deluxe
 ;-------------------------------------------------------;
-SEC_005 = Playback
-;PAGEUPDOWN  Adjust song volume
-K = Toggle karaoke playback (removes vocals)
-;V Toggle fullscreen video preview
-;A Switch aspect ratio (fullscreen mode only)
-;-------------------------------------------------------;
 SEC_010 = Navigation
 UPDOWN = Move to previous/next category (if categories selected)
 LEFTRIGHT = Rotate left/right through song collection
@@ -1467,7 +1461,6 @@ SEC_002 = Playback
 SPACE = Pause/unpause song
 P = Pause/unpause song
 R = Restart song from beginning
-K = Toggle karaoke playback (removes vocals)
 V = Toggle video/visualization/background (if available)
 W = Toggle webcam on/off (if available)
 T = Toggle running time/remaining time/total time display

--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -230,12 +230,6 @@ type
   end;
 
 type
-  TSoundEffect = class
-    public
-      EngineData: Pointer; // can be used for engine-specific data
-      procedure Callback(Buffer: PByteArray; BufSize: integer); virtual; abstract;
-  end;
-
   TSoundFX = class
     public
       EngineData: Pointer; // can be used for engine-specific data
@@ -341,9 +335,6 @@ type
 
       procedure GetFFTData(var data: TFFTData);          virtual; abstract;
       function GetPCMData(var data: TPCMData): Cardinal; virtual; abstract;
-
-      procedure AddSoundEffect(Effect: TSoundEffect);    virtual; abstract;
-      procedure RemoveSoundEffect(Effect: TSoundEffect); virtual; abstract;
 
       procedure AddSoundFX(FX: TSoundFX);    virtual; abstract;
       procedure RemoveSoundFX(FX: TSoundFX); virtual; abstract;

--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -236,11 +236,6 @@ type
       procedure Callback(Buffer: PByteArray; BufSize: integer); virtual; abstract;
   end;
 
-  TVoiceRemoval = class(TSoundEffect)
-    public
-      procedure Callback(Buffer: PByteArray; BufSize: integer); override;
-  end;
-
   TSoundFX = class
     public
       EngineData: Pointer; // can be used for engine-specific data
@@ -1050,33 +1045,6 @@ begin
   If (Soundlib.BGMusic <> nil) then
   begin
     Soundlib.BGMusic.Pause;
-  end;
-end;
-
-{ TVoiceRemoval }
-
-procedure TVoiceRemoval.Callback(Buffer: PByteArray; BufSize: integer);
-var
-  FrameIndex, FrameSize: integer;
-  Value: integer;
-  Sample: PPCMStereoSample;
-begin
-  FrameSize := 2 * SizeOf(SmallInt);
-  for FrameIndex := 0 to (BufSize div FrameSize)-1 do
-  begin
-    Sample := PPCMStereoSample(Buffer);
-    // channel difference
-    Value := Sample[0] - Sample[1];
-    // clip
-    if (Value > High(SmallInt)) then
-      Value := High(SmallInt)
-    else if (Value < Low(SmallInt)) then
-      Value := Low(SmallInt);
-    // assign result
-    Sample[0] := Value;
-    Sample[1] := Value;
-    // increase to next frame
-    Inc(PByte(Buffer), FrameSize);
   end;
 end;
 

--- a/src/media/UAudioPlaybackBase.pas
+++ b/src/media/UAudioPlaybackBase.pas
@@ -127,23 +127,14 @@ type
       procedure Close(); override;
   end;
 
-procedure ToggleVoiceRemoval();
-
 implementation
 
 uses
   ULog;
 
-var doVoiceRemoval: boolean;
-
 constructor TAudioPlaybackBase.Create();
 begin
   inherited;
-end;
-
-procedure ToggleVoiceRemoval();
-begin
-  doVoiceRemoval:=not(doVoiceRemoval);
 end;
 
 { TAudioPlaybackBase }
@@ -167,7 +158,6 @@ begin
     Exit;
   end;
 
-  if doVoiceRemoval then MusicStream.AddSoundEffect(TVoiceRemoval.Create());
   if assigned(IReplayGain) and IReplayGain.CanEnable then MusicStream.AddSoundFX(IReplayGain.Create());
 
   Result := true;

--- a/src/media/UAudioPlayback_Bass.pas
+++ b/src/media/UAudioPlayback_Bass.pas
@@ -783,11 +783,6 @@ begin
   //BASS_SetConfig(BASS_CONFIG_UPDATEPERIOD, 10);
   //BASS_SetConfig(BASS_CONFIG_BUFFER, 100);
 
-  // Using floating-point DSP config converts the passed data to 32bit sample data
-  // some used effects doesn't expect this kind of data, therefore they are bugging
-  // (see Voice removal; UMusic TVoiceRemoval.Callback)
-  //BASS_SetConfig(BASS_CONFIG_FLOATDSP, 1); // enable floating-point DSP
-
   Result := true;
 end;
 

--- a/src/media/UAudioPlayback_Bass.pas
+++ b/src/media/UAudioPlayback_Bass.pas
@@ -85,9 +85,6 @@ type
       procedure FadeIn(Time: real; TargetVolume: single); override;
       procedure Fade(Time: real; TargetVolume: single); override;
 
-      procedure AddSoundEffect(Effect: TSoundEffect);    override;
-      procedure RemoveSoundEffect(Effect: TSoundEffect); override;
-
       procedure AddSoundFX(FX: TSoundFX);    override;
       procedure RemoveSoundFX(FX: TSoundFX); override;
 
@@ -507,53 +504,10 @@ begin
     SourceStream.Loop := Enabled;
 end;
 
+// This is an empty handler because we need to implement it but never use it
 procedure DSPProcHandler(handle: HDSP; channel: DWORD; buffer: Pointer; length: DWORD; user: Pointer);
 {$IFDEF MSWINDOWS}stdcall;{$ELSE}cdecl;{$ENDIF}
-var
-  Effect: TSoundEffect;
 begin
-  Effect := TSoundEffect(user);
-  if assigned(Effect) then
-    Effect.Callback(buffer, length);
-end;
-
-procedure TBassPlaybackStream.AddSoundEffect(Effect: TSoundEffect);
-var
-  DspHandle: HDSP;
-begin
-  if assigned(Effect.engineData) then
-  begin
-    Log.LogError('TSoundEffect.engineData already set', 'TBassPlaybackStream.AddSoundEffect');
-    Exit;
-  end;
-
-  DspHandle := BASS_ChannelSetDSP(Handle, @DSPProcHandler, Effect, 0);
-  if (DspHandle = 0) then
-  begin
-    Log.LogError(BassCore.ErrorGetString(), 'TBassPlaybackStream.AddSoundEffect');
-    Exit;
-  end;
-
-  GetMem(Effect.EngineData, SizeOf(HDSP));
-  PHDSP(Effect.EngineData)^ := DspHandle;
-end;
-
-procedure TBassPlaybackStream.RemoveSoundEffect(Effect: TSoundEffect);
-begin
-  if not assigned(Effect.EngineData) then
-  begin
-    Log.LogError('TSoundEffect.engineData invalid', 'TBassPlaybackStream.RemoveSoundEffect');
-    Exit;
-  end;
-
-  if not BASS_ChannelRemoveDSP(Handle, PHDSP(Effect.EngineData)^) then
-  begin
-    Log.LogError(BassCore.ErrorGetString(), 'TBassPlaybackStream.RemoveSoundEffect');
-    Exit;
-  end;
-
-  FreeMem(Effect.EngineData);
-  Effect.EngineData := nil;
 end;
 
 procedure TBassPlaybackStream.AddSoundFX(FX: TSoundFX);

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -785,16 +785,6 @@ begin
           Exit;
         end;
 
-      Ord('K'):
-        begin
-          UAudioPlaybackBase.ToggleVoiceRemoval();
-          StopVideoPreview();
-          StopMusicPreview();
-          StartMusicPreview();
-          StartVideoPreview();
-          Exit;
-        end;
-
       Ord('F'):
         begin
           if (Mode = smNormal) and (SDL_ModState = KMOD_LSHIFT) and MakeMedley then


### PR DESCRIPTION
fixes #748 

removes both the stuff directly related to `K`, as well as the now-unused underlying infrastructure (in separate commits).
I've left in a now-empty `procedure DSPProcHandler` because searching the codebase for `dspproc` turns up a dozen or so results and I don't know this works.
Tested only on Linux, I can do the Windows one once the PR artifact has built and hopefully someone can also check this on Mac (since this touches stuff that could be platform-specific)

EDIT: make sure to also edit https://github.com/UltraStar-Deluxe/USDX/wiki/Controls#shortcuts-for-song-selection-screen when merging this