### PR TITLE
Improve release documentation

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,7 +10,7 @@
     * in `variables.nsh` update both blocks immediately and swap the comments
     * in `ultrastardx.appdata.xml` add a new entry
 3. Commit, `git tag v<the-new-version>` and then `git push origin master v<the-new-version> master:release`\
-    __It is important that these two get pushed together__ otherwise Flatpak gets confused.
+    __It is important that master and the version get pushed together__ otherwise Flatpak gets confused.
 4. Wait and get the artifacts from the CI.
     If any of them fail, just add an extra `;` on one of the already commented lines in `variables.nsh`, commit, and then push only `master`.
 5. Add `+dev` to the version in the first two files and swap the comments in `variables.nsh` again, commit, push.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,10 @@
 # Making a release
 1. Find the contents of `VERSION` (strip the `+dev`) throughout the code.
     This should result in four places:
-    * VERSION
-    * UConfig.pas
-    * variables.nsh
-    * ultrastardx.appdata.xml
+    * [VERSION](VERSION)
+    * [UConfig.pas](src/base/UConfig.pas)
+    * [variables.nsh](installer/settings/variables.nsh)
+    * [ultrastardx.appdata.xml](dists/ultrastardx.appdata.xml)
 2. Make the release:
     * in the first two files, update it to the new version _without_ the `+dev` bit
     * in `variables.nsh` update both blocks immediately and swap the comments

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,7 +9,7 @@
     * in the first two files, update it to the new version _without_ the `+dev` bit
     * in `variables.nsh` update both blocks immediately and swap the comments
     * in `ultrastardx.appdata.xml` add a new entry
-3. Commit, `git tag v<the-new-version>` and then `git push origin master v<the-new-version>`\
+3. Commit, `git tag v<the-new-version>` and then `git push origin master v<the-new-version> master:release`\
     __It is important that these two get pushed together__ otherwise Flatpak gets confused.
 4. Wait and get the artifacts from the CI.
     If any of them fail, just add an extra `;` on one of the already commented lines in `variables.nsh`, commit, and then push only `master`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,14 +1,16 @@
 # Making a release
 1. Find the contents of `VERSION` (strip the `+dev`) throughout the code.
-    This should result in four places:
+    This should result in six places:
     * [VERSION](VERSION)
     * [UConfig.pas](src/base/UConfig.pas)
     * [variables.nsh](installer/settings/variables.nsh)
     * [ultrastardx.appdata.xml](dists/ultrastardx.appdata.xml)
+    * 2x [Info.plist](src/macosx/Info.plist)
 2. Make the release:
     * in the first two files, update it to the new version _without_ the `+dev` bit
     * in `variables.nsh` update both blocks immediately and swap the comments
     * in `ultrastardx.appdata.xml` add a new entry
+    * in `Info.plist` update the version number
 3. Commit, `git tag v<the-new-version>` and then `git push origin master v<the-new-version> master:release`\
     __It is important that master and the version get pushed together__ otherwise Flatpak gets confused.
 4. Wait and get the artifacts from the CI.


### PR DESCRIPTION
This updates some release information:
- also update the `releases` branch, fixes #735 
- update the Mac version number, see #744 and PR #745
- some miscellaneous improvements

Do not merge this before 745