### PR TITLE
Simplify theme loading

### DIFF
--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -413,27 +413,27 @@ end;
 procedure SingDrawOscilloscopes;
 begin;
   if PlayersPlay = 1 then
-    SingDrawOscilloscope(Theme.Sing.SingP1Oscilloscope, 0);
+    SingDrawOscilloscope(Theme.Sing.Solo1PP1.Oscilloscope, 0);
 
   if PlayersPlay = 2 then
   begin
-    SingDrawOscilloscope(Theme.Sing.SingP1TwoPOscilloscope, 0);
-    SingDrawOscilloscope(Theme.Sing.SingP2ROscilloscope, 1);
+    SingDrawOscilloscope(Theme.Sing.Solo2PP1.Oscilloscope, 0);
+    SingDrawOscilloscope(Theme.Sing.Solo2PP2.Oscilloscope, 1);
   end;
 
   if PlayersPlay = 3 then
   begin
     if (CurrentSong.isDuet) then
     begin
-      SingDrawOscilloscope(Theme.Sing.SingDuetP1ThreePOscilloscope, 0);
-      SingDrawOscilloscope(Theme.Sing.SingDuetP2MOscilloscope, 1);
-      SingDrawOscilloscope(Theme.Sing.SingDuetP3ROscilloscope, 2);
+      SingDrawOscilloscope(Theme.Sing.Duet3PP1.Oscilloscope, 0);
+      SingDrawOscilloscope(Theme.Sing.Duet3PP2.Oscilloscope, 1);
+      SingDrawOscilloscope(Theme.Sing.Duet3PP3.Oscilloscope, 2);
     end
     else
     begin
-      SingDrawOscilloscope(Theme.Sing.SingP1ThreePOscilloscope, 0);
-      SingDrawOscilloscope(Theme.Sing.SingP2MOscilloscope, 1);
-      SingDrawOscilloscope(Theme.Sing.SingP3ROscilloscope, 2);
+      SingDrawOscilloscope(Theme.Sing.Solo3PP1.Oscilloscope, 0);
+      SingDrawOscilloscope(Theme.Sing.Solo3PP2.Oscilloscope, 1);
+      SingDrawOscilloscope(Theme.Sing.Solo3PP3.Oscilloscope, 2);
     end;
   end;
 
@@ -443,30 +443,30 @@ begin;
     begin
       if ScreenAct = 1 then
       begin
-        SingDrawOscilloscope(Theme.Sing.SingP1TwoPOscilloscope, 0);
-        SingDrawOscilloscope(Theme.Sing.SingP2ROscilloscope, 1);
+        SingDrawOscilloscope(Theme.Sing.Solo2PP1.Oscilloscope, 0);
+        SingDrawOscilloscope(Theme.Sing.Solo2PP2.Oscilloscope, 1);
       end;
       if ScreenAct = 2 then
       begin
-        SingDrawOscilloscope(Theme.Sing.SingP1TwoPOscilloscope, 2);
-        SingDrawOscilloscope(Theme.Sing.SingP2ROscilloscope, 3);
+        SingDrawOscilloscope(Theme.Sing.Solo2PP1.Oscilloscope, 2);
+        SingDrawOscilloscope(Theme.Sing.Solo2PP2.Oscilloscope, 3);
       end;
     end
     else
     begin
       if (CurrentSong.isDuet) then
       begin
-        SingDrawOscilloscope(Theme.Sing.SingP1DuetFourPOscilloscope, 0);
-        SingDrawOscilloscope(Theme.Sing.SingP2DuetFourPOscilloscope, 1);
-        SingDrawOscilloscope(Theme.Sing.SingP3DuetFourPOscilloscope, 2);
-        SingDrawOscilloscope(Theme.Sing.SingP4DuetFourPOscilloscope, 3);
+        SingDrawOscilloscope(Theme.Sing.Duet4PP1.Oscilloscope, 0);
+        SingDrawOscilloscope(Theme.Sing.Duet4PP2.Oscilloscope, 1);
+        SingDrawOscilloscope(Theme.Sing.Duet4PP3.Oscilloscope, 2);
+        SingDrawOscilloscope(Theme.Sing.Duet4PP4.Oscilloscope, 3);
       end
       else
       begin
-        SingDrawOscilloscope(Theme.Sing.SingP1FourPOscilloscope, 0);
-        SingDrawOscilloscope(Theme.Sing.SingP2FourPOscilloscope, 1);
-        SingDrawOscilloscope(Theme.Sing.SingP3FourPOscilloscope, 2);
-        SingDrawOscilloscope(Theme.Sing.SingP4FourPOscilloscope, 3);
+        SingDrawOscilloscope(Theme.Sing.Solo4PP1.Oscilloscope, 0);
+        SingDrawOscilloscope(Theme.Sing.Solo4PP2.Oscilloscope, 1);
+        SingDrawOscilloscope(Theme.Sing.Solo4PP3.Oscilloscope, 2);
+        SingDrawOscilloscope(Theme.Sing.Solo4PP4.Oscilloscope, 3);
       end;
     end;
   end;
@@ -479,31 +479,31 @@ begin;
       begin
         if ScreenAct = 1 then
         begin
-          SingDrawOscilloscope(Theme.Sing.SingDuetP1ThreePOscilloscope, 0);
-          SingDrawOscilloscope(Theme.Sing.SingDuetP2MOscilloscope, 1);
-          SingDrawOscilloscope(Theme.Sing.SingDuetP3ROscilloscope, 2);
+          SingDrawOscilloscope(Theme.Sing.Duet3PP1.Oscilloscope, 0);
+          SingDrawOscilloscope(Theme.Sing.Duet3PP2.Oscilloscope, 1);
+          SingDrawOscilloscope(Theme.Sing.Duet3PP3.Oscilloscope, 2);
         end;
         if ScreenAct = 2 then
         begin
-          SingDrawOscilloscope(Theme.Sing.SingDuetP1ThreePOscilloscope, 3);
-          SingDrawOscilloscope(Theme.Sing.SingDuetP2MOscilloscope, 4);
-          SingDrawOscilloscope(Theme.Sing.SingDuetP3ROscilloscope, 5);
+          SingDrawOscilloscope(Theme.Sing.Duet3PP1.Oscilloscope, 3);
+          SingDrawOscilloscope(Theme.Sing.Duet3PP2.Oscilloscope, 4);
+          SingDrawOscilloscope(Theme.Sing.Duet3PP3.Oscilloscope, 5);
         end;
       end
       else
       begin
         if ScreenAct = 1 then
         begin
-          SingDrawOscilloscope(Theme.Sing.SingP1ThreePOscilloscope, 0);
-          SingDrawOscilloscope(Theme.Sing.SingP2MOscilloscope, 1);
-          SingDrawOscilloscope(Theme.Sing.SingP3ROscilloscope, 2);
+          SingDrawOscilloscope(Theme.Sing.Solo3PP1.Oscilloscope, 0);
+          SingDrawOscilloscope(Theme.Sing.Solo3PP2.Oscilloscope, 1);
+          SingDrawOscilloscope(Theme.Sing.Solo3PP3.Oscilloscope, 2);
         end;
 
         if ScreenAct = 2 then
         begin
-          SingDrawOscilloscope(Theme.Sing.SingP1ThreePOscilloscope, 3);
-          SingDrawOscilloscope(Theme.Sing.SingP2MOscilloscope, 4);
-          SingDrawOscilloscope(Theme.Sing.SingP3ROscilloscope, 5);
+          SingDrawOscilloscope(Theme.Sing.Solo3PP1.Oscilloscope, 3);
+          SingDrawOscilloscope(Theme.Sing.Solo3PP2.Oscilloscope, 4);
+          SingDrawOscilloscope(Theme.Sing.Solo3PP3.Oscilloscope, 5);
         end;
       end;
     end
@@ -511,21 +511,21 @@ begin;
     begin
       if (CurrentSong.isDuet) then
       begin
-        SingDrawOscilloscope(Theme.Sing.SingP1DuetSixPOscilloscope, 0);
-        SingDrawOscilloscope(Theme.Sing.SingP2DuetSixPOscilloscope, 1);
-        SingDrawOscilloscope(Theme.Sing.SingP3DuetSixPOscilloscope, 2);
-        SingDrawOscilloscope(Theme.Sing.SingP4DuetSixPOscilloscope, 3);
-        SingDrawOscilloscope(Theme.Sing.SingP5DuetSixPOscilloscope, 4);
-        SingDrawOscilloscope(Theme.Sing.SingP6DuetSixPOscilloscope, 5);
+        SingDrawOscilloscope(Theme.Sing.Duet6PP1.Oscilloscope, 0);
+        SingDrawOscilloscope(Theme.Sing.Duet6PP2.Oscilloscope, 1);
+        SingDrawOscilloscope(Theme.Sing.Duet6PP3.Oscilloscope, 2);
+        SingDrawOscilloscope(Theme.Sing.Duet6PP4.Oscilloscope, 3);
+        SingDrawOscilloscope(Theme.Sing.Duet6PP5.Oscilloscope, 4);
+        SingDrawOscilloscope(Theme.Sing.Duet6PP6.Oscilloscope, 5);
       end
       else
       begin
-        SingDrawOscilloscope(Theme.Sing.SingP1SixPOscilloscope, 0);
-        SingDrawOscilloscope(Theme.Sing.SingP2SixPOscilloscope, 1);
-        SingDrawOscilloscope(Theme.Sing.SingP3SixPOscilloscope, 2);
-        SingDrawOscilloscope(Theme.Sing.SingP4SixPOscilloscope, 3);
-        SingDrawOscilloscope(Theme.Sing.SingP5SixPOscilloscope, 4);
-        SingDrawOscilloscope(Theme.Sing.SingP6SixPOscilloscope, 5);
+        SingDrawOscilloscope(Theme.Sing.Solo6PP1.Oscilloscope, 0);
+        SingDrawOscilloscope(Theme.Sing.Solo6PP2.Oscilloscope, 1);
+        SingDrawOscilloscope(Theme.Sing.Solo6PP3.Oscilloscope, 2);
+        SingDrawOscilloscope(Theme.Sing.Solo6PP4.Oscilloscope, 3);
+        SingDrawOscilloscope(Theme.Sing.Solo6PP5.Oscilloscope, 4);
+        SingDrawOscilloscope(Theme.Sing.Solo6PP6.Oscilloscope, 5);
       end;
     end;
   end;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -976,14 +976,14 @@ begin
                     end;
                   3:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP4DuetSixPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP4DuetSixPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Duet6PP4.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Duet6PP4.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP4DuetSixPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP4DuetSixPScore.Y + 40;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Duet6PP4.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Duet6PP4.Score.Y + 40;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP4DuetSixPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP4DuetSixPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Duet6PP4.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Duet6PP4.Score.Y;
                     end;
                   4:
                     begin
@@ -1497,16 +1497,16 @@ begin
                Position.TextSize  := Theme.Sing.Duet6PP3.Score.Size;
              end;
           3: begin
-               Position.BGX := Theme.Sing.StaticP4DuetSixPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP4DuetSixPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP4DuetSixPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP4DuetSixPScoreBG.H;
+               Position.BGX := Theme.Sing.Duet6PP4.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Duet6PP4.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Duet6PP4.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Duet6PP4.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP4DuetSixPScore.X;
-               Position.TextY     := Theme.Sing.TextP4DuetSixPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP4DuetSixPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP4DuetSixPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP4DuetSixPScore.Size;
+               Position.TextX     := Theme.Sing.Duet6PP4.Score.X;
+               Position.TextY     := Theme.Sing.Duet6PP4.Score.Y;
+               Position.TextFont  := Theme.Sing.Duet6PP4.Score.Font;
+               Position.TextStyle := Theme.Sing.Duet6PP4.Score.Style;
+               Position.TextSize  := Theme.Sing.Duet6PP4.Score.Size;
              end;
           4: begin
                Position.BGX := Theme.Sing.StaticP5DuetSixPScoreBG.X;
@@ -1815,10 +1815,10 @@ begin
                Position.RBH := Theme.Sing.Duet6PP3.SingBar.H;
              end;
           3: begin
-               Position.RBX := Theme.Sing.StaticP4DuetSixPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP4DuetSixPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP4DuetSixPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP4DuetSixPSingBar.H;
+               Position.RBX := Theme.Sing.Duet6PP4.SingBar.X;
+               Position.RBY := Theme.Sing.Duet6PP4.SingBar.Y;
+               Position.RBW := Theme.Sing.Duet6PP4.SingBar.W;
+               Position.RBH := Theme.Sing.Duet6PP4.SingBar.H;
              end;
           4: begin
                Position.RBX := Theme.Sing.StaticP5DuetSixPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -848,14 +848,14 @@ begin
                     end;
                   1:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP2DuetFourPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP2DuetFourPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Duet4PP2.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Duet4PP2.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP2DuetFourPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP2DuetFourPScore.Y + 40;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Duet4PP2.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Duet4PP2.Score.Y + 40;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP2DuetFourPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP2DuetFourPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Duet4PP2.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Duet4PP2.Score.Y;
                     end;
                   2:
                     begin
@@ -1363,16 +1363,16 @@ begin
                Position.TextSize  := Theme.Sing.Duet4PP1.Score.Size;
              end;
           1: begin
-               Position.BGX := Theme.Sing.StaticP2DuetFourPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP2DuetFourPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP2DuetFourPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP2DuetFourPScoreBG.H;
+               Position.BGX := Theme.Sing.Duet4PP2.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Duet4PP2.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Duet4PP2.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Duet4PP2.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP2DuetFourPScore.X;
-               Position.TextY     := Theme.Sing.TextP2DuetFourPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP2DuetFourPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP2DuetFourPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP2DuetFourPScore.Size;
+               Position.TextX     := Theme.Sing.Duet4PP2.Score.X;
+               Position.TextY     := Theme.Sing.Duet4PP2.Score.Y;
+               Position.TextFont  := Theme.Sing.Duet4PP2.Score.Font;
+               Position.TextStyle := Theme.Sing.Duet4PP2.Score.Style;
+               Position.TextSize  := Theme.Sing.Duet4PP2.Score.Size;
              end;
           2: begin
                Position.BGX := Theme.Sing.StaticP3DuetFourPScoreBG.X;
@@ -1739,10 +1739,10 @@ begin
                Position.RBH := Theme.Sing.Duet4PP1.SingBar.H;
              end;
           1: begin
-               Position.RBX := Theme.Sing.StaticP2DuetFourPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP2DuetFourPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP2DuetFourPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP2DuetFourPSingBar.H;
+               Position.RBX := Theme.Sing.Duet4PP2.SingBar.X;
+               Position.RBY := Theme.Sing.Duet4PP2.SingBar.Y;
+               Position.RBW := Theme.Sing.Duet4PP2.SingBar.W;
+               Position.RBH := Theme.Sing.Duet4PP2.SingBar.H;
              end;
           2: begin
                Position.RBX := Theme.Sing.StaticP3DuetFourPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -1118,14 +1118,14 @@ begin
                   end;
                 2, 5, 8:
                   begin
-                    aPositions[PIndex].PUW := Theme.Sing.StaticDuetP3RScoreBG.W;
-                    aPositions[PIndex].PUH := Theme.Sing.StaticDuetP3RScoreBG.H;
+                    aPositions[PIndex].PUW := Theme.Sing.Duet3PP3.ScoreBackground.W;
+                    aPositions[PIndex].PUH := Theme.Sing.Duet3PP3.ScoreBackground.H;
 
-                    aPositions[PIndex].PUStartX := Theme.Sing.StaticDuetP3RScoreBG.X;
-                    aPositions[PIndex].PUStartY := Theme.Sing.TextDuetP3RScore.Y + 40;
+                    aPositions[PIndex].PUStartX := Theme.Sing.Duet3PP3.ScoreBackground.X;
+                    aPositions[PIndex].PUStartY := Theme.Sing.Duet3PP3.Score.Y + 40;
 
-                    aPositions[PIndex].PUTargetX := Theme.Sing.StaticDuetP3RScoreBG.X;
-                    aPositions[PIndex].PUTargetY := Theme.Sing.TextDuetP3RScore.Y;
+                    aPositions[PIndex].PUTargetX := Theme.Sing.Duet3PP3.ScoreBackground.X;
+                    aPositions[PIndex].PUTargetY := Theme.Sing.Duet3PP3.Score.Y;
                   end;
               end;
             end;
@@ -1652,15 +1652,15 @@ begin
                  Position.TextSize := Theme.Sing.TextDuetP2MScore.Size;
                end;
             2, 5, 8: begin
-                 Position.BGX := Theme.Sing.StaticDuetP3RScoreBG.X;
-                 Position.BGY := Theme.Sing.StaticDuetP3RScoreBG.Y;
-                 Position.BGW := Theme.Sing.StaticDuetP3RScoreBG.W;
-                 Position.BGH := Theme.Sing.StaticDuetP3RScoreBG.H;
+                 Position.BGX := Theme.Sing.Duet3PP3.ScoreBackground.X;
+                 Position.BGY := Theme.Sing.Duet3PP3.ScoreBackground.Y;
+                 Position.BGW := Theme.Sing.Duet3PP3.ScoreBackground.W;
+                 Position.BGH := Theme.Sing.Duet3PP3.ScoreBackground.H;
 
-                 Position.TextX := Theme.Sing.TextDuetP3RScore.X;
-                 Position.TextY := Theme.Sing.TextDuetP3RScore.Y;
-                 Position.TextFont := Theme.Sing.TextDuetP3RScore.Font;
-                 Position.TextSize := Theme.Sing.TextDuetP3RScore.Size;
+                 Position.TextX := Theme.Sing.Duet3PP3.Score.X;
+                 Position.TextY := Theme.Sing.Duet3PP3.Score.Y;
+                 Position.TextFont := Theme.Sing.Duet3PP3.Score.Font;
+                 Position.TextSize := Theme.Sing.Duet3PP3.Score.Size;
                end;
           end;
       end;
@@ -1911,10 +1911,10 @@ begin
                  Position.RBH := Theme.Sing.StaticDuetP2MSingBar.H;
                end;
             2, 5, 8: begin
-                 Position.RBX := Theme.Sing.StaticDuetP3RSingBar.X;
-                 Position.RBY := Theme.Sing.StaticDuetP3RSingBar.Y;
-                 Position.RBW := Theme.Sing.StaticDuetP3RSingBar.W;
-                 Position.RBH := Theme.Sing.StaticDuetP3RSingBar.H;
+                 Position.RBX := Theme.Sing.Duet3PP3.SingBar.X;
+                 Position.RBY := Theme.Sing.Duet3PP3.SingBar.Y;
+                 Position.RBW := Theme.Sing.Duet3PP3.SingBar.W;
+                 Position.RBH := Theme.Sing.Duet3PP3.SingBar.H;
                end;
           end;
         end;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -1096,14 +1096,14 @@ begin
               case (PopUp.Player) of
                 0, 3, 6:
                   begin
-                    aPositions[PIndex].PUW := Theme.Sing.StaticDuetP1ThreePScoreBG.W;
-                    aPositions[PIndex].PUH := Theme.Sing.StaticDuetP1ThreePScoreBG.H;
+                    aPositions[PIndex].PUW := Theme.Sing.Duet3PP1.ScoreBackground.W;
+                    aPositions[PIndex].PUH := Theme.Sing.Duet3PP1.ScoreBackground.H;
 
-                    aPositions[PIndex].PUStartX := Theme.Sing.StaticDuetP1ThreePScoreBG.X;
-                    aPositions[PIndex].PUStartY := Theme.Sing.TextDuetP1ThreePScore.Y + 40;
+                    aPositions[PIndex].PUStartX := Theme.Sing.Duet3PP1.ScoreBackground.X;
+                    aPositions[PIndex].PUStartY := Theme.Sing.Duet3PP1.Score.Y + 40;
 
-                    aPositions[PIndex].PUTargetX := Theme.Sing.StaticDuetP1ThreePScoreBG.X;
-                    aPositions[PIndex].PUTargetY := Theme.Sing.TextDuetP1ThreePScore.Y;
+                    aPositions[PIndex].PUTargetX := Theme.Sing.Duet3PP1.ScoreBackground.X;
+                    aPositions[PIndex].PUTargetY := Theme.Sing.Duet3PP1.Score.Y;
                   end;
                 1, 4, 7:
                   begin
@@ -1630,15 +1630,15 @@ begin
         begin
           case Index of
             0, 3, 6: begin
-                 Position.BGX := Theme.Sing.StaticDuetP1ThreePScoreBG.X;
-                 Position.BGY := Theme.Sing.StaticDuetP1ThreePScoreBG.Y;
-                 Position.BGW := Theme.Sing.StaticDuetP1ThreePScoreBG.W;
-                 Position.BGH := Theme.Sing.StaticDuetP1ThreePScoreBG.H;
+                 Position.BGX := Theme.Sing.Duet3PP1.ScoreBackground.X;
+                 Position.BGY := Theme.Sing.Duet3PP1.ScoreBackground.Y;
+                 Position.BGW := Theme.Sing.Duet3PP1.ScoreBackground.W;
+                 Position.BGH := Theme.Sing.Duet3PP1.ScoreBackground.H;
 
-                 Position.TextX := Theme.Sing.TextDuetP1ThreePScore.X;
-                 Position.TextY := Theme.Sing.TextDuetP1ThreePScore.Y;
-                 Position.TextFont := Theme.Sing.TextDuetP1ThreePScore.Font;
-                 Position.TextSize := Theme.Sing.TextDuetP1ThreePScore.Size;
+                 Position.TextX := Theme.Sing.Duet3PP1.Score.X;
+                 Position.TextY := Theme.Sing.Duet3PP1.Score.Y;
+                 Position.TextFont := Theme.Sing.Duet3PP1.Score.Font;
+                 Position.TextSize := Theme.Sing.Duet3PP1.Score.Size;
                end;
             1, 4, 7: begin
                  Position.BGX := Theme.Sing.Duet3PP2.ScoreBackground.X;
@@ -1899,10 +1899,10 @@ begin
           case Index of
             0, 3, 6:
                begin
-                 Position.RBX := Theme.Sing.StaticDuetP1ThreePSingBar.X;
-                 Position.RBY := Theme.Sing.StaticDuetP1ThreePSingBar.Y;
-                 Position.RBW := Theme.Sing.StaticDuetP1ThreePSingBar.W;
-                 Position.RBH := Theme.Sing.StaticDuetP1ThreePSingBar.H;
+                 Position.RBX := Theme.Sing.Duet3PP1.SingBar.X;
+                 Position.RBY := Theme.Sing.Duet3PP1.SingBar.Y;
+                 Position.RBW := Theme.Sing.Duet3PP1.SingBar.W;
+                 Position.RBH := Theme.Sing.Duet3PP1.SingBar.H;
                end;
             1, 4, 7: begin
                  Position.RBX := Theme.Sing.Duet3PP2.SingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -888,14 +888,14 @@ begin
               case (PopUp.Player) of
                   0:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP1FourPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP1FourPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Solo4PP1.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Solo4PP1.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP1FourPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP1FourPScore.Y + 65;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Solo4PP1.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Solo4PP1.Score.Y + 65;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP1FourPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP1FourPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Solo4PP1.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Solo4PP1.Score.Y;
                     end;
                   1:
                     begin
@@ -1404,16 +1404,16 @@ begin
       begin
         case Index of
           0: begin
-               Position.BGX := Theme.Sing.StaticP1FourPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP1FourPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP1FourPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP1FourPScoreBG.H;
+               Position.BGX := Theme.Sing.Solo4PP1.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Solo4PP1.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Solo4PP1.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Solo4PP1.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP1FourPScore.X;
-               Position.TextY     := Theme.Sing.TextP1FourPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP1FourPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP1FourPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP1FourPScore.Size;
+               Position.TextX     := Theme.Sing.Solo4PP1.Score.X;
+               Position.TextY     := Theme.Sing.Solo4PP1.Score.Y;
+               Position.TextFont  := Theme.Sing.Solo4PP1.Score.Font;
+               Position.TextStyle := Theme.Sing.Solo4PP1.Score.Style;
+               Position.TextSize  := Theme.Sing.Solo4PP1.Score.Size;
              end;
           1: begin
                Position.BGX := Theme.Sing.StaticP2FourPScoreBG.X;
@@ -1763,10 +1763,10 @@ begin
         case Index of
           0:
              begin
-               Position.RBX := Theme.Sing.StaticP1FourPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP1FourPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP1FourPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP1FourPSingBar.H;
+               Position.RBX := Theme.Sing.Solo4PP1.SingBar.X;
+               Position.RBY := Theme.Sing.Solo4PP1.SingBar.Y;
+               Position.RBW := Theme.Sing.Solo4PP1.SingBar.W;
+               Position.RBH := Theme.Sing.Solo4PP1.SingBar.H;
              end;
           1: begin
                Position.RBX := Theme.Sing.StaticP2FourPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -1107,14 +1107,14 @@ begin
                   end;
                 1, 4, 7:
                   begin
-                    aPositions[PIndex].PUW := Theme.Sing.StaticDuetP2MScoreBG.W;
-                    aPositions[PIndex].PUH := Theme.Sing.StaticDuetP2MScoreBG.H;
+                    aPositions[PIndex].PUW := Theme.Sing.Duet3PP2.ScoreBackground.W;
+                    aPositions[PIndex].PUH := Theme.Sing.Duet3PP2.ScoreBackground.H;
 
-                    aPositions[PIndex].PUStartX := Theme.Sing.StaticDuetP2MScoreBG.X;
-                    aPositions[PIndex].PUStartY := Theme.Sing.TextDuetP2MScore.Y + 40;
+                    aPositions[PIndex].PUStartX := Theme.Sing.Duet3PP2.ScoreBackground.X;
+                    aPositions[PIndex].PUStartY := Theme.Sing.Duet3PP2.Score.Y + 40;
 
-                    aPositions[PIndex].PUTargetX := Theme.Sing.StaticDuetP2MScoreBG.X;
-                    aPositions[PIndex].PUTargetY := Theme.Sing.TextDuetP2MScore.Y;
+                    aPositions[PIndex].PUTargetX := Theme.Sing.Duet3PP2.ScoreBackground.X;
+                    aPositions[PIndex].PUTargetY := Theme.Sing.Duet3PP2.Score.Y;
                   end;
                 2, 5, 8:
                   begin
@@ -1641,15 +1641,15 @@ begin
                  Position.TextSize := Theme.Sing.TextDuetP1ThreePScore.Size;
                end;
             1, 4, 7: begin
-                 Position.BGX := Theme.Sing.StaticDuetP2MScoreBG.X;
-                 Position.BGY := Theme.Sing.StaticDuetP2MScoreBG.Y;
-                 Position.BGW := Theme.Sing.StaticDuetP2MScoreBG.W;
-                 Position.BGH := Theme.Sing.StaticDuetP2MScoreBG.H;
+                 Position.BGX := Theme.Sing.Duet3PP2.ScoreBackground.X;
+                 Position.BGY := Theme.Sing.Duet3PP2.ScoreBackground.Y;
+                 Position.BGW := Theme.Sing.Duet3PP2.ScoreBackground.W;
+                 Position.BGH := Theme.Sing.Duet3PP2.ScoreBackground.H;
 
-                 Position.TextX := Theme.Sing.TextDuetP2MScore.X;
-                 Position.TextY := Theme.Sing.TextDuetP2MScore.Y;
-                 Position.TextFont := Theme.Sing.TextDuetP2MScore.Font;
-                 Position.TextSize := Theme.Sing.TextDuetP2MScore.Size;
+                 Position.TextX := Theme.Sing.Duet3PP2.Score.X;
+                 Position.TextY := Theme.Sing.Duet3PP2.Score.Y;
+                 Position.TextFont := Theme.Sing.Duet3PP2.Score.Font;
+                 Position.TextSize := Theme.Sing.Duet3PP2.Score.Size;
                end;
             2, 5, 8: begin
                  Position.BGX := Theme.Sing.Duet3PP3.ScoreBackground.X;
@@ -1905,10 +1905,10 @@ begin
                  Position.RBH := Theme.Sing.StaticDuetP1ThreePSingBar.H;
                end;
             1, 4, 7: begin
-                 Position.RBX := Theme.Sing.StaticDuetP2MSingBar.X;
-                 Position.RBY := Theme.Sing.StaticDuetP2MSingBar.Y;
-                 Position.RBW := Theme.Sing.StaticDuetP2MSingBar.W;
-                 Position.RBH := Theme.Sing.StaticDuetP2MSingBar.H;
+                 Position.RBX := Theme.Sing.Duet3PP2.SingBar.X;
+                 Position.RBY := Theme.Sing.Duet3PP2.SingBar.Y;
+                 Position.RBW := Theme.Sing.Duet3PP2.SingBar.W;
+                 Position.RBH := Theme.Sing.Duet3PP2.SingBar.H;
                end;
             2, 5, 8: begin
                  Position.RBX := Theme.Sing.Duet3PP3.SingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -1049,14 +1049,14 @@ begin
                     end;
                   3:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP4SixPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP4SixPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Solo6PP4.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Solo6PP4.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP4SixPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP4SixPScore.Y + 65;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Solo6PP4.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Solo6PP4.Score.Y + 65;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP4SixPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP4SixPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Solo6PP4.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Solo6PP4.Score.Y;
                     end;
                   4:
                     begin
@@ -1574,16 +1574,16 @@ begin
                Position.TextSize  := Theme.Sing.Solo6PP3.Score.Size;
              end;
           3: begin
-               Position.BGX := Theme.Sing.StaticP4SixPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP4SixPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP4SixPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP4SixPScoreBG.H;
+               Position.BGX := Theme.Sing.Solo6PP4.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Solo6PP4.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Solo6PP4.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Solo6PP4.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP4SixPScore.X;
-               Position.TextY     := Theme.Sing.TextP4SixPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP4SixPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP4SixPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP4SixPScore.Size;
+               Position.TextX     := Theme.Sing.Solo6PP4.Score.X;
+               Position.TextY     := Theme.Sing.Solo6PP4.Score.Y;
+               Position.TextFont  := Theme.Sing.Solo6PP4.Score.Font;
+               Position.TextStyle := Theme.Sing.Solo6PP4.Score.Style;
+               Position.TextSize  := Theme.Sing.Solo6PP4.Score.Size;
              end;
           4: begin
                Position.BGX := Theme.Sing.StaticP5SixPScoreBG.X;
@@ -1857,10 +1857,10 @@ begin
                Position.RBH := Theme.Sing.Solo6PP3.SingBar.H;
              end;
           3: begin
-               Position.RBX := Theme.Sing.StaticP4SixPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP4SixPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP4SixPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP4SixPSingBar.H;
+               Position.RBX := Theme.Sing.Solo6PP4.SingBar.X;
+               Position.RBY := Theme.Sing.Solo6PP4.SingBar.Y;
+               Position.RBW := Theme.Sing.Solo6PP4.SingBar.W;
+               Position.RBH := Theme.Sing.Solo6PP4.SingBar.H;
              end;
           4: begin
                Position.RBX := Theme.Sing.StaticP5SixPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -418,7 +418,7 @@ begin
   // player 1:
   AddByStatics(1, Theme.Sing.StaticP1ScoreBG, Theme.Sing.StaticP1SingBar, Theme.Sing.TextP1Score);
   AddByStatics(2, Theme.Sing.StaticP1TwoPScoreBG, Theme.Sing.StaticP1TwoPSingBar, Theme.Sing.TextP1TwoPScore);
-  AddByStatics(4, Theme.Sing.StaticP1ThreePScoreBG, Theme.Sing.StaticP1ThreePSingBar, Theme.Sing.TextP1ThreePScore);
+  AddByStatics(4, Theme.Sing.Solo3PP1.ScoreBackground, Theme.Sing.Solo3PP1.SingBar, Theme.Sing.Solo3PP1.Score);
 
   // player 2:
   AddByStatics(2, Theme.Sing.Solo2PP2.ScoreBackground, Theme.Sing.Solo2PP2.SingBar, Theme.Sing.Solo2PP2.Score);
@@ -1139,14 +1139,14 @@ begin
               case (PopUp.Player) of
                 0, 3, 6:
                   begin
-                    aPositions[PIndex].PUW := Theme.Sing.StaticP1ThreePScoreBG.W;
-                    aPositions[PIndex].PUH := Theme.Sing.StaticP1ThreePScoreBG.H;
+                    aPositions[PIndex].PUW := Theme.Sing.Solo3PP1.ScoreBackground.W;
+                    aPositions[PIndex].PUH := Theme.Sing.Solo3PP1.ScoreBackground.H;
 
-                    aPositions[PIndex].PUStartX := Theme.Sing.StaticP1ThreePScoreBG.X;
-                    aPositions[PIndex].PUStartY := Theme.Sing.TextP1ThreePScore.Y + 65;
+                    aPositions[PIndex].PUStartX := Theme.Sing.Solo3PP1.ScoreBackground.X;
+                    aPositions[PIndex].PUStartY := Theme.Sing.Solo3PP1.Score.Y + 65;
 
-                    aPositions[PIndex].PUTargetX := Theme.Sing.StaticP1ThreePScoreBG.X;
-                    aPositions[PIndex].PUTargetY := Theme.Sing.TextP1ThreePScore.Y;
+                    aPositions[PIndex].PUTargetX := Theme.Sing.Solo3PP1.ScoreBackground.X;
+                    aPositions[PIndex].PUTargetY := Theme.Sing.Solo3PP1.Score.Y;
                   end;
                 1, 4, 7:
                   begin

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -910,14 +910,14 @@ begin
                     end;
                   2:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP3FourPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP3FourPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Solo4PP3.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Solo4PP3.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP3FourPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP3FourPScore.Y + 65;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Solo4PP3.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Solo4PP3.Score.Y + 65;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP3FourPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP3FourPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Solo4PP3.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Solo4PP3.Score.Y;
                     end;
                   3:
                     begin
@@ -1428,16 +1428,16 @@ begin
                Position.TextSize  := Theme.Sing.Solo4PP2.Score.Size;
              end;
           2: begin
-               Position.BGX := Theme.Sing.StaticP3FourPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP3FourPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP3FourPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP3FourPScoreBG.H;
+               Position.BGX := Theme.Sing.Solo4PP3.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Solo4PP3.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Solo4PP3.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Solo4PP3.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP3FourPScore.X;
-               Position.TextY     := Theme.Sing.TextP3FourPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP3FourPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP3FourPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP3FourPScore.Size;
+               Position.TextX     := Theme.Sing.Solo4PP3.Score.X;
+               Position.TextY     := Theme.Sing.Solo4PP3.Score.Y;
+               Position.TextFont  := Theme.Sing.Solo4PP3.Score.Font;
+               Position.TextStyle := Theme.Sing.Solo4PP3.Score.Style;
+               Position.TextSize  := Theme.Sing.Solo4PP3.Score.Size;
              end;
           3: begin
                Position.BGX := Theme.Sing.StaticP4FourPScoreBG.X;
@@ -1775,10 +1775,10 @@ begin
                Position.RBH := Theme.Sing.Solo4PP2.SingBar.H;
              end;
           2: begin
-               Position.RBX := Theme.Sing.StaticP3FourPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP3FourPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP3FourPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP3FourPSingBar.H;
+               Position.RBX := Theme.Sing.Solo4PP3.SingBar.X;
+               Position.RBY := Theme.Sing.Solo4PP3.SingBar.Y;
+               Position.RBW := Theme.Sing.Solo4PP3.SingBar.W;
+               Position.RBH := Theme.Sing.Solo4PP3.SingBar.H;
              end;
           3: begin
                Position.RBX := Theme.Sing.StaticP4FourPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -859,14 +859,14 @@ begin
                     end;
                   2:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP3DuetFourPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP3DuetFourPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Duet4PP3.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Duet4PP3.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP3DuetFourPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP3DuetFourPScore.Y + 40;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Duet4PP3.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Duet4PP3.Score.Y + 40;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP3DuetFourPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP3DuetFourPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Duet4PP3.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Duet4PP3.Score.Y;
                     end;
                   3:
                     begin
@@ -1375,16 +1375,16 @@ begin
                Position.TextSize  := Theme.Sing.Duet4PP2.Score.Size;
              end;
           2: begin
-               Position.BGX := Theme.Sing.StaticP3DuetFourPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP3DuetFourPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP3DuetFourPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP3DuetFourPScoreBG.H;
+               Position.BGX := Theme.Sing.Duet4PP3.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Duet4PP3.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Duet4PP3.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Duet4PP3.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP3DuetFourPScore.X;
-               Position.TextY     := Theme.Sing.TextP3DuetFourPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP3DuetFourPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP3DuetFourPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP3DuetFourPScore.Size;
+               Position.TextX     := Theme.Sing.Duet4PP3.Score.X;
+               Position.TextY     := Theme.Sing.Duet4PP3.Score.Y;
+               Position.TextFont  := Theme.Sing.Duet4PP3.Score.Font;
+               Position.TextStyle := Theme.Sing.Duet4PP3.Score.Style;
+               Position.TextSize  := Theme.Sing.Duet4PP3.Score.Size;
              end;
           3: begin
                Position.BGX := Theme.Sing.StaticP4DuetFourPScoreBG.X;
@@ -1745,10 +1745,10 @@ begin
                Position.RBH := Theme.Sing.Duet4PP2.SingBar.H;
              end;
           2: begin
-               Position.RBX := Theme.Sing.StaticP3DuetFourPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP3DuetFourPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP3DuetFourPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP3DuetFourPSingBar.H;
+               Position.RBX := Theme.Sing.Duet4PP3.SingBar.X;
+               Position.RBY := Theme.Sing.Duet4PP3.SingBar.Y;
+               Position.RBW := Theme.Sing.Duet4PP3.SingBar.W;
+               Position.RBH := Theme.Sing.Duet4PP3.SingBar.H;
              end;
           3: begin
                Position.RBX := Theme.Sing.StaticP4DuetFourPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -1038,14 +1038,14 @@ begin
                     end;
                   2:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP3SixPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP3SixPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Solo6PP3.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Solo6PP3.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP3SixPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP3SixPScore.Y + 65;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Solo6PP3.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Solo6PP3.Score.Y + 65;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP3SixPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP3SixPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Solo6PP3.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Solo6PP3.Score.Y;
                     end;
                   3:
                     begin
@@ -1562,16 +1562,16 @@ begin
                Position.TextSize  := Theme.Sing.Solo6PP2.Score.Size;
              end;
           2: begin
-               Position.BGX := Theme.Sing.StaticP3SixPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP3SixPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP3SixPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP3SixPScoreBG.H;
+               Position.BGX := Theme.Sing.Solo6PP3.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Solo6PP3.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Solo6PP3.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Solo6PP3.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP3SixPScore.X;
-               Position.TextY     := Theme.Sing.TextP3SixPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP3SixPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP3SixPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP3SixPScore.Size;
+               Position.TextX     := Theme.Sing.Solo6PP3.Score.X;
+               Position.TextY     := Theme.Sing.Solo6PP3.Score.Y;
+               Position.TextFont  := Theme.Sing.Solo6PP3.Score.Font;
+               Position.TextStyle := Theme.Sing.Solo6PP3.Score.Style;
+               Position.TextSize  := Theme.Sing.Solo6PP3.Score.Size;
              end;
           3: begin
                Position.BGX := Theme.Sing.StaticP4SixPScoreBG.X;
@@ -1851,10 +1851,10 @@ begin
                Position.RBH := Theme.Sing.Solo6PP2.SingBar.H;
              end;
           2: begin
-               Position.RBX := Theme.Sing.StaticP3SixPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP3SixPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP3SixPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP3SixPSingBar.H;
+               Position.RBX := Theme.Sing.Solo6PP3.SingBar.X;
+               Position.RBY := Theme.Sing.Solo6PP3.SingBar.Y;
+               Position.RBW := Theme.Sing.Solo6PP3.SingBar.W;
+               Position.RBH := Theme.Sing.Solo6PP3.SingBar.H;
              end;
           3: begin
                Position.RBX := Theme.Sing.StaticP4SixPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -425,7 +425,7 @@ begin
   AddByStatics(4, Theme.Sing.StaticP2MScoreBG, Theme.Sing.StaticP2MSingBar, Theme.Sing.TextP2MScore);
 
   // player 3:
-  AddByStatics(4, Theme.Sing.StaticP3RScoreBG, Theme.Sing.StaticP3SingBar, Theme.Sing.TextP3RScore);
+  AddByStatics(4, Theme.Sing.Solo3PP3.ScoreBackground, Theme.Sing.Solo3PP3.SingBar, Theme.Sing.Solo3PP3.Score);
 
 end;
 
@@ -1161,14 +1161,14 @@ begin
                   end;
                 2, 5, 8:
                   begin
-                    aPositions[PIndex].PUW := Theme.Sing.StaticP3RScoreBG.W;
-                    aPositions[PIndex].PUH := Theme.Sing.StaticP3RScoreBG.H;
+                    aPositions[PIndex].PUW := Theme.Sing.Solo3PP3.ScoreBackground.W;
+                    aPositions[PIndex].PUH := Theme.Sing.Solo3PP3.ScoreBackground.H;
 
-                    aPositions[PIndex].PUStartX := Theme.Sing.StaticP3RScoreBG.X;
-                    aPositions[PIndex].PUStartY := Theme.Sing.TextP3RScore.Y + 65;
+                    aPositions[PIndex].PUStartX := Theme.Sing.Solo3PP3.ScoreBackground.X;
+                    aPositions[PIndex].PUStartY := Theme.Sing.Solo3PP3.Score.Y + 65;
 
-                    aPositions[PIndex].PUTargetX := Theme.Sing.StaticP3RScoreBG.X;
-                    aPositions[PIndex].PUTargetY := Theme.Sing.TextP3RScore.Y;
+                    aPositions[PIndex].PUTargetX := Theme.Sing.Solo3PP3.ScoreBackground.X;
+                    aPositions[PIndex].PUTargetY := Theme.Sing.Solo3PP3.Score.Y;
                   end;
               end;
             end;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -1027,14 +1027,14 @@ begin
                     end;
                   1:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP2SixPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP2SixPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Solo6PP2.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Solo6PP2.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP2SixPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP2SixPScore.Y + 65;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Solo6PP2.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Solo6PP2.Score.Y + 65;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP2SixPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP2SixPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Solo6PP2.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Solo6PP2.Score.Y;
                     end;
                   2:
                     begin
@@ -1550,16 +1550,16 @@ begin
                Position.TextSize  := Theme.Sing.Solo6PP1.Score.Size;
              end;
           1: begin
-               Position.BGX := Theme.Sing.StaticP2SixPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP2SixPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP2SixPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP2SixPScoreBG.H;
+               Position.BGX := Theme.Sing.Solo6PP2.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Solo6PP2.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Solo6PP2.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Solo6PP2.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP2SixPScore.X;
-               Position.TextY     := Theme.Sing.TextP2SixPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP2SixPScore.Font;
-               Position.TextStyle  := Theme.Sing.TextP2SixPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP2SixPScore.Size;
+               Position.TextX     := Theme.Sing.Solo6PP2.Score.X;
+               Position.TextY     := Theme.Sing.Solo6PP2.Score.Y;
+               Position.TextFont  := Theme.Sing.Solo6PP2.Score.Font;
+               Position.TextStyle  := Theme.Sing.Solo6PP2.Score.Style;
+               Position.TextSize  := Theme.Sing.Solo6PP2.Score.Size;
              end;
           2: begin
                Position.BGX := Theme.Sing.StaticP3SixPScoreBG.X;
@@ -1845,10 +1845,10 @@ begin
                Position.RBH := Theme.Sing.Solo6PP1.SingBar.H;
              end;
           1: begin
-               Position.RBX := Theme.Sing.StaticP2SixPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP2SixPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP2SixPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP2SixPSingBar.H;
+               Position.RBX := Theme.Sing.Solo6PP2.SingBar.X;
+               Position.RBY := Theme.Sing.Solo6PP2.SingBar.Y;
+               Position.RBW := Theme.Sing.Solo6PP2.SingBar.W;
+               Position.RBH := Theme.Sing.Solo6PP2.SingBar.H;
              end;
           2: begin
                Position.RBX := Theme.Sing.StaticP3SixPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -837,14 +837,14 @@ begin
               case (PopUp.Player) of
                   0:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP1DuetFourPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP1DuetFourPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Duet4PP1.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Duet4PP1.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP1DuetFourPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP1DuetFourPScore.Y + 40;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Duet4PP1.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Duet4PP1.Score.Y + 40;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP1DuetFourPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP1DuetFourPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Duet4PP1.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Duet4PP1.Score.Y;
                     end;
                   1:
                     begin
@@ -1351,16 +1351,16 @@ begin
       begin
         case Index of
           0: begin
-               Position.BGX := Theme.Sing.StaticP1DuetFourPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP1DuetFourPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP1DuetFourPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP1DuetFourPScoreBG.H;
+               Position.BGX := Theme.Sing.Duet4PP1.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Duet4PP1.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Duet4PP1.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Duet4PP1.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP1DuetFourPScore.X;
-               Position.TextY     := Theme.Sing.TextP1DuetFourPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP1DuetFourPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP1DuetFourPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP1DuetFourPScore.Size;
+               Position.TextX     := Theme.Sing.Duet4PP1.Score.X;
+               Position.TextY     := Theme.Sing.Duet4PP1.Score.Y;
+               Position.TextFont  := Theme.Sing.Duet4PP1.Score.Font;
+               Position.TextStyle := Theme.Sing.Duet4PP1.Score.Style;
+               Position.TextSize  := Theme.Sing.Duet4PP1.Score.Size;
              end;
           1: begin
                Position.BGX := Theme.Sing.StaticP2DuetFourPScoreBG.X;
@@ -1733,10 +1733,10 @@ begin
         case Index of
           0:
              begin
-               Position.RBX := Theme.Sing.StaticP1DuetFourPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP1DuetFourPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP1DuetFourPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP1DuetFourPSingBar.H;
+               Position.RBX := Theme.Sing.Duet4PP1.SingBar.X;
+               Position.RBY := Theme.Sing.Duet4PP1.SingBar.Y;
+               Position.RBW := Theme.Sing.Duet4PP1.SingBar.W;
+               Position.RBH := Theme.Sing.Duet4PP1.SingBar.H;
              end;
           1: begin
                Position.RBX := Theme.Sing.StaticP2DuetFourPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -1071,14 +1071,14 @@ begin
                     end;
                   5:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP6SixPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP6SixPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Solo6PP6.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Solo6PP6.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP6SixPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP6SixPScore.Y + 65;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Solo6PP6.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Solo6PP6.Score.Y + 65;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP6SixPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP6SixPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Solo6PP6.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Solo6PP6.Score.Y;
                     end;
                 end;
             end;
@@ -1598,16 +1598,16 @@ begin
                Position.TextSize  := Theme.Sing.Solo6PP5.Score.Size;
              end;
           5: begin
-               Position.BGX := Theme.Sing.StaticP6SixPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP6SixPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP6SixPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP6SixPScoreBG.H;
+               Position.BGX := Theme.Sing.Solo6PP6.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Solo6PP6.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Solo6PP6.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Solo6PP6.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP6SixPScore.X;
-               Position.TextY     := Theme.Sing.TextP6SixPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP6SixPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP6SixPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP6SixPScore.Size;
+               Position.TextX     := Theme.Sing.Solo6PP6.Score.X;
+               Position.TextY     := Theme.Sing.Solo6PP6.Score.Y;
+               Position.TextFont  := Theme.Sing.Solo6PP6.Score.Font;
+               Position.TextStyle := Theme.Sing.Solo6PP6.Score.Style;
+               Position.TextSize  := Theme.Sing.Solo6PP6.Score.Size;
              end;
         end;
       end;
@@ -1869,10 +1869,10 @@ begin
                Position.RBH := Theme.Sing.Solo6PP5.SingBar.H;
              end;
           5: begin
-               Position.RBX := Theme.Sing.StaticP6SixPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP6SixPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP6SixPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP6SixPSingBar.H;
+               Position.RBX := Theme.Sing.Solo6PP6.SingBar.X;
+               Position.RBY := Theme.Sing.Solo6PP6.SingBar.Y;
+               Position.RBW := Theme.Sing.Solo6PP6.SingBar.W;
+               Position.RBH := Theme.Sing.Solo6PP6.SingBar.H;
              end;
         end;
       end;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -1060,14 +1060,14 @@ begin
                     end;
                   4:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP5SixPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP5SixPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Solo6PP5.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Solo6PP5.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP5SixPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP5SixPScore.Y + 65;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Solo6PP5.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Solo6PP5.Score.Y + 65;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP5SixPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP5SixPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Solo6PP5.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Solo6PP5.Score.Y;
                     end;
                   5:
                     begin
@@ -1586,16 +1586,16 @@ begin
                Position.TextSize  := Theme.Sing.Solo6PP4.Score.Size;
              end;
           4: begin
-               Position.BGX := Theme.Sing.StaticP5SixPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP5SixPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP5SixPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP5SixPScoreBG.H;
+               Position.BGX := Theme.Sing.Solo6PP5.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Solo6PP5.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Solo6PP5.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Solo6PP5.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP5SixPScore.X;
-               Position.TextY     := Theme.Sing.TextP5SixPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP5SixPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP5SixPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP5SixPScore.Size;
+               Position.TextX     := Theme.Sing.Solo6PP5.Score.X;
+               Position.TextY     := Theme.Sing.Solo6PP5.Score.Y;
+               Position.TextFont  := Theme.Sing.Solo6PP5.Score.Font;
+               Position.TextStyle := Theme.Sing.Solo6PP5.Score.Style;
+               Position.TextSize  := Theme.Sing.Solo6PP5.Score.Size;
              end;
           5: begin
                Position.BGX := Theme.Sing.StaticP6SixPScoreBG.X;
@@ -1863,10 +1863,10 @@ begin
                Position.RBH := Theme.Sing.Solo6PP4.SingBar.H;
              end;
           4: begin
-               Position.RBX := Theme.Sing.StaticP5SixPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP5SixPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP5SixPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP5SixPSingBar.H;
+               Position.RBX := Theme.Sing.Solo6PP5.SingBar.X;
+               Position.RBY := Theme.Sing.Solo6PP5.SingBar.Y;
+               Position.RBW := Theme.Sing.Solo6PP5.SingBar.W;
+               Position.RBH := Theme.Sing.Solo6PP5.SingBar.H;
              end;
           5: begin
                Position.RBX := Theme.Sing.StaticP6SixPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -899,14 +899,14 @@ begin
                     end;
                   1:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP2FourPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP2FourPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Solo4PP2.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Solo4PP2.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP2FourPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP2FourPScore.Y + 65;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Solo4PP2.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Solo4PP2.Score.Y + 65;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP2FourPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP2FourPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Solo4PP2.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Solo4PP2.Score.Y;
                     end;
                   2:
                     begin
@@ -1416,16 +1416,16 @@ begin
                Position.TextSize  := Theme.Sing.Solo4PP1.Score.Size;
              end;
           1: begin
-               Position.BGX := Theme.Sing.StaticP2FourPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP2FourPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP2FourPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP2FourPScoreBG.H;
+               Position.BGX := Theme.Sing.Solo4PP2.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Solo4PP2.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Solo4PP2.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Solo4PP2.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP2FourPScore.X;
-               Position.TextY     := Theme.Sing.TextP2FourPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP2FourPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP2FourPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP2FourPScore.Size;
+               Position.TextX     := Theme.Sing.Solo4PP2.Score.X;
+               Position.TextY     := Theme.Sing.Solo4PP2.Score.Y;
+               Position.TextFont  := Theme.Sing.Solo4PP2.Score.Font;
+               Position.TextStyle := Theme.Sing.Solo4PP2.Score.Style;
+               Position.TextSize  := Theme.Sing.Solo4PP2.Score.Size;
              end;
           2: begin
                Position.BGX := Theme.Sing.StaticP3FourPScoreBG.X;
@@ -1769,10 +1769,10 @@ begin
                Position.RBH := Theme.Sing.Solo4PP1.SingBar.H;
              end;
           1: begin
-               Position.RBX := Theme.Sing.StaticP2FourPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP2FourPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP2FourPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP2FourPSingBar.H;
+               Position.RBX := Theme.Sing.Solo4PP2.SingBar.X;
+               Position.RBY := Theme.Sing.Solo4PP2.SingBar.Y;
+               Position.RBW := Theme.Sing.Solo4PP2.SingBar.W;
+               Position.RBH := Theme.Sing.Solo4PP2.SingBar.H;
              end;
           2: begin
                Position.RBX := Theme.Sing.StaticP3FourPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -1016,14 +1016,14 @@ begin
               case (PopUp.Player) of
                   0:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP1SixPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP1SixPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Solo6PP1.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Solo6PP1.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP1SixPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP1SixPScore.Y + 65;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Solo6PP1.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Solo6PP1.Score.Y + 65;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP1SixPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP1SixPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Solo6PP1.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Solo6PP1.Score.Y;
                     end;
                   1:
                     begin
@@ -1538,16 +1538,16 @@ begin
       begin
         case Index of
           0: begin
-               Position.BGX := Theme.Sing.StaticP1SixPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP1SixPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP1SixPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP1SixPScoreBG.H;
+               Position.BGX := Theme.Sing.Solo6PP1.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Solo6PP1.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Solo6PP1.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Solo6PP1.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP1SixPScore.X;
-               Position.TextY     := Theme.Sing.TextP1SixPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP1SixPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP1SixPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP1SixPScore.Size;
+               Position.TextX     := Theme.Sing.Solo6PP1.Score.X;
+               Position.TextY     := Theme.Sing.Solo6PP1.Score.Y;
+               Position.TextFont  := Theme.Sing.Solo6PP1.Score.Font;
+               Position.TextStyle := Theme.Sing.Solo6PP1.Score.Style;
+               Position.TextSize  := Theme.Sing.Solo6PP1.Score.Size;
              end;
           1: begin
                Position.BGX := Theme.Sing.StaticP2SixPScoreBG.X;
@@ -1839,10 +1839,10 @@ begin
         case Index of
           0:
              begin
-               Position.RBX := Theme.Sing.StaticP1SixPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP1SixPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP1SixPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP1SixPSingBar.H;
+               Position.RBX := Theme.Sing.Solo6PP1.SingBar.X;
+               Position.RBY := Theme.Sing.Solo6PP1.SingBar.Y;
+               Position.RBW := Theme.Sing.Solo6PP1.SingBar.W;
+               Position.RBH := Theme.Sing.Solo6PP1.SingBar.H;
              end;
           1: begin
                Position.RBX := Theme.Sing.StaticP2SixPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -870,14 +870,14 @@ begin
                     end;
                   3:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP4DuetFourPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP4DuetFourPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Duet4PP4.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Duet4PP4.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP4DuetFourPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP4DuetFourPScore.Y + 40;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Duet4PP4.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Duet4PP4.Score.Y + 40;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP4DuetFourPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP4DuetFourPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Duet4PP4.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Duet4PP4.Score.Y;
                     end;
                 end;
             end
@@ -1387,16 +1387,16 @@ begin
                Position.TextSize  := Theme.Sing.Duet4PP3.Score.Size;
              end;
           3: begin
-               Position.BGX := Theme.Sing.StaticP4DuetFourPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP4DuetFourPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP4DuetFourPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP4DuetFourPScoreBG.H;
+               Position.BGX := Theme.Sing.Duet4PP4.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Duet4PP4.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Duet4PP4.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Duet4PP4.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP4DuetFourPScore.X;
-               Position.TextY     := Theme.Sing.TextP4DuetFourPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP4DuetFourPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP4DuetFourPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP4DuetFourPScore.Size;
+               Position.TextX     := Theme.Sing.Duet4PP4.Score.X;
+               Position.TextY     := Theme.Sing.Duet4PP4.Score.Y;
+               Position.TextFont  := Theme.Sing.Duet4PP4.Score.Font;
+               Position.TextStyle := Theme.Sing.Duet4PP4.Score.Style;
+               Position.TextSize  := Theme.Sing.Duet4PP4.Score.Size;
              end;
         end;
       end
@@ -1751,10 +1751,10 @@ begin
                Position.RBH := Theme.Sing.Duet4PP3.SingBar.H;
              end;
           3: begin
-               Position.RBX := Theme.Sing.StaticP4DuetFourPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP4DuetFourPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP4DuetFourPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP4DuetFourPSingBar.H;
+               Position.RBX := Theme.Sing.Duet4PP4.SingBar.X;
+               Position.RBY := Theme.Sing.Duet4PP4.SingBar.Y;
+               Position.RBW := Theme.Sing.Duet4PP4.SingBar.W;
+               Position.RBH := Theme.Sing.Duet4PP4.SingBar.H;
              end;
         end;
       end

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -965,14 +965,14 @@ begin
                     end;
                   2:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP3DuetSixPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP3DuetSixPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Duet6PP3.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Duet6PP3.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP3DuetSixPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP3DuetSixPScore.Y + 40;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Duet6PP3.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Duet6PP3.Score.Y + 40;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP3DuetSixPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP3DuetSixPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Duet6PP3.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Duet6PP3.Score.Y;
                     end;
                   3:
                     begin
@@ -1485,16 +1485,16 @@ begin
                Position.TextSize  := Theme.Sing.Duet6PP2.Score.Size;
              end;
           2: begin
-               Position.BGX := Theme.Sing.StaticP3DuetSixPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP3DuetSixPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP3DuetSixPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP3DuetSixPScoreBG.H;
+               Position.BGX := Theme.Sing.Duet6PP3.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Duet6PP3.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Duet6PP3.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Duet6PP3.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP3DuetSixPScore.X;
-               Position.TextY     := Theme.Sing.TextP3DuetSixPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP3DuetSixPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP3DuetSixPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP3DuetSixPScore.Size;
+               Position.TextX     := Theme.Sing.Duet6PP3.Score.X;
+               Position.TextY     := Theme.Sing.Duet6PP3.Score.Y;
+               Position.TextFont  := Theme.Sing.Duet6PP3.Score.Font;
+               Position.TextStyle := Theme.Sing.Duet6PP3.Score.Style;
+               Position.TextSize  := Theme.Sing.Duet6PP3.Score.Size;
              end;
           3: begin
                Position.BGX := Theme.Sing.StaticP4DuetSixPScoreBG.X;
@@ -1809,10 +1809,10 @@ begin
                Position.RBH := Theme.Sing.Duet6PP2.SingBar.H;
              end;
           2: begin
-               Position.RBX := Theme.Sing.StaticP3DuetSixPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP3DuetSixPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP3DuetSixPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP3DuetSixPSingBar.H;
+               Position.RBX := Theme.Sing.Duet6PP3.SingBar.X;
+               Position.RBY := Theme.Sing.Duet6PP3.SingBar.Y;
+               Position.RBW := Theme.Sing.Duet6PP3.SingBar.W;
+               Position.RBH := Theme.Sing.Duet6PP3.SingBar.H;
              end;
           3: begin
                Position.RBX := Theme.Sing.StaticP4DuetSixPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -987,14 +987,14 @@ begin
                     end;
                   4:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP5DuetSixPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP5DuetSixPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Duet6PP5.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Duet6PP5.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP5DuetSixPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP5DuetSixPScore.Y + 40;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Duet6PP5.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Duet6PP5.Score.Y + 40;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP5DuetSixPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP5DuetSixPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Duet6PP5.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Duet6PP5.Score.Y;
                     end;
                   5:
                     begin
@@ -1509,16 +1509,16 @@ begin
                Position.TextSize  := Theme.Sing.Duet6PP4.Score.Size;
              end;
           4: begin
-               Position.BGX := Theme.Sing.StaticP5DuetSixPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP5DuetSixPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP5DuetSixPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP5DuetSixPScoreBG.H;
+               Position.BGX := Theme.Sing.Duet6PP5.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Duet6PP5.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Duet6PP5.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Duet6PP5.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP5DuetSixPScore.X;
-               Position.TextY     := Theme.Sing.TextP5DuetSixPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP5DuetSixPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP5DuetSixPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP5DuetSixPScore.Size;
+               Position.TextX     := Theme.Sing.Duet6PP5.Score.X;
+               Position.TextY     := Theme.Sing.Duet6PP5.Score.Y;
+               Position.TextFont  := Theme.Sing.Duet6PP5.Score.Font;
+               Position.TextStyle := Theme.Sing.Duet6PP5.Score.Style;
+               Position.TextSize  := Theme.Sing.Duet6PP5.Score.Size;
              end;
           5: begin
                Position.BGX := Theme.Sing.StaticP6DuetSixPScoreBG.X;
@@ -1821,10 +1821,10 @@ begin
                Position.RBH := Theme.Sing.Duet6PP4.SingBar.H;
              end;
           4: begin
-               Position.RBX := Theme.Sing.StaticP5DuetSixPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP5DuetSixPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP5DuetSixPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP5DuetSixPSingBar.H;
+               Position.RBX := Theme.Sing.Duet6PP5.SingBar.X;
+               Position.RBY := Theme.Sing.Duet6PP5.SingBar.Y;
+               Position.RBW := Theme.Sing.Duet6PP5.SingBar.W;
+               Position.RBH := Theme.Sing.Duet6PP5.SingBar.H;
              end;
           5: begin
                Position.RBX := Theme.Sing.StaticP6DuetSixPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -416,7 +416,7 @@ begin
   // load positions from theme
 
   // player 1:
-  AddByStatics(1, Theme.Sing.StaticP1ScoreBG, Theme.Sing.StaticP1SingBar, Theme.Sing.TextP1Score);
+  AddByStatics(1, Theme.Sing.Solo1PP1.ScoreBackground, Theme.Sing.Solo1PP1.SingBar, Theme.Sing.Solo1PP1.Score);
   AddByStatics(2, Theme.Sing.Solo2PP1.ScoreBackground, Theme.Sing.Solo2PP1.SingBar, Theme.Sing.Solo2PP1.Score);
   AddByStatics(4, Theme.Sing.Solo3PP1.ScoreBackground, Theme.Sing.Solo3PP1.SingBar, Theme.Sing.Solo3PP1.Score);
 

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -998,14 +998,14 @@ begin
                     end;
                   5:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP6DuetSixPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP6DuetSixPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Duet6PP6.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Duet6PP6.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP6DuetSixPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP6DuetSixPScore.Y + 40;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Duet6PP6.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Duet6PP6.Score.Y + 40;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP6DuetSixPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP6DuetSixPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Duet6PP6.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Duet6PP6.Score.Y;
                     end;
                 end;
             end
@@ -1521,16 +1521,16 @@ begin
                Position.TextSize  := Theme.Sing.Duet6PP5.Score.Size;
              end;
           5: begin
-               Position.BGX := Theme.Sing.StaticP6DuetSixPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP6DuetSixPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP6DuetSixPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP6DuetSixPScoreBG.H;
+               Position.BGX := Theme.Sing.Duet6PP6.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Duet6PP6.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Duet6PP6.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Duet6PP6.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP6DuetSixPScore.X;
-               Position.TextY     := Theme.Sing.TextP6DuetSixPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP6DuetSixPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP6DuetSixPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP6DuetSixPScore.Size;
+               Position.TextX     := Theme.Sing.Duet6PP6.Score.X;
+               Position.TextY     := Theme.Sing.Duet6PP6.Score.Y;
+               Position.TextFont  := Theme.Sing.Duet6PP6.Score.Font;
+               Position.TextStyle := Theme.Sing.Duet6PP6.Score.Style;
+               Position.TextSize  := Theme.Sing.Duet6PP6.Score.Size;
              end;
         end;
       end
@@ -1827,10 +1827,10 @@ begin
                Position.RBH := Theme.Sing.Duet6PP5.SingBar.H;
              end;
           5: begin
-               Position.RBX := Theme.Sing.StaticP6DuetSixPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP6DuetSixPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP6DuetSixPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP6DuetSixPSingBar.H;
+               Position.RBX := Theme.Sing.Duet6PP6.SingBar.X;
+               Position.RBY := Theme.Sing.Duet6PP6.SingBar.Y;
+               Position.RBW := Theme.Sing.Duet6PP6.SingBar.W;
+               Position.RBH := Theme.Sing.Duet6PP6.SingBar.H;
              end;
         end;
       end

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -421,7 +421,7 @@ begin
   AddByStatics(4, Theme.Sing.StaticP1ThreePScoreBG, Theme.Sing.StaticP1ThreePSingBar, Theme.Sing.TextP1ThreePScore);
 
   // player 2:
-  AddByStatics(2, Theme.Sing.StaticP2RScoreBG, Theme.Sing.StaticP2RSingBar, Theme.Sing.TextP2RScore);
+  AddByStatics(2, Theme.Sing.Solo2PP2.ScoreBackground, Theme.Sing.Solo2PP2.SingBar, Theme.Sing.Solo2PP2.Score);
   AddByStatics(4, Theme.Sing.Solo3PP2.ScoreBackground, Theme.Sing.Solo3PP2.SingBar, Theme.Sing.Solo3PP2.Score);
 
   // player 3:

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -943,14 +943,14 @@ begin
               case (PopUp.Player) of
                   0:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP1DuetSixPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP1DuetSixPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Duet6PP1.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Duet6PP1.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP1DuetSixPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP1DuetSixPScore.Y + 40;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Duet6PP1.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Duet6PP1.Score.Y + 40;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP1DuetSixPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP1DuetSixPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Duet6PP1.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Duet6PP1.Score.Y;
                     end;
                   1:
                     begin
@@ -1461,16 +1461,16 @@ begin
       begin
         case Index of
           0: begin
-               Position.BGX := Theme.Sing.StaticP1DuetSixPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP1DuetSixPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP1DuetSixPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP1DuetSixPScoreBG.H;
+               Position.BGX := Theme.Sing.Duet6PP1.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Duet6PP1.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Duet6PP1.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Duet6PP1.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP1DuetSixPScore.X;
-               Position.TextY     := Theme.Sing.TextP1DuetSixPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP1DuetSixPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP1DuetSixPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP1DuetSixPScore.Size;
+               Position.TextX     := Theme.Sing.Duet6PP1.Score.X;
+               Position.TextY     := Theme.Sing.Duet6PP1.Score.Y;
+               Position.TextFont  := Theme.Sing.Duet6PP1.Score.Font;
+               Position.TextStyle := Theme.Sing.Duet6PP1.Score.Style;
+               Position.TextSize  := Theme.Sing.Duet6PP1.Score.Size;
              end;
           1: begin
                Position.BGX := Theme.Sing.StaticP2DuetSixPScoreBG.X;
@@ -1797,10 +1797,10 @@ begin
         case Index of
           0:
              begin
-               Position.RBX := Theme.Sing.StaticP1DuetSixPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP1DuetSixPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP1DuetSixPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP1DuetSixPSingBar.H;
+               Position.RBX := Theme.Sing.Duet6PP1.SingBar.X;
+               Position.RBY := Theme.Sing.Duet6PP1.SingBar.Y;
+               Position.RBW := Theme.Sing.Duet6PP1.SingBar.W;
+               Position.RBH := Theme.Sing.Duet6PP1.SingBar.H;
              end;
           1: begin
                Position.RBX := Theme.Sing.StaticP2DuetSixPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -954,14 +954,14 @@ begin
                     end;
                   1:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP2DuetSixPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP2DuetSixPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Duet6PP2.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Duet6PP2.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP2DuetSixPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP2DuetSixPScore.Y + 40;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Duet6PP2.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Duet6PP2.Score.Y + 40;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP2DuetSixPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP2DuetSixPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Duet6PP2.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Duet6PP2.Score.Y;
                     end;
                   2:
                     begin
@@ -1473,16 +1473,16 @@ begin
                Position.TextSize  := Theme.Sing.Duet6PP1.Score.Size;
              end;
           1: begin
-               Position.BGX := Theme.Sing.StaticP2DuetSixPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP2DuetSixPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP2DuetSixPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP2DuetSixPScoreBG.H;
+               Position.BGX := Theme.Sing.Duet6PP2.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Duet6PP2.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Duet6PP2.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Duet6PP2.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP2DuetSixPScore.X;
-               Position.TextY     := Theme.Sing.TextP2DuetSixPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP2DuetSixPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP2DuetSixPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP2DuetSixPScore.Size;
+               Position.TextX     := Theme.Sing.Duet6PP2.Score.X;
+               Position.TextY     := Theme.Sing.Duet6PP2.Score.Y;
+               Position.TextFont  := Theme.Sing.Duet6PP2.Score.Font;
+               Position.TextStyle := Theme.Sing.Duet6PP2.Score.Style;
+               Position.TextSize  := Theme.Sing.Duet6PP2.Score.Size;
              end;
           2: begin
                Position.BGX := Theme.Sing.StaticP3DuetSixPScoreBG.X;
@@ -1803,10 +1803,10 @@ begin
                Position.RBH := Theme.Sing.Duet6PP1.SingBar.H;
              end;
           1: begin
-               Position.RBX := Theme.Sing.StaticP2DuetSixPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP2DuetSixPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP2DuetSixPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP2DuetSixPSingBar.H;
+               Position.RBX := Theme.Sing.Duet6PP2.SingBar.X;
+               Position.RBY := Theme.Sing.Duet6PP2.SingBar.Y;
+               Position.RBW := Theme.Sing.Duet6PP2.SingBar.W;
+               Position.RBH := Theme.Sing.Duet6PP2.SingBar.H;
              end;
           2: begin
                Position.RBX := Theme.Sing.StaticP3DuetSixPSingBar.X;

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -417,7 +417,7 @@ begin
 
   // player 1:
   AddByStatics(1, Theme.Sing.StaticP1ScoreBG, Theme.Sing.StaticP1SingBar, Theme.Sing.TextP1Score);
-  AddByStatics(2, Theme.Sing.StaticP1TwoPScoreBG, Theme.Sing.StaticP1TwoPSingBar, Theme.Sing.TextP1TwoPScore);
+  AddByStatics(2, Theme.Sing.Solo2PP1.ScoreBackground, Theme.Sing.Solo2PP1.SingBar, Theme.Sing.Solo2PP1.Score);
   AddByStatics(4, Theme.Sing.Solo3PP1.ScoreBackground, Theme.Sing.Solo3PP1.SingBar, Theme.Sing.Solo3PP1.Score);
 
   // player 2:

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -422,7 +422,7 @@ begin
 
   // player 2:
   AddByStatics(2, Theme.Sing.StaticP2RScoreBG, Theme.Sing.StaticP2RSingBar, Theme.Sing.TextP2RScore);
-  AddByStatics(4, Theme.Sing.StaticP2MScoreBG, Theme.Sing.StaticP2MSingBar, Theme.Sing.TextP2MScore);
+  AddByStatics(4, Theme.Sing.Solo3PP2.ScoreBackground, Theme.Sing.Solo3PP2.SingBar, Theme.Sing.Solo3PP2.Score);
 
   // player 3:
   AddByStatics(4, Theme.Sing.Solo3PP3.ScoreBackground, Theme.Sing.Solo3PP3.SingBar, Theme.Sing.Solo3PP3.Score);
@@ -1150,14 +1150,14 @@ begin
                   end;
                 1, 4, 7:
                   begin
-                    aPositions[PIndex].PUW := Theme.Sing.StaticP2MScoreBG.W;
-                    aPositions[PIndex].PUH := Theme.Sing.StaticP2MScoreBG.H;
+                    aPositions[PIndex].PUW := Theme.Sing.Solo3PP2.ScoreBackground.W;
+                    aPositions[PIndex].PUH := Theme.Sing.Solo3PP2.ScoreBackground.H;
 
-                    aPositions[PIndex].PUStartX := Theme.Sing.StaticP2MScoreBG.X;
-                    aPositions[PIndex].PUStartY := Theme.Sing.TextP2MScore.Y + 65;
+                    aPositions[PIndex].PUStartX := Theme.Sing.Solo3PP2.ScoreBackground.X;
+                    aPositions[PIndex].PUStartY := Theme.Sing.Solo3PP2.Score.Y + 65;
 
-                    aPositions[PIndex].PUTargetX := Theme.Sing.StaticP2MScoreBG.X;
-                    aPositions[PIndex].PUTargetY := Theme.Sing.TextP2MScore.Y;
+                    aPositions[PIndex].PUTargetX := Theme.Sing.Solo3PP2.ScoreBackground.X;
+                    aPositions[PIndex].PUTargetY := Theme.Sing.Solo3PP2.Score.Y;
                   end;
                 2, 5, 8:
                   begin

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -921,14 +921,14 @@ begin
                     end;
                   3:
                     begin
-                      aPositions[PIndex].PUW := Theme.Sing.StaticP4FourPScoreBG.W;
-                      aPositions[PIndex].PUH := Theme.Sing.StaticP4FourPScoreBG.H;
+                      aPositions[PIndex].PUW := Theme.Sing.Solo4PP4.ScoreBackground.W;
+                      aPositions[PIndex].PUH := Theme.Sing.Solo4PP4.ScoreBackground.H;
 
-                      aPositions[PIndex].PUStartX := Theme.Sing.StaticP4FourPScoreBG.X;
-                      aPositions[PIndex].PUStartY := Theme.Sing.TextP4FourPScore.Y + 65;
+                      aPositions[PIndex].PUStartX := Theme.Sing.Solo4PP4.ScoreBackground.X;
+                      aPositions[PIndex].PUStartY := Theme.Sing.Solo4PP4.Score.Y + 65;
 
-                      aPositions[PIndex].PUTargetX := Theme.Sing.StaticP4FourPScoreBG.X;
-                      aPositions[PIndex].PUTargetY := Theme.Sing.TextP4FourPScore.Y;
+                      aPositions[PIndex].PUTargetX := Theme.Sing.Solo4PP4.ScoreBackground.X;
+                      aPositions[PIndex].PUTargetY := Theme.Sing.Solo4PP4.Score.Y;
                     end;
                 end;
             end;
@@ -1440,16 +1440,16 @@ begin
                Position.TextSize  := Theme.Sing.Solo4PP3.Score.Size;
              end;
           3: begin
-               Position.BGX := Theme.Sing.StaticP4FourPScoreBG.X;
-               Position.BGY := Theme.Sing.StaticP4FourPScoreBG.Y;
-               Position.BGW := Theme.Sing.StaticP4FourPScoreBG.W;
-               Position.BGH := Theme.Sing.StaticP4FourPScoreBG.H;
+               Position.BGX := Theme.Sing.Solo4PP4.ScoreBackground.X;
+               Position.BGY := Theme.Sing.Solo4PP4.ScoreBackground.Y;
+               Position.BGW := Theme.Sing.Solo4PP4.ScoreBackground.W;
+               Position.BGH := Theme.Sing.Solo4PP4.ScoreBackground.H;
 
-               Position.TextX     := Theme.Sing.TextP4FourPScore.X;
-               Position.TextY     := Theme.Sing.TextP4FourPScore.Y;
-               Position.TextFont  := Theme.Sing.TextP4FourPScore.Font;
-               Position.TextStyle := Theme.Sing.TextP4FourPScore.Style;
-               Position.TextSize  := Theme.Sing.TextP4FourPScore.Size;
+               Position.TextX     := Theme.Sing.Solo4PP4.Score.X;
+               Position.TextY     := Theme.Sing.Solo4PP4.Score.Y;
+               Position.TextFont  := Theme.Sing.Solo4PP4.Score.Font;
+               Position.TextStyle := Theme.Sing.Solo4PP4.Score.Style;
+               Position.TextSize  := Theme.Sing.Solo4PP4.Score.Size;
              end;
         end;
       end;
@@ -1781,10 +1781,10 @@ begin
                Position.RBH := Theme.Sing.Solo4PP3.SingBar.H;
              end;
           3: begin
-               Position.RBX := Theme.Sing.StaticP4FourPSingBar.X;
-               Position.RBY := Theme.Sing.StaticP4FourPSingBar.Y;
-               Position.RBW := Theme.Sing.StaticP4FourPSingBar.W;
-               Position.RBH := Theme.Sing.StaticP4FourPSingBar.H;
+               Position.RBX := Theme.Sing.Solo4PP4.SingBar.X;
+               Position.RBY := Theme.Sing.Solo4PP4.SingBar.Y;
+               Position.RBW := Theme.Sing.Solo4PP4.SingBar.W;
+               Position.RBH := Theme.Sing.Solo4PP4.SingBar.H;
              end;
         end;
       end;

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -556,12 +556,7 @@ type
     StaticDuetP3RSingBar:       TThemePosition;
 
     //game in 4/6 player modi in 1 Screen
-    StaticP1FourPSingBar: TThemePosition;
-    StaticP1FourP:        TThemeStatic;
-    StaticP1FourPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP1FourPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP1FourP:          TThemeText;
-    TextP1FourPScore:     TThemeText;
+    Solo4PP1: TThemeSingPlayer;
 
     StaticP2FourPSingBar: TThemePosition;
     StaticP2FourP:        TThemeStatic;
@@ -2120,12 +2115,7 @@ begin
       ThemeLoadPosition(Sing.StaticDuetP3RSingBar, 'SingDuetP3RSingBar');
 
       //4P/6P mode in 1 Screen
-      ThemeLoadPosition(Sing.StaticP1FourPSingBar, 'SingP1FourPSingBar');
-      ThemeLoadStatic(Sing.StaticP1FourP, 'SingP1FourPStatic');
-      ThemeLoadText(Sing.TextP1FourP, 'SingP1FourPText');
-      ThemeLoadPosition(Sing.StaticP1FourPScoreBG, 'SingP1FourPStatic2');
-      ThemeLoadText(Sing.TextP1FourPScore, 'SingP1FourPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP1FourPAvatar, 'SingP1FourPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Solo4PP1, 'P1FourP');
 
       ThemeLoadPosition(Sing.StaticP2FourPSingBar, 'SingP2FourPSingBar');
       ThemeLoadStatic(Sing.StaticP2FourP, 'SingP2FourPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -539,16 +539,10 @@ type
     StaticDuetP1ThreePScoreBG: TThemePosition;
     TextDuetP1ThreePScore:     TThemeText;
 
-    StaticDuetP2M:        TThemeStatic;
-    StaticDuetP2MAvatar:  TThemeStaticAlphaRectangle;
-    TextDuetP2M:          TThemeText;
-    StaticDuetP2MScoreBG: TThemePosition;
-    TextDuetP2MScore:     TThemeText;
-
+    Duet3PP2: TThemeSingPlayer;
     Duet3PP3: TThemeSingPlayer;
 
     StaticDuetP1ThreePSingBar: TThemePosition;
-    StaticDuetP2MSingBar:      TThemePosition;
 
     //game in 4/6 player modi in 1 Screen
     Solo4PP1: TThemeSingPlayer;
@@ -1982,16 +1976,10 @@ begin
       ThemeLoadText(Sing.TextDuetP1ThreePScore, 'SingDuetP1ThreePTextScore');
       ThemeLoadStaticAlphaRectangle(Sing.StaticDuetP1ThreePAvatar, 'SingDuetP1ThreePAvatar');
 
-      ThemeLoadStatic(Sing.StaticDuetP2M, 'SingDuetP2MStatic');
-      ThemeLoadText(Sing.TextDuetP2M, 'SingDuetP2MText');
-      ThemeLoadPosition(Sing.StaticDuetP2MScoreBG, 'SingDuetP2MStatic2');
-      ThemeLoadText(Sing.TextDuetP2MScore, 'SingDuetP2MTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticDuetP2MAvatar, 'SingDuetP2MAvatar');
-
+      ThemeLoadSingPlayerStatics(Sing.Duet3PP2, 'DuetP2M');
       ThemeLoadSingPlayerStatics(Sing.Duet3PP3, 'DuetP3R');
 
       ThemeLoadPosition(Sing.StaticDuetP1ThreePSingBar, 'SingDuetP1ThreePSingBar');
-      ThemeLoadPosition(Sing.StaticDuetP2MSingBar, 'SingDuetP2MSingBar');
 
       //4P/6P mode in 1 Screen
       ThemeLoadSingPlayerStatics(Sing.Solo4PP1, 'P1FourP');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -559,13 +559,7 @@ type
     Solo4PP1: TThemeSingPlayer;
     Solo4PP2: TThemeSingPlayer;
     Solo4PP3: TThemeSingPlayer;
-
-    StaticP4FourPSingBar: TThemePosition;
-    StaticP4FourP:        TThemeStatic;
-    StaticP4FourPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP4FourPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP4FourP:          TThemeText;
-    TextP4FourPScore:     TThemeText;
+    Solo4PP4: TThemeSingPlayer;
 
     StaticP1SixPSingBar: TThemePosition;
     StaticP1SixP:        TThemeStatic;
@@ -2106,13 +2100,7 @@ begin
       ThemeLoadSingPlayerStatics(Sing.Solo4PP1, 'P1FourP');
       ThemeLoadSingPlayerStatics(Sing.Solo4PP2, 'P2FourP');
       ThemeLoadSingPlayerStatics(Sing.Solo4PP3, 'P3FourP');
-
-      ThemeLoadPosition(Sing.StaticP4FourPSingBar, 'SingP4FourPSingBar');
-      ThemeLoadStatic(Sing.StaticP4FourP, 'SingP4FourPStatic');
-      ThemeLoadText(Sing.TextP4FourP, 'SingP4FourPText');
-      ThemeLoadPosition(Sing.StaticP4FourPScoreBG, 'SingP4FourPStatic2');
-      ThemeLoadText(Sing.TextP4FourPScore, 'SingP4FourPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP4FourPAvatar, 'SingP4FourPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Solo4PP4, 'P4FourP');
 
       ThemeLoadPosition(Sing.StaticP1SixPSingBar, 'SingP1SixPSingBar');
       ThemeLoadStatic(Sing.StaticP1SixP, 'SingP1SixPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -571,13 +571,7 @@ type
     // duet 4/6 players in one screen
     Duet4PP1: TThemeSingPlayer;
     Duet4PP2: TThemeSingPlayer;
-
-    StaticP3DuetFourPSingBar: TThemePosition;
-    StaticP3DuetFourP:        TThemeStatic;
-    StaticP3DuetFourPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP3DuetFourPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP3DuetFourP:          TThemeText;
-    TextP3DuetFourPScore:     TThemeText;
+    Duet4PP3: TThemeSingPlayer;
 
     StaticP4DuetFourPSingBar: TThemePosition;
     StaticP4DuetFourP:        TThemeStatic;
@@ -2066,13 +2060,7 @@ begin
       // duet 4/6 players in one screen
       ThemeLoadSingPlayerStatics(Sing.Duet4PP1, 'P1DuetFourP');
       ThemeLoadSingPlayerStatics(Sing.Duet4PP2, 'P2DuetFourP');
-
-      ThemeLoadPosition(Sing.StaticP3DuetFourPSingBar, 'SingP3DuetFourPSingBar');
-      ThemeLoadStatic(Sing.StaticP3DuetFourP, 'SingP3DuetFourPStatic');
-      ThemeLoadText(Sing.TextP3DuetFourP, 'SingP3DuetFourPText');
-      ThemeLoadPosition(Sing.StaticP3DuetFourPScoreBG, 'SingP3DuetFourPStatic2');
-      ThemeLoadText(Sing.TextP3DuetFourPScore, 'SingP3DuetFourPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP3DuetFourPAvatar, 'SingP3DuetFourPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Duet4PP3, 'P3DuetFourP');
 
       ThemeLoadPosition(Sing.StaticP4DuetFourPSingBar, 'SingP4DuetFourPSingBar');
       ThemeLoadStatic(Sing.StaticP4DuetFourP, 'SingP4DuetFourPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -570,13 +570,7 @@ type
 
     // duet 4/6 players in one screen
     Duet4PP1: TThemeSingPlayer;
-
-    StaticP2DuetFourPSingBar: TThemePosition;
-    StaticP2DuetFourP:        TThemeStatic;
-    StaticP2DuetFourPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP2DuetFourPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP2DuetFourP:          TThemeText;
-    TextP2DuetFourPScore:     TThemeText;
+    Duet4PP2: TThemeSingPlayer;
 
     StaticP3DuetFourPSingBar: TThemePosition;
     StaticP3DuetFourP:        TThemeStatic;
@@ -2071,13 +2065,7 @@ begin
 
       // duet 4/6 players in one screen
       ThemeLoadSingPlayerStatics(Sing.Duet4PP1, 'P1DuetFourP');
-
-      ThemeLoadPosition(Sing.StaticP2DuetFourPSingBar, 'SingP2DuetFourPSingBar');
-      ThemeLoadStatic(Sing.StaticP2DuetFourP, 'SingP2DuetFourPStatic');
-      ThemeLoadText(Sing.TextP2DuetFourP, 'SingP2DuetFourPText');
-      ThemeLoadPosition(Sing.StaticP2DuetFourPScoreBG, 'SingP2DuetFourPStatic2');
-      ThemeLoadText(Sing.TextP2DuetFourPScore, 'SingP2DuetFourPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP2DuetFourPAvatar, 'SingP2DuetFourPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Duet4PP2, 'P2DuetFourP');
 
       ThemeLoadPosition(Sing.StaticP3DuetFourPSingBar, 'SingP3DuetFourPSingBar');
       ThemeLoadStatic(Sing.StaticP3DuetFourP, 'SingP3DuetFourPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -575,13 +575,7 @@ type
     Duet4PP4: TThemeSingPlayer;
 
     Duet6PP1: TThemeSingPlayer;
-
-    StaticP2DuetSixPSingBar: TThemePosition;
-    StaticP2DuetSixP:        TThemeStatic;
-    StaticP2DuetSixPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP2DuetSixPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP2DuetSixP:          TThemeText;
-    TextP2DuetSixPScore:     TThemeText;
+    Duet6PP2: TThemeSingPlayer;
 
     StaticP3DuetSixPSingBar: TThemePosition;
     StaticP3DuetSixP:        TThemeStatic;
@@ -2053,13 +2047,7 @@ begin
       ThemeLoadSingPlayerStatics(Sing.Duet4PP4, 'P4DuetFourP');
 
       ThemeLoadSingPlayerStatics(Sing.Duet6PP1, 'P1DuetSixP');
-
-      ThemeLoadPosition(Sing.StaticP2DuetSixPSingBar, 'SingP2DuetSixPSingBar');
-      ThemeLoadStatic(Sing.StaticP2DuetSixP, 'SingP2DuetSixPStatic');
-      ThemeLoadText(Sing.TextP2DuetSixP, 'SingP2DuetSixPText');
-      ThemeLoadPosition(Sing.StaticP2DuetSixPScoreBG, 'SingP2DuetSixPStatic2');
-      ThemeLoadText(Sing.TextP2DuetSixPScore, 'SingP2DuetSixPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP2DuetSixPAvatar, 'SingP2DuetSixPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Duet6PP2, 'P2DuetSixP');
 
       ThemeLoadPosition(Sing.StaticP3DuetSixPSingBar, 'SingP3DuetSixPSingBar');
       ThemeLoadStatic(Sing.StaticP3DuetSixP, 'SingP3DuetSixPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -579,13 +579,7 @@ type
     Duet6PP3: TThemeSingPlayer;
     Duet6PP4: TThemeSingPlayer;
     Duet6PP5: TThemeSingPlayer;
-
-    StaticP6DuetSixPSingBar: TThemePosition;
-    StaticP6DuetSixP:        TThemeStatic;
-    StaticP6DuetSixPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP6DuetSixPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP6DuetSixP:          TThemeText;
-    TextP6DuetSixPScore:     TThemeText;
+    Duet6PP6: TThemeSingPlayer;
 
     SingP1Oscilloscope:           TThemePosition;
     SingP1TwoPOscilloscope:       TThemePosition;
@@ -2033,13 +2027,7 @@ begin
       ThemeLoadSingPlayerStatics(Sing.Duet6PP3, 'P3DuetSixP');
       ThemeLoadSingPlayerStatics(Sing.Duet6PP4, 'P4DuetSixP');
       ThemeLoadSingPlayerStatics(Sing.Duet6PP5, 'P5DuetSixP');
-
-      ThemeLoadPosition(Sing.StaticP6DuetSixPSingBar, 'SingP6DuetSixPSingBar');
-      ThemeLoadStatic(Sing.StaticP6DuetSixP, 'SingP6DuetSixPStatic');
-      ThemeLoadText(Sing.TextP6DuetSixP, 'SingP6DuetSixPText');
-      ThemeLoadPosition(Sing.StaticP6DuetSixPScoreBG, 'SingP6DuetSixPStatic2');
-      ThemeLoadText(Sing.TextP6DuetSixPScore, 'SingP6DuetSixPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP6DuetSixPAvatar, 'SingP6DuetSixPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Duet6PP6, 'P6DuetSixP');
 
       // Oscilloscope Position
       ThemeLoadPosition(Sing.SingP1Oscilloscope, 'SingP1Oscilloscope');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -574,12 +574,7 @@ type
     Duet4PP3: TThemeSingPlayer;
     Duet4PP4: TThemeSingPlayer;
 
-    StaticP1DuetSixPSingBar: TThemePosition;
-    StaticP1DuetSixP:        TThemeStatic;
-    StaticP1DuetSixPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP1DuetSixPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP1DuetSixP:          TThemeText;
-    TextP1DuetSixPScore:     TThemeText;
+    Duet6PP1: TThemeSingPlayer;
 
     StaticP2DuetSixPSingBar: TThemePosition;
     StaticP2DuetSixP:        TThemeStatic;
@@ -2057,13 +2052,7 @@ begin
       ThemeLoadSingPlayerStatics(Sing.Duet4PP3, 'P3DuetFourP');
       ThemeLoadSingPlayerStatics(Sing.Duet4PP4, 'P4DuetFourP');
 
-
-      ThemeLoadPosition(Sing.StaticP1DuetSixPSingBar, 'SingP1DuetSixPSingBar');
-      ThemeLoadStatic(Sing.StaticP1DuetSixP, 'SingP1DuetSixPStatic');
-      ThemeLoadText(Sing.TextP1DuetSixP, 'SingP1DuetSixPText');
-      ThemeLoadPosition(Sing.StaticP1DuetSixPScoreBG, 'SingP1DuetSixPStatic2');
-      ThemeLoadText(Sing.TextP1DuetSixPScore, 'SingP1DuetSixPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP1DuetSixPAvatar, 'SingP1DuetSixPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Duet6PP1, 'P1DuetSixP');
 
       ThemeLoadPosition(Sing.StaticP2DuetSixPSingBar, 'SingP2DuetSixPSingBar');
       ThemeLoadStatic(Sing.StaticP2DuetSixP, 'SingP2DuetSixPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -1882,26 +1882,11 @@ begin
       ThemeLoadText(Sing.TextP1Score, 'SingP1TextScore');
       ThemeLoadStaticAlphaRectangle(Sing.StaticP1Avatar, 'SingP1Avatar');
 
-
-  //Added for ps3 skin
-  //This one is shown in 2/4P mode
-  //if it exists, otherwise the one Player equivaltents are used
-      if (ThemeIni.SectionExists('SingP1TwoPTextScore')) then
-      begin
-        ThemeLoadStatic(Sing.StaticP1TwoP, 'SingP1TwoPStatic');
-        ThemeLoadStaticAlphaRectangle(Sing.StaticP1TwoPAvatar, 'SingP1TwoPAvatar');
-        ThemeLoadText(Sing.TextP1TwoP, 'SingP1TwoPText');
-        ThemeLoadPosition(Sing.StaticP1TwoPScoreBG, 'SingP1TwoPStatic2');
-        ThemeLoadText(Sing.TextP1TwoPScore, 'SingP1TwoPTextScore');
-      end
-      else
-      begin
-        Sing.StaticP1TwoP := Sing.StaticP1;
-        Sing.StaticP1TwoPAvatar := Sing.StaticP1Avatar;
-        Sing.TextP1TwoP := Sing.TextP1;
-        Sing.StaticP1TwoPScoreBG := Sing.StaticP1ScoreBG;
-        Sing.TextP1TwoPScore := Sing.TextP1Score;
-      end;
+      ThemeLoadStatic(Sing.StaticP1TwoP, 'SingP1TwoPStatic');
+      ThemeLoadStaticAlphaRectangle(Sing.StaticP1TwoPAvatar, 'SingP1TwoPAvatar');
+      ThemeLoadText(Sing.TextP1TwoP, 'SingP1TwoPText');
+      ThemeLoadPosition(Sing.StaticP1TwoPScoreBG, 'SingP1TwoPStatic2');
+      ThemeLoadText(Sing.TextP1TwoPScore, 'SingP1TwoPTextScore');
 
   //This one is shown in 3/6P mode
   //if it exists, otherwise the one Player equivaltents are used

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -563,13 +563,7 @@ type
 
     Solo6PP1: TThemeSingPlayer;
     Solo6PP2: TThemeSingPlayer;
-
-    StaticP3SixPSingBar: TThemePosition;
-    StaticP3SixP:        TThemeStatic;
-    StaticP3SixPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP3SixPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP3SixP:          TThemeText;
-    TextP3SixPScore:     TThemeText;
+    Solo6PP3: TThemeSingPlayer;
 
     StaticP4SixPSingBar: TThemePosition;
     StaticP4SixP:        TThemeStatic;
@@ -2093,13 +2087,7 @@ begin
 
       ThemeLoadSingPlayerStatics(Sing.Solo6PP1, 'P1SixP');
       ThemeLoadSingPlayerStatics(Sing.Solo6PP2, 'P2SixP');
-
-      ThemeLoadPosition(Sing.StaticP3SixPSingBar, 'SingP3SixPSingBar');
-      ThemeLoadStatic(Sing.StaticP3SixP, 'SingP3SixPStatic');
-      ThemeLoadText(Sing.TextP3SixP, 'SingP3SixPText');
-      ThemeLoadPosition(Sing.StaticP3SixPScoreBG, 'SingP3SixPStatic2');
-      ThemeLoadText(Sing.TextP3SixPScore, 'SingP3SixPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP3SixPAvatar, 'SingP3SixPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Solo6PP3, 'P3SixP');
 
       ThemeLoadPosition(Sing.StaticP4SixPSingBar, 'SingP4SixPSingBar');
       ThemeLoadStatic(Sing.StaticP4SixP, 'SingP4SixPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -564,13 +564,7 @@ type
     Solo6PP1: TThemeSingPlayer;
     Solo6PP2: TThemeSingPlayer;
     Solo6PP3: TThemeSingPlayer;
-
-    StaticP4SixPSingBar: TThemePosition;
-    StaticP4SixP:        TThemeStatic;
-    StaticP4SixPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP4SixPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP4SixP:          TThemeText;
-    TextP4SixPScore:     TThemeText;
+    Solo6PP4: TThemeSingPlayer;
 
     StaticP5SixPSingBar: TThemePosition;
     StaticP5SixP:        TThemeStatic;
@@ -2088,13 +2082,7 @@ begin
       ThemeLoadSingPlayerStatics(Sing.Solo6PP1, 'P1SixP');
       ThemeLoadSingPlayerStatics(Sing.Solo6PP2, 'P2SixP');
       ThemeLoadSingPlayerStatics(Sing.Solo6PP3, 'P3SixP');
-
-      ThemeLoadPosition(Sing.StaticP4SixPSingBar, 'SingP4SixPSingBar');
-      ThemeLoadStatic(Sing.StaticP4SixP, 'SingP4SixPStatic');
-      ThemeLoadText(Sing.TextP4SixP, 'SingP4SixPText');
-      ThemeLoadPosition(Sing.StaticP4SixPScoreBG, 'SingP4SixPStatic2');
-      ThemeLoadText(Sing.TextP4SixPScore, 'SingP4SixPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP4SixPAvatar, 'SingP4SixPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Solo6PP4, 'P4SixP');
 
       ThemeLoadPosition(Sing.StaticP5SixPSingBar, 'SingP5SixPSingBar');
       ThemeLoadStatic(Sing.StaticP5SixP, 'SingP5SixPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -496,7 +496,6 @@ type
     StaticP1ThreePSingBar: TThemePosition;
     StaticP1TwoPSingBar:   TThemePosition;
     StaticP2RSingBar:      TThemePosition;
-    StaticP2MSingBar:      TThemePosition;
     //eoa moveable singbar
 
     //added for ps3 skin
@@ -520,12 +519,7 @@ type
     TextP2R:          TThemeText;
     TextP2RScore:     TThemeText;
 
-    StaticP2M:        TThemeStatic;
-    StaticP2MAvatar:  TThemeStaticAlphaRectangle;
-    StaticP2MScoreBG: TThemePosition; //Static for ScoreBG
-    TextP2M:          TThemeText;
-    TextP2MScore:     TThemeText;
-
+    Solo3PP2: TThemeSingPlayer;
     Solo3PP3: TThemeSingPlayer;
 
     Duet3PP1: TThemeSingPlayer;
@@ -1886,7 +1880,6 @@ begin
       ThemeLoadPosition(Sing.StaticP1TwoPSingBar, 'SingP1TwoPSingBar');
       ThemeLoadPosition(Sing.StaticP1ThreePSingBar, 'SingP1ThreePSingBar');
       ThemeLoadPosition(Sing.StaticP2RSingBar, 'SingP2RSingBar');
-      ThemeLoadPosition(Sing.StaticP2MSingBar, 'SingP2MSingBar');
     //eoa moveable singbar
 
       ThemeLoadStatic(Sing.StaticP1, 'SingP1Static');
@@ -1941,12 +1934,7 @@ begin
       ThemeLoadText(Sing.TextP2RScore, 'SingP2RTextScore');
       ThemeLoadStaticAlphaRectangle(Sing.StaticP2RAvatar, 'SingP2RAvatar');
 
-      ThemeLoadStatic(Sing.StaticP2M, 'SingP2MStatic');
-      ThemeLoadText(Sing.TextP2M, 'SingP2MText');
-      ThemeLoadPosition(Sing.StaticP2MScoreBG, 'SingP2MStatic2');
-      ThemeLoadText(Sing.TextP2MScore, 'SingP2MTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP2MAvatar, 'SingP2MAvatar');
-
+      ThemeLoadSingPlayerStatics(Sing.Solo3PP2, 'P2M');
       // TODO: we have to load Solo3PP3 manually because the SingBar uses a different name
       ThemeLoadText(Sing.Solo3PP3.Name, 'SingP3RText');
       ThemeLoadText(Sing.Solo3PP3.Score, 'SingP3RTextScore');
@@ -3947,7 +3935,6 @@ begin
   ThemeSavePosition(Sing.StaticP1TwoPSingBar, 'SingP1TwoPSingBar');
   ThemeSavePosition(Sing.StaticP1ThreePSingBar, 'SingP1ThreePSingBar');
   ThemeSavePosition(Sing.StaticP2RSingBar, 'SingP2RSingBar');
-  ThemeSavePosition(Sing.StaticP2MSingBar, 'SingP2MSingBar');
   //eoa moveable singbar
 
   //Added for ps3 skin
@@ -3969,10 +3956,11 @@ begin
   ThemeSavePosition(Sing.StaticP2RScoreBG, 'SingP2RStatic2');
   ThemeSaveText(Sing.TextP2RScore, 'SingP2RTextScore');
 
-  ThemeSaveStatic(Sing.StaticP2M, 'SingP2MStatic');
-  ThemeSaveText(Sing.TextP2M, 'SingP2MText');
-  ThemeSavePosition(Sing.StaticP2MScoreBG, 'SingP2MStatic2');
-  ThemeSaveText(Sing.TextP2MScore, 'SingP2MTextScore');
+  ThemeSaveText(Sing.Solo3PP2.Name, 'SingP2MText');
+  ThemeSaveText(Sing.Solo3PP2.Score, 'SingP2MTextScore');
+  ThemeSavePosition(Sing.Solo3PP2.ScoreBackground, 'SingP2MStatic2');
+  ThemeSaveStatic(Sing.Solo3PP2.AvatarFrame, 'SingP2MStatic');
+  ThemeSavePosition(Sing.Solo3PP2.SingBar, 'SingP2MSingBar');
 
   ThemeSaveText(Sing.Solo3PP3.Name, 'SingP3RText');
   ThemeSaveText(Sing.Solo3PP3.Score, 'SingP3RTextScore');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -495,7 +495,6 @@ type
     StaticP1SingBar:       TThemePosition;
     StaticP1ThreePSingBar: TThemePosition;
     StaticP1TwoPSingBar:   TThemePosition;
-    StaticP2RSingBar:      TThemePosition;
     //eoa moveable singbar
 
     //added for ps3 skin
@@ -513,11 +512,7 @@ type
     TextP1ThreePScore:      TThemeText;
     //eoa
 
-    StaticP2R:        TThemeStatic;
-    StaticP2RAvatar:  TThemeStaticAlphaRectangle;
-    StaticP2RScoreBG: TThemePosition; //Static for ScoreBG
-    TextP2R:          TThemeText;
-    TextP2RScore:     TThemeText;
+    Solo2PP2: TThemeSingPlayer;
 
     Solo3PP2: TThemeSingPlayer;
     Solo3PP3: TThemeSingPlayer;
@@ -1879,7 +1874,6 @@ begin
       ThemeLoadPosition(Sing.StaticP1SingBar, 'SingP1SingBar');
       ThemeLoadPosition(Sing.StaticP1TwoPSingBar, 'SingP1TwoPSingBar');
       ThemeLoadPosition(Sing.StaticP1ThreePSingBar, 'SingP1ThreePSingBar');
-      ThemeLoadPosition(Sing.StaticP2RSingBar, 'SingP2RSingBar');
     //eoa moveable singbar
 
       ThemeLoadStatic(Sing.StaticP1, 'SingP1Static');
@@ -1928,11 +1922,7 @@ begin
         Sing.TextP1ThreePScore := Sing.TextP1Score;
       end;
   //eoa
-      ThemeLoadStatic(Sing.StaticP2R, 'SingP2RStatic');
-      ThemeLoadText(Sing.TextP2R, 'SingP2RText');
-      ThemeLoadPosition(Sing.StaticP2RScoreBG, 'SingP2RStatic2');
-      ThemeLoadText(Sing.TextP2RScore, 'SingP2RTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP2RAvatar, 'SingP2RAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Solo2PP2, 'P2R');
 
       ThemeLoadSingPlayerStatics(Sing.Solo3PP2, 'P2M');
       // TODO: we have to load Solo3PP3 manually because the SingBar uses a different name
@@ -3934,7 +3924,6 @@ begin
   ThemeSavePosition(Sing.StaticP1SingBar, 'SingP1SingBar');
   ThemeSavePosition(Sing.StaticP1TwoPSingBar, 'SingP1TwoPSingBar');
   ThemeSavePosition(Sing.StaticP1ThreePSingBar, 'SingP1ThreePSingBar');
-  ThemeSavePosition(Sing.StaticP2RSingBar, 'SingP2RSingBar');
   //eoa moveable singbar
 
   //Added for ps3 skin
@@ -3951,10 +3940,11 @@ begin
   ThemeSaveText(Sing.TextP1ThreePScore, 'SingP1ThreePTextScore');
   //eoa
 
-  ThemeSaveStatic(Sing.StaticP2R, 'SingP2RStatic');
-  ThemeSaveText(Sing.TextP2R, 'SingP2RText');
-  ThemeSavePosition(Sing.StaticP2RScoreBG, 'SingP2RStatic2');
-  ThemeSaveText(Sing.TextP2RScore, 'SingP2RTextScore');
+  ThemeSaveText(Sing.Solo2PP2.Name, 'SingP2RText');
+  ThemeSaveText(Sing.Solo2PP2.Score, 'SingP2RTextScore');
+  ThemeSavePosition(Sing.Solo2PP2.ScoreBackground, 'SingP2RStatic2');
+  ThemeSaveStatic(Sing.Solo2PP2.AvatarFrame, 'SingP2RStatic');
+  ThemeSavePosition(Sing.Solo2PP2.SingBar, 'SingP2RSingBar');
 
   ThemeSaveText(Sing.Solo3PP2.Name, 'SingP2MText');
   ThemeSaveText(Sing.Solo3PP2.Score, 'SingP2MTextScore');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -497,7 +497,6 @@ type
     StaticP1TwoPSingBar:   TThemePosition;
     StaticP2RSingBar:      TThemePosition;
     StaticP2MSingBar:      TThemePosition;
-    StaticP3SingBar:       TThemePosition;
     //eoa moveable singbar
 
     //added for ps3 skin
@@ -527,11 +526,7 @@ type
     TextP2M:          TThemeText;
     TextP2MScore:     TThemeText;
 
-    StaticP3R:        TThemeStatic;
-    StaticP3RAvatar:  TThemeStaticAlphaRectangle;
-    StaticP3RScoreBG: TThemePosition; //Static for ScoreBG
-    TextP3R:          TThemeText;
-    TextP3RScore:     TThemeText;
+    Solo3PP3: TThemeSingPlayer;
 
     Duet3PP1: TThemeSingPlayer;
     Duet3PP2: TThemeSingPlayer;
@@ -1892,7 +1887,6 @@ begin
       ThemeLoadPosition(Sing.StaticP1ThreePSingBar, 'SingP1ThreePSingBar');
       ThemeLoadPosition(Sing.StaticP2RSingBar, 'SingP2RSingBar');
       ThemeLoadPosition(Sing.StaticP2MSingBar, 'SingP2MSingBar');
-      ThemeLoadPosition(Sing.StaticP3SingBar, 'SingP3SingBar');
     //eoa moveable singbar
 
       ThemeLoadStatic(Sing.StaticP1, 'SingP1Static');
@@ -1953,11 +1947,14 @@ begin
       ThemeLoadText(Sing.TextP2MScore, 'SingP2MTextScore');
       ThemeLoadStaticAlphaRectangle(Sing.StaticP2MAvatar, 'SingP2MAvatar');
 
-      ThemeLoadStatic(Sing.StaticP3R, 'SingP3RStatic');
-      ThemeLoadText(Sing.TextP3R, 'SingP3RText');
-      ThemeLoadPosition(Sing.StaticP3RScoreBG, 'SingP3RStatic2');
-      ThemeLoadText(Sing.TextP3RScore, 'SingP3RTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP3RAvatar, 'SingP3RAvatar');
+      // TODO: we have to load Solo3PP3 manually because the SingBar uses a different name
+      ThemeLoadText(Sing.Solo3PP3.Name, 'SingP3RText');
+      ThemeLoadText(Sing.Solo3PP3.Score, 'SingP3RTextScore');
+      ThemeLoadPosition(Sing.Solo3PP3.ScoreBackground, 'SingP3RStatic2');
+      ThemeLoadStatic(Sing.Solo3PP3.AvatarFrame, 'SingP3RStatic');
+      ThemeLoadStaticAlphaRectangle(Sing.Solo3PP3.Avatar, 'SingP3RAvatar');
+      // TODO: SingBar uses non-consistent naming in theme
+      ThemeLoadPosition(Sing.Solo3PP3.SingBar, 'SingP3SingBar');
 
       ThemeLoadStatic(Sing.StaticSongName, 'SingSongNameStatic');
       ThemeLoadText(Sing.TextSongName, 'SingSongNameText');
@@ -3951,7 +3948,6 @@ begin
   ThemeSavePosition(Sing.StaticP1ThreePSingBar, 'SingP1ThreePSingBar');
   ThemeSavePosition(Sing.StaticP2RSingBar, 'SingP2RSingBar');
   ThemeSavePosition(Sing.StaticP2MSingBar, 'SingP2MSingBar');
-  ThemeSavePosition(Sing.StaticP3SingBar, 'SingP3SingBar');
   //eoa moveable singbar
 
   //Added for ps3 skin
@@ -3978,10 +3974,12 @@ begin
   ThemeSavePosition(Sing.StaticP2MScoreBG, 'SingP2MStatic2');
   ThemeSaveText(Sing.TextP2MScore, 'SingP2MTextScore');
 
-  ThemeSaveStatic(Sing.StaticP3R, 'SingP3RStatic');
-  ThemeSaveText(Sing.TextP3R, 'SingP3RText');
-  ThemeSavePosition(Sing.StaticP3RScoreBG, 'SingP3RStatic2');
-  ThemeSaveText(Sing.TextP3RScore, 'SingP3RTextScore');
+  ThemeSaveText(Sing.Solo3PP3.Name, 'SingP3RText');
+  ThemeSaveText(Sing.Solo3PP3.Score, 'SingP3RTextScore');
+  ThemeSavePosition(Sing.Solo3PP3.ScoreBackground, 'SingP3RStatic2');
+  ThemeSaveStatic(Sing.Solo3PP3.AvatarFrame, 'SingP3RStatic');
+  // TODO: inconsistent naming!
+  ThemeSavePosition(Sing.Solo3PP3.SingBar, 'SingP3SingBar');
 
   ThemeSaveBasic(Score, 'Score');
   ThemeSaveText(Score.TextArtist, 'ScoreTextArtist');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -545,15 +545,10 @@ type
     StaticDuetP2MScoreBG: TThemePosition;
     TextDuetP2MScore:     TThemeText;
 
-    StaticDuetP3R:        TThemeStatic;
-    StaticDuetP3RAvatar:  TThemeStaticAlphaRectangle;
-    TextDuetP3R:          TThemeText;
-    StaticDuetP3RScoreBG: TThemePosition;
-    TextDuetP3RScore:     TThemeText;
+    Duet3PP3: TThemeSingPlayer;
 
     StaticDuetP1ThreePSingBar: TThemePosition;
     StaticDuetP2MSingBar:      TThemePosition;
-    StaticDuetP3RSingBar:       TThemePosition;
 
     //game in 4/6 player modi in 1 Screen
     Solo4PP1: TThemeSingPlayer;
@@ -1993,15 +1988,10 @@ begin
       ThemeLoadText(Sing.TextDuetP2MScore, 'SingDuetP2MTextScore');
       ThemeLoadStaticAlphaRectangle(Sing.StaticDuetP2MAvatar, 'SingDuetP2MAvatar');
 
-      ThemeLoadStatic(Sing.StaticDuetP3R, 'SingDuetP3RStatic');
-      ThemeLoadText(Sing.TextDuetP3R, 'SingDuetP3RText');
-      ThemeLoadPosition(Sing.StaticDuetP3RScoreBG, 'SingDuetP3RStatic2');
-      ThemeLoadText(Sing.TextDuetP3RScore, 'SingDuetP3RTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticDuetP3RAvatar, 'SingDuetP3RAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Duet3PP3, 'DuetP3R');
 
       ThemeLoadPosition(Sing.StaticDuetP1ThreePSingBar, 'SingDuetP1ThreePSingBar');
       ThemeLoadPosition(Sing.StaticDuetP2MSingBar, 'SingDuetP2MSingBar');
-      ThemeLoadPosition(Sing.StaticDuetP3RSingBar, 'SingDuetP3RSingBar');
 
       //4P/6P mode in 1 Screen
       ThemeLoadSingPlayerStatics(Sing.Solo4PP1, 'P1FourP');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -576,13 +576,7 @@ type
 
     Duet6PP1: TThemeSingPlayer;
     Duet6PP2: TThemeSingPlayer;
-
-    StaticP3DuetSixPSingBar: TThemePosition;
-    StaticP3DuetSixP:        TThemeStatic;
-    StaticP3DuetSixPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP3DuetSixPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP3DuetSixP:          TThemeText;
-    TextP3DuetSixPScore:     TThemeText;
+    Duet6PP3: TThemeSingPlayer;
 
     StaticP4DuetSixPSingBar: TThemePosition;
     StaticP4DuetSixP:        TThemeStatic;
@@ -2048,13 +2042,7 @@ begin
 
       ThemeLoadSingPlayerStatics(Sing.Duet6PP1, 'P1DuetSixP');
       ThemeLoadSingPlayerStatics(Sing.Duet6PP2, 'P2DuetSixP');
-
-      ThemeLoadPosition(Sing.StaticP3DuetSixPSingBar, 'SingP3DuetSixPSingBar');
-      ThemeLoadStatic(Sing.StaticP3DuetSixP, 'SingP3DuetSixPStatic');
-      ThemeLoadText(Sing.TextP3DuetSixP, 'SingP3DuetSixPText');
-      ThemeLoadPosition(Sing.StaticP3DuetSixPScoreBG, 'SingP3DuetSixPStatic2');
-      ThemeLoadText(Sing.TextP3DuetSixPScore, 'SingP3DuetSixPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP3DuetSixPAvatar, 'SingP3DuetSixPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Duet6PP3, 'P3DuetSixP');
 
       ThemeLoadPosition(Sing.StaticP4DuetSixPSingBar, 'SingP4DuetSixPSingBar');
       ThemeLoadStatic(Sing.StaticP4DuetSixP, 'SingP4DuetSixPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -578,13 +578,7 @@ type
     Duet6PP2: TThemeSingPlayer;
     Duet6PP3: TThemeSingPlayer;
     Duet6PP4: TThemeSingPlayer;
-
-    StaticP5DuetSixPSingBar: TThemePosition;
-    StaticP5DuetSixP:        TThemeStatic;
-    StaticP5DuetSixPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP5DuetSixPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP5DuetSixP:          TThemeText;
-    TextP5DuetSixPScore:     TThemeText;
+    Duet6PP5: TThemeSingPlayer;
 
     StaticP6DuetSixPSingBar: TThemePosition;
     StaticP6DuetSixP:        TThemeStatic;
@@ -2038,13 +2032,7 @@ begin
       ThemeLoadSingPlayerStatics(Sing.Duet6PP2, 'P2DuetSixP');
       ThemeLoadSingPlayerStatics(Sing.Duet6PP3, 'P3DuetSixP');
       ThemeLoadSingPlayerStatics(Sing.Duet6PP4, 'P4DuetSixP');
-
-      ThemeLoadPosition(Sing.StaticP5DuetSixPSingBar, 'SingP5DuetSixPSingBar');
-      ThemeLoadStatic(Sing.StaticP5DuetSixP, 'SingP5DuetSixPStatic');
-      ThemeLoadText(Sing.TextP5DuetSixP, 'SingP5DuetSixPText');
-      ThemeLoadPosition(Sing.StaticP5DuetSixPScoreBG, 'SingP5DuetSixPStatic2');
-      ThemeLoadText(Sing.TextP5DuetSixPScore, 'SingP5DuetSixPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP5DuetSixPAvatar, 'SingP5DuetSixPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Duet6PP5, 'P5DuetSixP');
 
       ThemeLoadPosition(Sing.StaticP6DuetSixPSingBar, 'SingP6DuetSixPSingBar');
       ThemeLoadStatic(Sing.StaticP6DuetSixP, 'SingP6DuetSixPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -557,13 +557,7 @@ type
 
     //game in 4/6 player modi in 1 Screen
     Solo4PP1: TThemeSingPlayer;
-
-    StaticP2FourPSingBar: TThemePosition;
-    StaticP2FourP:        TThemeStatic;
-    StaticP2FourPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP2FourPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP2FourP:          TThemeText;
-    TextP2FourPScore:     TThemeText;
+    Solo4PP2: TThemeSingPlayer;
 
     StaticP3FourPSingBar: TThemePosition;
     StaticP3FourP:        TThemeStatic;
@@ -2116,13 +2110,7 @@ begin
 
       //4P/6P mode in 1 Screen
       ThemeLoadSingPlayerStatics(Sing.Solo4PP1, 'P1FourP');
-
-      ThemeLoadPosition(Sing.StaticP2FourPSingBar, 'SingP2FourPSingBar');
-      ThemeLoadStatic(Sing.StaticP2FourP, 'SingP2FourPStatic');
-      ThemeLoadText(Sing.TextP2FourP, 'SingP2FourPText');
-      ThemeLoadPosition(Sing.StaticP2FourPScoreBG, 'SingP2FourPStatic2');
-      ThemeLoadText(Sing.TextP2FourPScore, 'SingP2FourPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP2FourPAvatar, 'SingP2FourPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Solo4PP2, 'P2FourP');
 
       ThemeLoadPosition(Sing.StaticP3FourPSingBar, 'SingP3FourPSingBar');
       ThemeLoadStatic(Sing.StaticP3FourP, 'SingP3FourPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -493,7 +493,6 @@ type
 
     //moveable singbar mod
     StaticP1SingBar:       TThemePosition;
-    StaticP1ThreePSingBar: TThemePosition;
     StaticP1TwoPSingBar:   TThemePosition;
     //eoa moveable singbar
 
@@ -504,16 +503,11 @@ type
     StaticP1TwoPScoreBG:  TThemePosition; //Static for ScoreBG
     TextP1TwoP:           TThemeText;
     TextP1TwoPScore:      TThemeText;
-    //game in 3/6 player modi
-    StaticP1ThreeP:         TThemeStatic;
-    StaticP1ThreePAvatar:   TThemeStaticAlphaRectangle;
-    StaticP1ThreePScoreBG:  TThemePosition; //Static for ScoreBG
-    TextP1ThreeP:           TThemeText;
-    TextP1ThreePScore:      TThemeText;
     //eoa
 
     Solo2PP2: TThemeSingPlayer;
 
+    Solo3PP1: TThemeSingPlayer;
     Solo3PP2: TThemeSingPlayer;
     Solo3PP3: TThemeSingPlayer;
 
@@ -1873,7 +1867,6 @@ begin
       //moveable singbar mod
       ThemeLoadPosition(Sing.StaticP1SingBar, 'SingP1SingBar');
       ThemeLoadPosition(Sing.StaticP1TwoPSingBar, 'SingP1TwoPSingBar');
-      ThemeLoadPosition(Sing.StaticP1ThreePSingBar, 'SingP1ThreePSingBar');
     //eoa moveable singbar
 
       ThemeLoadStatic(Sing.StaticP1, 'SingP1Static');
@@ -1888,14 +1881,9 @@ begin
       ThemeLoadPosition(Sing.StaticP1TwoPScoreBG, 'SingP1TwoPStatic2');
       ThemeLoadText(Sing.TextP1TwoPScore, 'SingP1TwoPTextScore');
 
-      ThemeLoadStatic(Sing.StaticP1ThreeP, 'SingP1ThreePStatic');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP1ThreePAvatar, 'SingP1ThreePAvatar');
-      ThemeLoadText(Sing.TextP1ThreeP, 'SingP1ThreePText');
-      ThemeLoadPosition(Sing.StaticP1ThreePScoreBG, 'SingP1ThreePStatic2');
-      ThemeLoadText(Sing.TextP1ThreePScore, 'SingP1ThreePTextScore');
-
       ThemeLoadSingPlayerStatics(Sing.Solo2PP2, 'P2R');
 
+      ThemeLoadSingPlayerStatics(Sing.Solo3PP1, 'P1ThreeP');
       ThemeLoadSingPlayerStatics(Sing.Solo3PP2, 'P2M');
       // TODO: we have to load Solo3PP3 manually because the SingBar uses a different name
       ThemeLoadText(Sing.Solo3PP3.Name, 'SingP3RText');
@@ -3895,7 +3883,6 @@ begin
   //moveable singbar mod
   ThemeSavePosition(Sing.StaticP1SingBar, 'SingP1SingBar');
   ThemeSavePosition(Sing.StaticP1TwoPSingBar, 'SingP1TwoPSingBar');
-  ThemeSavePosition(Sing.StaticP1ThreePSingBar, 'SingP1ThreePSingBar');
   //eoa moveable singbar
 
   //Added for ps3 skin
@@ -3906,10 +3893,11 @@ begin
   ThemeSaveText(Sing.TextP1TwoPScore, 'SingP1TwoPTextScore');
 
   //This one is shown in 3/6P mode
-  ThemeSaveStatic(Sing.StaticP1ThreeP, 'SingP1ThreePStatic');
-  ThemeSaveText(Sing.TextP1ThreeP, 'SingP1ThreePText');
-  ThemeSavePosition(Sing.StaticP1ThreePScoreBG, 'SingP1ThreePStatic2');
-  ThemeSaveText(Sing.TextP1ThreePScore, 'SingP1ThreePTextScore');
+  ThemeSaveText(Sing.Solo3PP1.Name, 'SingP1ThreePText');
+  ThemeSaveText(Sing.Solo3PP1.Score, 'SingP1ThreePTextScore');
+  ThemeSavePosition(Sing.Solo3PP1.ScoreBackground, 'SingP1ThreePStatic2');
+  ThemeSaveStatic(Sing.Solo3PP1.AvatarFrame, 'SingP1ThreePStatic');
+  ThemeSavePosition(Sing.Solo3PP1.SingBar, 'SingP1ThreePSingBar');
   //eoa
 
   ThemeSaveText(Sing.Solo2PP2.Name, 'SingP2RText');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -577,13 +577,7 @@ type
     Duet6PP1: TThemeSingPlayer;
     Duet6PP2: TThemeSingPlayer;
     Duet6PP3: TThemeSingPlayer;
-
-    StaticP4DuetSixPSingBar: TThemePosition;
-    StaticP4DuetSixP:        TThemeStatic;
-    StaticP4DuetSixPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP4DuetSixPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP4DuetSixP:          TThemeText;
-    TextP4DuetSixPScore:     TThemeText;
+    Duet6PP4: TThemeSingPlayer;
 
     StaticP5DuetSixPSingBar: TThemePosition;
     StaticP5DuetSixP:        TThemeStatic;
@@ -2043,13 +2037,7 @@ begin
       ThemeLoadSingPlayerStatics(Sing.Duet6PP1, 'P1DuetSixP');
       ThemeLoadSingPlayerStatics(Sing.Duet6PP2, 'P2DuetSixP');
       ThemeLoadSingPlayerStatics(Sing.Duet6PP3, 'P3DuetSixP');
-
-      ThemeLoadPosition(Sing.StaticP4DuetSixPSingBar, 'SingP4DuetSixPSingBar');
-      ThemeLoadStatic(Sing.StaticP4DuetSixP, 'SingP4DuetSixPStatic');
-      ThemeLoadText(Sing.TextP4DuetSixP, 'SingP4DuetSixPText');
-      ThemeLoadPosition(Sing.StaticP4DuetSixPScoreBG, 'SingP4DuetSixPStatic2');
-      ThemeLoadText(Sing.TextP4DuetSixPScore, 'SingP4DuetSixPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP4DuetSixPAvatar, 'SingP4DuetSixPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Duet6PP4, 'P4DuetSixP');
 
       ThemeLoadPosition(Sing.StaticP5DuetSixPSingBar, 'SingP5DuetSixPSingBar');
       ThemeLoadStatic(Sing.StaticP5DuetSixP, 'SingP5DuetSixPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -1888,25 +1888,12 @@ begin
       ThemeLoadPosition(Sing.StaticP1TwoPScoreBG, 'SingP1TwoPStatic2');
       ThemeLoadText(Sing.TextP1TwoPScore, 'SingP1TwoPTextScore');
 
-  //This one is shown in 3/6P mode
-  //if it exists, otherwise the one Player equivaltents are used
-      if (ThemeIni.SectionExists('SingP1TwoPTextScore')) then
-      begin
-        ThemeLoadStatic(Sing.StaticP1ThreeP, 'SingP1ThreePStatic');
-        ThemeLoadStaticAlphaRectangle(Sing.StaticP1ThreePAvatar, 'SingP1ThreePAvatar');
-        ThemeLoadText(Sing.TextP1ThreeP, 'SingP1ThreePText');
-        ThemeLoadPosition(Sing.StaticP1ThreePScoreBG, 'SingP1ThreePStatic2');
-        ThemeLoadText(Sing.TextP1ThreePScore, 'SingP1ThreePTextScore');
-      end
-      else
-      begin
-        Sing.StaticP1ThreeP := Sing.StaticP1;
-        Sing.StaticP1ThreePAvatar := Sing.StaticP1Avatar;
-        Sing.TextP1ThreeP := Sing.TextP1;
-        Sing.StaticP1ThreePScoreBG := Sing.StaticP1ScoreBG;
-        Sing.TextP1ThreePScore := Sing.TextP1Score;
-      end;
-  //eoa
+      ThemeLoadStatic(Sing.StaticP1ThreeP, 'SingP1ThreePStatic');
+      ThemeLoadStaticAlphaRectangle(Sing.StaticP1ThreePAvatar, 'SingP1ThreePAvatar');
+      ThemeLoadText(Sing.TextP1ThreeP, 'SingP1ThreePText');
+      ThemeLoadPosition(Sing.StaticP1ThreePScoreBG, 'SingP1ThreePStatic2');
+      ThemeLoadText(Sing.TextP1ThreePScore, 'SingP1ThreePTextScore');
+
       ThemeLoadSingPlayerStatics(Sing.Solo2PP2, 'P2R');
 
       ThemeLoadSingPlayerStatics(Sing.Solo3PP2, 'P2M');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -572,13 +572,7 @@ type
     Duet4PP1: TThemeSingPlayer;
     Duet4PP2: TThemeSingPlayer;
     Duet4PP3: TThemeSingPlayer;
-
-    StaticP4DuetFourPSingBar: TThemePosition;
-    StaticP4DuetFourP:        TThemeStatic;
-    StaticP4DuetFourPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP4DuetFourPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP4DuetFourP:          TThemeText;
-    TextP4DuetFourPScore:     TThemeText;
+    Duet4PP4: TThemeSingPlayer;
 
     StaticP1DuetSixPSingBar: TThemePosition;
     StaticP1DuetSixP:        TThemeStatic;
@@ -2061,13 +2055,7 @@ begin
       ThemeLoadSingPlayerStatics(Sing.Duet4PP1, 'P1DuetFourP');
       ThemeLoadSingPlayerStatics(Sing.Duet4PP2, 'P2DuetFourP');
       ThemeLoadSingPlayerStatics(Sing.Duet4PP3, 'P3DuetFourP');
-
-      ThemeLoadPosition(Sing.StaticP4DuetFourPSingBar, 'SingP4DuetFourPSingBar');
-      ThemeLoadStatic(Sing.StaticP4DuetFourP, 'SingP4DuetFourPStatic');
-      ThemeLoadText(Sing.TextP4DuetFourP, 'SingP4DuetFourPText');
-      ThemeLoadPosition(Sing.StaticP4DuetFourPScoreBG, 'SingP4DuetFourPStatic2');
-      ThemeLoadText(Sing.TextP4DuetFourPScore, 'SingP4DuetFourPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP4DuetFourPAvatar, 'SingP4DuetFourPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Duet4PP4, 'P4DuetFourP');
 
 
       ThemeLoadPosition(Sing.StaticP1DuetSixPSingBar, 'SingP1DuetSixPSingBar');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -565,13 +565,7 @@ type
     Solo6PP2: TThemeSingPlayer;
     Solo6PP3: TThemeSingPlayer;
     Solo6PP4: TThemeSingPlayer;
-
-    StaticP5SixPSingBar: TThemePosition;
-    StaticP5SixP:        TThemeStatic;
-    StaticP5SixPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP5SixPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP5SixP:          TThemeText;
-    TextP5SixPScore:     TThemeText;
+    Solo6PP5: TThemeSingPlayer;
 
     StaticP6SixPSingBar: TThemePosition;
     StaticP6SixP:        TThemeStatic;
@@ -2083,13 +2077,7 @@ begin
       ThemeLoadSingPlayerStatics(Sing.Solo6PP2, 'P2SixP');
       ThemeLoadSingPlayerStatics(Sing.Solo6PP3, 'P3SixP');
       ThemeLoadSingPlayerStatics(Sing.Solo6PP4, 'P4SixP');
-
-      ThemeLoadPosition(Sing.StaticP5SixPSingBar, 'SingP5SixPSingBar');
-      ThemeLoadStatic(Sing.StaticP5SixP, 'SingP5SixPStatic');
-      ThemeLoadText(Sing.TextP5SixP, 'SingP5SixPText');
-      ThemeLoadPosition(Sing.StaticP5SixPScoreBG, 'SingP5SixPStatic2');
-      ThemeLoadText(Sing.TextP5SixPScore, 'SingP5SixPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP5SixPAvatar, 'SingP5SixPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Solo6PP5, 'P5SixP');
 
       ThemeLoadPosition(Sing.StaticP6SixPSingBar, 'SingP6SixPSingBar');
       ThemeLoadStatic(Sing.StaticP6SixP, 'SingP6SixPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -561,12 +561,7 @@ type
     Solo4PP3: TThemeSingPlayer;
     Solo4PP4: TThemeSingPlayer;
 
-    StaticP1SixPSingBar: TThemePosition;
-    StaticP1SixP:        TThemeStatic;
-    StaticP1SixPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP1SixPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP1SixP:          TThemeText;
-    TextP1SixPScore:     TThemeText;
+    Solo6PP1: TThemeSingPlayer;
 
     StaticP2SixPSingBar: TThemePosition;
     StaticP2SixP:        TThemeStatic;
@@ -2102,12 +2097,7 @@ begin
       ThemeLoadSingPlayerStatics(Sing.Solo4PP3, 'P3FourP');
       ThemeLoadSingPlayerStatics(Sing.Solo4PP4, 'P4FourP');
 
-      ThemeLoadPosition(Sing.StaticP1SixPSingBar, 'SingP1SixPSingBar');
-      ThemeLoadStatic(Sing.StaticP1SixP, 'SingP1SixPStatic');
-      ThemeLoadText(Sing.TextP1SixP, 'SingP1SixPText');
-      ThemeLoadPosition(Sing.StaticP1SixPScoreBG, 'SingP1SixPStatic2');
-      ThemeLoadText(Sing.TextP1SixPScore, 'SingP1SixPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP1SixPAvatar, 'SingP1SixPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Solo6PP1, 'P1SixP');
 
       ThemeLoadPosition(Sing.StaticP2SixPSingBar, 'SingP2SixPSingBar');
       ThemeLoadStatic(Sing.StaticP2SixP, 'SingP2SixPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -493,18 +493,9 @@ type
 
     //moveable singbar mod
     StaticP1SingBar:       TThemePosition;
-    StaticP1TwoPSingBar:   TThemePosition;
     //eoa moveable singbar
 
-    //added for ps3 skin
-    //game in 2/4 player modi
-    StaticP1TwoP:         TThemeStatic;
-    StaticP1TwoPAvatar:   TThemeStaticAlphaRectangle;
-    StaticP1TwoPScoreBG:  TThemePosition; //Static for ScoreBG
-    TextP1TwoP:           TThemeText;
-    TextP1TwoPScore:      TThemeText;
-    //eoa
-
+    Solo2PP1: TThemeSingPlayer;
     Solo2PP2: TThemeSingPlayer;
 
     Solo3PP1: TThemeSingPlayer;
@@ -1866,7 +1857,6 @@ begin
 
       //moveable singbar mod
       ThemeLoadPosition(Sing.StaticP1SingBar, 'SingP1SingBar');
-      ThemeLoadPosition(Sing.StaticP1TwoPSingBar, 'SingP1TwoPSingBar');
     //eoa moveable singbar
 
       ThemeLoadStatic(Sing.StaticP1, 'SingP1Static');
@@ -1875,12 +1865,7 @@ begin
       ThemeLoadText(Sing.TextP1Score, 'SingP1TextScore');
       ThemeLoadStaticAlphaRectangle(Sing.StaticP1Avatar, 'SingP1Avatar');
 
-      ThemeLoadStatic(Sing.StaticP1TwoP, 'SingP1TwoPStatic');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP1TwoPAvatar, 'SingP1TwoPAvatar');
-      ThemeLoadText(Sing.TextP1TwoP, 'SingP1TwoPText');
-      ThemeLoadPosition(Sing.StaticP1TwoPScoreBG, 'SingP1TwoPStatic2');
-      ThemeLoadText(Sing.TextP1TwoPScore, 'SingP1TwoPTextScore');
-
+      ThemeLoadSingPlayerStatics(Sing.Solo2PP1, 'P1TwoP');
       ThemeLoadSingPlayerStatics(Sing.Solo2PP2, 'P2R');
 
       ThemeLoadSingPlayerStatics(Sing.Solo3PP1, 'P1ThreeP');
@@ -3882,15 +3867,15 @@ begin
 
   //moveable singbar mod
   ThemeSavePosition(Sing.StaticP1SingBar, 'SingP1SingBar');
-  ThemeSavePosition(Sing.StaticP1TwoPSingBar, 'SingP1TwoPSingBar');
   //eoa moveable singbar
 
   //Added for ps3 skin
   //This one is shown in 2/4P mode
-  ThemeSaveStatic(Sing.StaticP1TwoP, 'SingP1TwoPStatic');
-  ThemeSaveText(Sing.TextP1TwoP, 'SingP1TwoPText');
-  ThemeSavePosition(Sing.StaticP1TwoPScoreBG, 'SingP1TwoPStatic2');
-  ThemeSaveText(Sing.TextP1TwoPScore, 'SingP1TwoPTextScore');
+  ThemeSaveText(Sing.Solo2PP1.Name, 'SingP1TwoPText');
+  ThemeSaveText(Sing.Solo2PP1.Score, 'SingP1TwoPTextScore');
+  ThemeSavePosition(Sing.Solo2PP1.ScoreBackground, 'SingP1TwoPStatic2');
+  ThemeSaveStatic(Sing.Solo2PP1.AvatarFrame, 'SingP1TwoPStatic');
+  ThemeSavePosition(Sing.Solo2PP1.SingBar, 'SingP1TwoPSingBar');
 
   //This one is shown in 3/6P mode
   ThemeSaveText(Sing.Solo3PP1.Name, 'SingP1ThreePText');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -562,13 +562,7 @@ type
     Solo4PP4: TThemeSingPlayer;
 
     Solo6PP1: TThemeSingPlayer;
-
-    StaticP2SixPSingBar: TThemePosition;
-    StaticP2SixP:        TThemeStatic;
-    StaticP2SixPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP2SixPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP2SixP:          TThemeText;
-    TextP2SixPScore:     TThemeText;
+    Solo6PP2: TThemeSingPlayer;
 
     StaticP3SixPSingBar: TThemePosition;
     StaticP3SixP:        TThemeStatic;
@@ -2098,13 +2092,7 @@ begin
       ThemeLoadSingPlayerStatics(Sing.Solo4PP4, 'P4FourP');
 
       ThemeLoadSingPlayerStatics(Sing.Solo6PP1, 'P1SixP');
-
-      ThemeLoadPosition(Sing.StaticP2SixPSingBar, 'SingP2SixPSingBar');
-      ThemeLoadStatic(Sing.StaticP2SixP, 'SingP2SixPStatic');
-      ThemeLoadText(Sing.TextP2SixP, 'SingP2SixPText');
-      ThemeLoadPosition(Sing.StaticP2SixPScoreBG, 'SingP2SixPStatic2');
-      ThemeLoadText(Sing.TextP2SixPScore, 'SingP2SixPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP2SixPAvatar, 'SingP2SixPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Solo6PP2, 'P2SixP');
 
       ThemeLoadPosition(Sing.StaticP3SixPSingBar, 'SingP3SixPSingBar');
       ThemeLoadStatic(Sing.StaticP3SixP, 'SingP3SixPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -558,13 +558,7 @@ type
     //game in 4/6 player modi in 1 Screen
     Solo4PP1: TThemeSingPlayer;
     Solo4PP2: TThemeSingPlayer;
-
-    StaticP3FourPSingBar: TThemePosition;
-    StaticP3FourP:        TThemeStatic;
-    StaticP3FourPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP3FourPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP3FourP:          TThemeText;
-    TextP3FourPScore:     TThemeText;
+    Solo4PP3: TThemeSingPlayer;
 
     StaticP4FourPSingBar: TThemePosition;
     StaticP4FourP:        TThemeStatic;
@@ -2111,13 +2105,7 @@ begin
       //4P/6P mode in 1 Screen
       ThemeLoadSingPlayerStatics(Sing.Solo4PP1, 'P1FourP');
       ThemeLoadSingPlayerStatics(Sing.Solo4PP2, 'P2FourP');
-
-      ThemeLoadPosition(Sing.StaticP3FourPSingBar, 'SingP3FourPSingBar');
-      ThemeLoadStatic(Sing.StaticP3FourP, 'SingP3FourPStatic');
-      ThemeLoadText(Sing.TextP3FourP, 'SingP3FourPText');
-      ThemeLoadPosition(Sing.StaticP3FourPScoreBG, 'SingP3FourPStatic2');
-      ThemeLoadText(Sing.TextP3FourPScore, 'SingP3FourPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP3FourPAvatar, 'SingP3FourPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Solo4PP3, 'P3FourP');
 
       ThemeLoadPosition(Sing.StaticP4FourPSingBar, 'SingP4FourPSingBar');
       ThemeLoadStatic(Sing.StaticP4FourP, 'SingP4FourPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -569,12 +569,7 @@ type
     Solo6PP6: TThemeSingPlayer;
 
     // duet 4/6 players in one screen
-    StaticP1DuetFourPSingBar: TThemePosition;
-    StaticP1DuetFourP:        TThemeStatic;
-    StaticP1DuetFourPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP1DuetFourPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP1DuetFourP:          TThemeText;
-    TextP1DuetFourPScore:     TThemeText;
+    Duet4PP1: TThemeSingPlayer;
 
     StaticP2DuetFourPSingBar: TThemePosition;
     StaticP2DuetFourP:        TThemeStatic;
@@ -2075,12 +2070,7 @@ begin
       ThemeLoadSingPlayerStatics(Sing.Solo6PP6, 'P6SixP');
 
       // duet 4/6 players in one screen
-      ThemeLoadPosition(Sing.StaticP1DuetFourPSingBar, 'SingP1DuetFourPSingBar');
-      ThemeLoadStatic(Sing.StaticP1DuetFourP, 'SingP1DuetFourPStatic');
-      ThemeLoadText(Sing.TextP1DuetFourP, 'SingP1DuetFourPText');
-      ThemeLoadPosition(Sing.StaticP1DuetFourPScoreBG, 'SingP1DuetFourPStatic2');
-      ThemeLoadText(Sing.TextP1DuetFourPScore, 'SingP1DuetFourPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP1DuetFourPAvatar, 'SingP1DuetFourPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Duet4PP1, 'P1DuetFourP');
 
       ThemeLoadPosition(Sing.StaticP2DuetFourPSingBar, 'SingP2DuetFourPSingBar');
       ThemeLoadStatic(Sing.StaticP2DuetFourP, 'SingP2DuetFourPStatic');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -533,16 +533,9 @@ type
     TextP3R:          TThemeText;
     TextP3RScore:     TThemeText;
 
-    StaticDuetP1ThreeP:        TThemeStatic;
-    StaticDuetP1ThreePAvatar:  TThemeStaticAlphaRectangle;
-    TextDuetP1ThreeP:          TThemeText;
-    StaticDuetP1ThreePScoreBG: TThemePosition;
-    TextDuetP1ThreePScore:     TThemeText;
-
+    Duet3PP1: TThemeSingPlayer;
     Duet3PP2: TThemeSingPlayer;
     Duet3PP3: TThemeSingPlayer;
-
-    StaticDuetP1ThreePSingBar: TThemePosition;
 
     //game in 4/6 player modi in 1 Screen
     Solo4PP1: TThemeSingPlayer;
@@ -1970,16 +1963,9 @@ begin
       ThemeLoadText(Sing.TextSongName, 'SingSongNameText');
 
       // 3/6 players duet
-      ThemeLoadStatic(Sing.StaticDuetP1ThreeP, 'SingDuetP1ThreePStatic');
-      ThemeLoadText(Sing.TextDuetP1ThreeP, 'SingDuetP1ThreePText');
-      ThemeLoadPosition(Sing.StaticDuetP1ThreePScoreBG, 'SingDuetP1ThreePStatic2');
-      ThemeLoadText(Sing.TextDuetP1ThreePScore, 'SingDuetP1ThreePTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticDuetP1ThreePAvatar, 'SingDuetP1ThreePAvatar');
-
+      ThemeLoadSingPlayerStatics(Sing.Duet3PP1, 'DuetP1ThreeP');
       ThemeLoadSingPlayerStatics(Sing.Duet3PP2, 'DuetP2M');
       ThemeLoadSingPlayerStatics(Sing.Duet3PP3, 'DuetP3R');
-
-      ThemeLoadPosition(Sing.StaticDuetP1ThreePSingBar, 'SingDuetP1ThreePSingBar');
 
       //4P/6P mode in 1 Screen
       ThemeLoadSingPlayerStatics(Sing.Solo4PP1, 'P1FourP');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -278,6 +278,15 @@ type
     H: integer;
   end;
 
+  TThemeSingPlayer = record
+    Name: TThemeText;
+    Score: TThemeText;
+    ScoreBackground: TThemePosition;
+    AvatarFrame: TThemeStatic; // TODO: is this actually the frame?
+    Avatar: TThemeStaticAlphaRectangle;
+    SingBar: TThemePosition;
+  end;
+
   TThemeLoading = class(TThemeBasic)
     StaticAnimation:  TThemeStatic;
     TextLoading:      TThemeText;
@@ -1512,6 +1521,7 @@ type
     procedure ThemeLoadStaticRectangle(var ThemeStaticRectangle: TThemeStaticRectangle; const Name: string);
     procedure ThemeLoadStaticAlphaRectangle(var static: TThemeStaticAlphaRectangle; const Name: string);
     procedure ThemeLoadStaticColorRectangle(var ThemeStaticColorRectangle: TThemeStaticColorRectangle; const Name: string);
+    procedure ThemeLoadSingPlayerStatics(var ThemeSingPlayer: TThemeSingPlayer; const Name: string);
 
     procedure ThemeLoadButton(var ThemeButton: TThemeButton; const Name: string; Collections: PAThemeButtonCollection = nil);
     procedure ThemeLoadButtonCollection(var Collection: TThemeButtonCollection; const Name: string);
@@ -3282,6 +3292,16 @@ begin
   ThemePosition.Y := ThemeIni.ReadInteger(Name, 'Y', 0);
   ThemePosition.H := ThemeIni.ReadInteger(Name, 'H', 0);
   ThemePosition.W := ThemeIni.ReadInteger(Name, 'W', 0);
+end;
+
+procedure TTheme.ThemeLoadSingPlayerStatics(var ThemeSingPlayer: TThemeSingPlayer; const Name: string);
+begin
+  ThemeLoadText(ThemeSingPlayer.Name, 'Sing' + Name + 'Text');
+  ThemeLoadText(ThemeSingPlayer.Score, 'Sing' + Name + 'TextScore');
+  ThemeLoadPosition(ThemeSingPlayer.ScoreBackground, 'Sing' + Name + 'Static2');
+  ThemeLoadStatic(ThemeSingPlayer.AvatarFrame, 'Sing' + Name + 'Static');
+  ThemeLoadStaticAlphaRectangle(ThemeSingPlayer.Avatar, 'Sing' + Name + 'Avatar');
+  ThemeLoadPosition(ThemeSingPlayer.SingBar, 'Sing' + Name + 'SingBar');
 end;
 
 procedure TTheme.LoadColors;

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -566,13 +566,7 @@ type
     Solo6PP3: TThemeSingPlayer;
     Solo6PP4: TThemeSingPlayer;
     Solo6PP5: TThemeSingPlayer;
-
-    StaticP6SixPSingBar: TThemePosition;
-    StaticP6SixP:        TThemeStatic;
-    StaticP6SixPAvatar:  TThemeStaticAlphaRectangle;
-    StaticP6SixPScoreBG: TThemePosition; //Static for ScoreBG
-    TextP6SixP:          TThemeText;
-    TextP6SixPScore:     TThemeText;
+    Solo6PP6: TThemeSingPlayer;
 
     // duet 4/6 players in one screen
     StaticP1DuetFourPSingBar: TThemePosition;
@@ -2078,13 +2072,7 @@ begin
       ThemeLoadSingPlayerStatics(Sing.Solo6PP3, 'P3SixP');
       ThemeLoadSingPlayerStatics(Sing.Solo6PP4, 'P4SixP');
       ThemeLoadSingPlayerStatics(Sing.Solo6PP5, 'P5SixP');
-
-      ThemeLoadPosition(Sing.StaticP6SixPSingBar, 'SingP6SixPSingBar');
-      ThemeLoadStatic(Sing.StaticP6SixP, 'SingP6SixPStatic');
-      ThemeLoadText(Sing.TextP6SixP, 'SingP6SixPText');
-      ThemeLoadPosition(Sing.StaticP6SixPScoreBG, 'SingP6SixPStatic2');
-      ThemeLoadText(Sing.TextP6SixPScore, 'SingP6SixPTextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP6SixPAvatar, 'SingP6SixPAvatar');
+      ThemeLoadSingPlayerStatics(Sing.Solo6PP6, 'P6SixP');
 
       // duet 4/6 players in one screen
       ThemeLoadPosition(Sing.StaticP1DuetFourPSingBar, 'SingP1DuetFourPSingBar');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -485,15 +485,7 @@ type
     TextTimeText:          TThemeText;
     //eoa TimeBar mod
 
-    StaticP1:              TThemeStatic;
-    TextP1:                TThemeText;
-    StaticP1ScoreBG:       TThemePosition; //Static for ScoreBG
-    TextP1Score:           TThemeText;
-    StaticP1Avatar:        TThemeStaticAlphaRectangle;
-
-    //moveable singbar mod
-    StaticP1SingBar:       TThemePosition;
-    //eoa moveable singbar
+    Solo1PP1: TThemeSingPlayer;
 
     Solo2PP1: TThemeSingPlayer;
     Solo2PP2: TThemeSingPlayer;
@@ -1855,15 +1847,7 @@ begin
       ThemeLoadText (Sing.InfoMessageText, 'SingInfoMessageText');
       ThemeLoadStatic (Sing.InfoMessageBG, 'SingInfoMessageBG');
 
-      //moveable singbar mod
-      ThemeLoadPosition(Sing.StaticP1SingBar, 'SingP1SingBar');
-    //eoa moveable singbar
-
-      ThemeLoadStatic(Sing.StaticP1, 'SingP1Static');
-      ThemeLoadText(Sing.TextP1, 'SingP1Text');
-      ThemeLoadPosition(Sing.StaticP1ScoreBG, 'SingP1Static2');
-      ThemeLoadText(Sing.TextP1Score, 'SingP1TextScore');
-      ThemeLoadStaticAlphaRectangle(Sing.StaticP1Avatar, 'SingP1Avatar');
+      ThemeLoadSingPlayerStatics(Sing.Solo1PP1, 'P1');
 
       ThemeLoadSingPlayerStatics(Sing.Solo2PP1, 'P1TwoP');
       ThemeLoadSingPlayerStatics(Sing.Solo2PP2, 'P2R');
@@ -3860,14 +3844,11 @@ begin
   ThemeSaveText(Sing.TextTimeText, 'SingTimeText');
   //eoa TimeBar mod
 
-  ThemeSaveStatic(Sing.StaticP1, 'SingP1Static');
-  ThemeSaveText(Sing.TextP1, 'SingP1Text');
-  ThemeSavePosition(Sing.StaticP1ScoreBG, 'SingP1Static2');
-  ThemeSaveText(Sing.TextP1Score, 'SingP1TextScore');
-
-  //moveable singbar mod
-  ThemeSavePosition(Sing.StaticP1SingBar, 'SingP1SingBar');
-  //eoa moveable singbar
+  ThemeSaveText(Sing.Solo1PP1.Name, 'SingP1Text');
+  ThemeSaveText(Sing.Solo1PP1.Score, 'SingP1TextScore');
+  ThemeSavePosition(Sing.Solo1PP1.ScoreBackground, 'SingP1Static2');
+  ThemeSaveStatic(Sing.Solo1PP1.AvatarFrame, 'SingP1Static');
+  ThemeSavePosition(Sing.Solo1PP1.SingBar, 'SingP1SingBar');
 
   //Added for ps3 skin
   //This one is shown in 2/4P mode

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -285,6 +285,7 @@ type
     AvatarFrame: TThemeStatic; // TODO: is this actually the frame?
     Avatar: TThemeStaticAlphaRectangle;
     SingBar: TThemePosition;
+    Oscilloscope: TThemePosition;
   end;
 
   TThemeLoading = class(TThemeBasic)
@@ -523,36 +524,6 @@ type
     Duet6PP4: TThemeSingPlayer;
     Duet6PP5: TThemeSingPlayer;
     Duet6PP6: TThemeSingPlayer;
-
-    SingP1Oscilloscope:           TThemePosition;
-    SingP1TwoPOscilloscope:       TThemePosition;
-    SingP2ROscilloscope:          TThemePosition;
-    SingP1ThreePOscilloscope:     TThemePosition;
-    SingP2MOscilloscope:          TThemePosition;
-    SingP3ROscilloscope:          TThemePosition;
-    SingDuetP1ThreePOscilloscope: TThemePosition;
-    SingDuetP2MOscilloscope:      TThemePosition;
-    SingDuetP3ROscilloscope:      TThemePosition;
-    SingP1FourPOscilloscope:      TThemePosition;
-    SingP2FourPOscilloscope:      TThemePosition;
-    SingP3FourPOscilloscope:      TThemePosition;
-    SingP4FourPOscilloscope:      TThemePosition;
-    SingP1SixPOscilloscope:       TThemePosition;
-    SingP2SixPOscilloscope:       TThemePosition;
-    SingP3SixPOscilloscope:       TThemePosition;
-    SingP4SixPOscilloscope:       TThemePosition;
-    SingP5SixPOscilloscope:       TThemePosition;
-    SingP6SixPOscilloscope:       TThemePosition;
-    SingP1DuetFourPOscilloscope:  TThemePosition;
-    SingP2DuetFourPOscilloscope:  TThemePosition;
-    SingP3DuetFourPOscilloscope:  TThemePosition;
-    SingP4DuetFourPOscilloscope:  TThemePosition;
-    SingP1DuetSixPOscilloscope:   TThemePosition;
-    SingP2DuetSixPOscilloscope:   TThemePosition;
-    SingP3DuetSixPOscilloscope:   TThemePosition;
-    SingP4DuetSixPOscilloscope:   TThemePosition;
-    SingP5DuetSixPOscilloscope:   TThemePosition;
-    SingP6DuetSixPOscilloscope:   TThemePosition;
 
     StaticSongName:   TThemeStatic;
     TextSongName:     TThemeText;
@@ -1862,6 +1833,7 @@ begin
       ThemeLoadStaticAlphaRectangle(Sing.Solo3PP3.Avatar, 'SingP3RAvatar');
       // TODO: SingBar uses non-consistent naming in theme
       ThemeLoadPosition(Sing.Solo3PP3.SingBar, 'SingP3SingBar');
+      ThemeLoadPosition(Sing.Solo3PP3.Oscilloscope, 'SingP3ROscilloscope');
 
       ThemeLoadStatic(Sing.StaticSongName, 'SingSongNameStatic');
       ThemeLoadText(Sing.TextSongName, 'SingSongNameText');
@@ -1896,37 +1868,6 @@ begin
       ThemeLoadSingPlayerStatics(Sing.Duet6PP4, 'P4DuetSixP');
       ThemeLoadSingPlayerStatics(Sing.Duet6PP5, 'P5DuetSixP');
       ThemeLoadSingPlayerStatics(Sing.Duet6PP6, 'P6DuetSixP');
-
-      // Oscilloscope Position
-      ThemeLoadPosition(Sing.SingP1Oscilloscope, 'SingP1Oscilloscope');
-      ThemeLoadPosition(Sing.SingP1TwoPOscilloscope, 'SingP1TwoPOscilloscope');
-      ThemeLoadPosition(Sing.SingP2ROscilloscope, 'SingP2ROscilloscope');
-      ThemeLoadPosition(Sing.SingP1ThreePOscilloscope, 'SingP1ThreePOscilloscope');
-      ThemeLoadPosition(Sing.SingP2MOscilloscope, 'SingP2MOscilloscope');
-      ThemeLoadPosition(Sing.SingP3ROscilloscope, 'SingP3ROscilloscope');
-      ThemeLoadPosition(Sing.SingDuetP1ThreePOscilloscope, 'SingDuetP1ThreePOscilloscope');
-      ThemeLoadPosition(Sing.SingDuetP2MOscilloscope, 'SingDuetP2MOscilloscope');
-      ThemeLoadPosition(Sing.SingDuetP3ROscilloscope, 'SingDuetP3ROscilloscope');
-      ThemeLoadPosition(Sing.SingP1FourPOscilloscope, 'SingP1FourPOscilloscope');
-      ThemeLoadPosition(Sing.SingP2FourPOscilloscope, 'SingP2FourPOscilloscope');
-      ThemeLoadPosition(Sing.SingP3FourPOscilloscope, 'SingP3FourPOscilloscope');
-      ThemeLoadPosition(Sing.SingP4FourPOscilloscope, 'SingP4FourPOscilloscope');
-      ThemeLoadPosition(Sing.SingP1SixPOscilloscope, 'SingP1SixPOscilloscope');
-      ThemeLoadPosition(Sing.SingP2SixPOscilloscope, 'SingP2SixPOscilloscope');
-      ThemeLoadPosition(Sing.SingP3SixPOscilloscope, 'SingP3SixPOscilloscope');
-      ThemeLoadPosition(Sing.SingP4SixPOscilloscope, 'SingP4SixPOscilloscope');
-      ThemeLoadPosition(Sing.SingP5SixPOscilloscope, 'SingP5SixPOscilloscope');
-      ThemeLoadPosition(Sing.SingP6SixPOscilloscope, 'SingP6SixPOscilloscope');
-      ThemeLoadPosition(Sing.SingP1DuetFourPOscilloscope, 'SingP1DuetFourPOscilloscope');
-      ThemeLoadPosition(Sing.SingP2DuetFourPOscilloscope, 'SingP2DuetFourPOscilloscope');
-      ThemeLoadPosition(Sing.SingP3DuetFourPOscilloscope, 'SingP3DuetFourPOscilloscope');
-      ThemeLoadPosition(Sing.SingP4DuetFourPOscilloscope, 'SingP4DuetFourPOscilloscope');
-      ThemeLoadPosition(Sing.SingP1DuetSixPOscilloscope, 'SingP1DuetSixPOscilloscope');
-      ThemeLoadPosition(Sing.SingP2DuetSixPOscilloscope, 'SingP2DuetSixPOscilloscope');
-      ThemeLoadPosition(Sing.SingP3DuetSixPOscilloscope, 'SingP3DuetSixPOscilloscope');
-      ThemeLoadPosition(Sing.SingP4DuetSixPOscilloscope, 'SingP4DuetSixPOscilloscope');
-      ThemeLoadPosition(Sing.SingP5DuetSixPOscilloscope, 'SingP5DuetSixPOscilloscope');
-      ThemeLoadPosition(Sing.SingP6DuetSixPOscilloscope, 'SingP6DuetSixPOscilloscope');
 
       //Line Bonus Texts
       Sing.LineBonusText[0] := Language.Translate('POPUP_AWFUL');
@@ -2937,6 +2878,7 @@ begin
   ThemeLoadStatic(ThemeSingPlayer.AvatarFrame, 'Sing' + Name + 'Static');
   ThemeLoadStaticAlphaRectangle(ThemeSingPlayer.Avatar, 'Sing' + Name + 'Avatar');
   ThemeLoadPosition(ThemeSingPlayer.SingBar, 'Sing' + Name + 'SingBar');
+  ThemeLoadPosition(ThemeSingPlayer.Oscilloscope, 'Sing' + Name + 'Oscilloscope');
 end;
 
 procedure TTheme.LoadColors;

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -781,9 +781,9 @@ begin
   Theme.Sing.Duet6PP1.AvatarFrame.ColB := Col[1].B;
 
   // P2
-  Theme.Sing.StaticP2DuetSixP.ColR := Col[2].R;
-  Theme.Sing.StaticP2DuetSixP.ColG := Col[2].G;
-  Theme.Sing.StaticP2DuetSixP.ColB := Col[2].B;
+  Theme.Sing.Duet6PP2.AvatarFrame.ColR := Col[2].R;
+  Theme.Sing.Duet6PP2.AvatarFrame.ColG := Col[2].G;
+  Theme.Sing.Duet6PP2.AvatarFrame.ColB := Col[2].B;
 
   // P3
   Theme.Sing.StaticP3DuetSixP.ColR := Col[3].R;
@@ -806,14 +806,14 @@ begin
   Theme.Sing.StaticP6DuetSixP.ColB := Col[6].B;
 
   StaticP1DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP1.AvatarFrame);
-  StaticP2DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP2DuetSixP);
+  StaticP2DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP2.AvatarFrame);
   StaticP3DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP3DuetSixP);
   StaticP4DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP4DuetSixP);
   StaticP5DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP5DuetSixP);
   StaticP6DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP6DuetSixP);
 
   TextP1DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP1.Name);
-  TextP2DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP2DuetSixP);
+  TextP2DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP2.Name);
   TextP3DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP3DuetSixP);
   TextP4DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP4DuetSixP);
   TextP5DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP5DuetSixP);
@@ -1183,14 +1183,14 @@ begin
   ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture.Z := Theme.Sing.Duet6PP1.Avatar.Z;
   ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture.Alpha := Theme.Sing.Duet6PP1.Avatar.Alpha;
 
-  StaticP2DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP2DuetSixPAvatar);
+  StaticP2DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet6PP2.Avatar);
   ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture := AvatarPlayerTextures[2];
-  ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture.X  := Theme.Sing.StaticP2DuetSixPAvatar.X;
-  ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture.Y  := Theme.Sing.StaticP2DuetSixPAvatar.Y;
-  ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture.H  := Theme.Sing.StaticP2DuetSixPAvatar.H;
-  ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture.W  := Theme.Sing.StaticP2DuetSixPAvatar.W;
-  ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture.Z := Theme.Sing.StaticP2DuetSixPAvatar.Z;
-  ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture.Alpha := Theme.Sing.StaticP2DuetSixPAvatar.Alpha;
+  ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture.X  := Theme.Sing.Duet6PP2.Avatar.X;
+  ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture.Y  := Theme.Sing.Duet6PP2.Avatar.Y;
+  ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture.H  := Theme.Sing.Duet6PP2.Avatar.H;
+  ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture.W  := Theme.Sing.Duet6PP2.Avatar.W;
+  ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture.Z := Theme.Sing.Duet6PP2.Avatar.Z;
+  ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture.Alpha := Theme.Sing.Duet6PP2.Avatar.Alpha;
 
   StaticP3DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP3DuetSixPAvatar);
   ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture := AvatarPlayerTextures[3];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -791,9 +791,9 @@ begin
   Theme.Sing.Duet6PP3.AvatarFrame.ColB := Col[3].B;
 
   // P4
-  Theme.Sing.StaticP4DuetSixP.ColR := Col[4].R;
-  Theme.Sing.StaticP4DuetSixP.ColG := Col[4].G;
-  Theme.Sing.StaticP4DuetSixP.ColB := Col[4].B;
+  Theme.Sing.Duet6PP4.AvatarFrame.ColR := Col[4].R;
+  Theme.Sing.Duet6PP4.AvatarFrame.ColG := Col[4].G;
+  Theme.Sing.Duet6PP4.AvatarFrame.ColB := Col[4].B;
 
   // P5
   Theme.Sing.StaticP5DuetSixP.ColR := Col[5].R;
@@ -808,14 +808,14 @@ begin
   StaticP1DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP1.AvatarFrame);
   StaticP2DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP2.AvatarFrame);
   StaticP3DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP3.AvatarFrame);
-  StaticP4DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP4DuetSixP);
+  StaticP4DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP4.AvatarFrame);
   StaticP5DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP5DuetSixP);
   StaticP6DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP6DuetSixP);
 
   TextP1DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP1.Name);
   TextP2DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP2.Name);
   TextP3DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP3.Name);
-  TextP4DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP4DuetSixP);
+  TextP4DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP4.Name);
   TextP5DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP5DuetSixP);
   TextP6DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP6DuetSixP);
 
@@ -1201,14 +1201,14 @@ begin
   ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture.Z := Theme.Sing.Duet6PP3.Avatar.Z;
   ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture.Alpha := Theme.Sing.Duet6PP3.Avatar.Alpha;
 
-  StaticP4DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP4DuetSixPAvatar);
+  StaticP4DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet6PP4.Avatar);
   ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture := AvatarPlayerTextures[4];
-  ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture.X  := Theme.Sing.StaticP4DuetSixPAvatar.X;
-  ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture.Y  := Theme.Sing.StaticP4DuetSixPAvatar.Y;
-  ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture.H  := Theme.Sing.StaticP4DuetSixPAvatar.H;
-  ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture.W  := Theme.Sing.StaticP4DuetSixPAvatar.W;
-  ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture.Z := Theme.Sing.StaticP4DuetSixPAvatar.Z;
-  ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture.Alpha := Theme.Sing.StaticP4DuetSixPAvatar.Alpha;
+  ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture.X  := Theme.Sing.Duet6PP4.Avatar.X;
+  ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture.Y  := Theme.Sing.Duet6PP4.Avatar.Y;
+  ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture.H  := Theme.Sing.Duet6PP4.Avatar.H;
+  ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture.W  := Theme.Sing.Duet6PP4.Avatar.W;
+  ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture.Z := Theme.Sing.Duet6PP4.Avatar.Z;
+  ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture.Alpha := Theme.Sing.Duet6PP4.Avatar.Alpha;
 
   StaticP5DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP5DuetSixPAvatar);
   ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture := AvatarPlayerTextures[5];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -715,9 +715,9 @@ begin
   Theme.Sing.Solo6PP3.AvatarFrame.ColB := Col[3].B;
 
   // P4
-  Theme.Sing.StaticP4SixP.ColR := Col[4].R;
-  Theme.Sing.StaticP4SixP.ColG := Col[4].G;
-  Theme.Sing.StaticP4SixP.ColB := Col[4].B;
+  Theme.Sing.Solo6PP4.AvatarFrame.ColR := Col[4].R;
+  Theme.Sing.Solo6PP4.AvatarFrame.ColG := Col[4].G;
+  Theme.Sing.Solo6PP4.AvatarFrame.ColB := Col[4].B;
 
   // P5
   Theme.Sing.StaticP5SixP.ColR := Col[5].R;
@@ -732,14 +732,14 @@ begin
   StaticP1SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP1.AvatarFrame);
   StaticP2SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP2.AvatarFrame);
   StaticP3SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP3.AvatarFrame);
-  StaticP4SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP4SixP);
+  StaticP4SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP4.AvatarFrame);
   StaticP5SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP5SixP);
   StaticP6SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP6SixP);
 
   TextP1SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP1.Name);
   TextP2SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP2.Name);
   TextP3SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP3.Name);
-  TextP4SixP   := ScreenSing.AddText(Theme.Sing.TextP4SixP);
+  TextP4SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP4.Name);
   TextP5SixP   := ScreenSing.AddText(Theme.Sing.TextP5SixP);
   TextP6SixP   := ScreenSing.AddText(Theme.Sing.TextP6SixP);
 
@@ -1147,14 +1147,14 @@ begin
   ScreenSing.Statics[StaticP3SixPAvatar].Texture.Z := Theme.Sing.Solo6PP3.Avatar.Z;
   ScreenSing.Statics[StaticP3SixPAvatar].Texture.Alpha := Theme.Sing.Solo6PP3.Avatar.Alpha;
 
-  StaticP4SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP4SixPAvatar);
+  StaticP4SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo6PP4.Avatar);
   ScreenSing.Statics[StaticP4SixPAvatar].Texture := AvatarPlayerTextures[4];
-  ScreenSing.Statics[StaticP4SixPAvatar].Texture.X  := Theme.Sing.StaticP4SixPAvatar.X;
-  ScreenSing.Statics[StaticP4SixPAvatar].Texture.Y  := Theme.Sing.StaticP4SixPAvatar.Y;
-  ScreenSing.Statics[StaticP4SixPAvatar].Texture.H  := Theme.Sing.StaticP4SixPAvatar.H;
-  ScreenSing.Statics[StaticP4SixPAvatar].Texture.W  := Theme.Sing.StaticP4SixPAvatar.W;
-  ScreenSing.Statics[StaticP4SixPAvatar].Texture.Z := Theme.Sing.StaticP4SixPAvatar.Z;
-  ScreenSing.Statics[StaticP4SixPAvatar].Texture.Alpha := Theme.Sing.StaticP4SixPAvatar.Alpha;
+  ScreenSing.Statics[StaticP4SixPAvatar].Texture.X  := Theme.Sing.Solo6PP4.Avatar.X;
+  ScreenSing.Statics[StaticP4SixPAvatar].Texture.Y  := Theme.Sing.Solo6PP4.Avatar.Y;
+  ScreenSing.Statics[StaticP4SixPAvatar].Texture.H  := Theme.Sing.Solo6PP4.Avatar.H;
+  ScreenSing.Statics[StaticP4SixPAvatar].Texture.W  := Theme.Sing.Solo6PP4.Avatar.W;
+  ScreenSing.Statics[StaticP4SixPAvatar].Texture.Z := Theme.Sing.Solo6PP4.Avatar.Z;
+  ScreenSing.Statics[StaticP4SixPAvatar].Texture.Alpha := Theme.Sing.Solo6PP4.Avatar.Alpha;
 
   StaticP5SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP5SixPAvatar);
   ScreenSing.Statics[StaticP5SixPAvatar].Texture := AvatarPlayerTextures[5];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -796,9 +796,9 @@ begin
   Theme.Sing.Duet6PP4.AvatarFrame.ColB := Col[4].B;
 
   // P5
-  Theme.Sing.StaticP5DuetSixP.ColR := Col[5].R;
-  Theme.Sing.StaticP5DuetSixP.ColG := Col[5].G;
-  Theme.Sing.StaticP5DuetSixP.ColB := Col[5].B;
+  Theme.Sing.Duet6PP5.AvatarFrame.ColR := Col[5].R;
+  Theme.Sing.Duet6PP5.AvatarFrame.ColG := Col[5].G;
+  Theme.Sing.Duet6PP5.AvatarFrame.ColB := Col[5].B;
 
   // P6
   Theme.Sing.StaticP6DuetSixP.ColR := Col[6].R;
@@ -809,14 +809,14 @@ begin
   StaticP2DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP2.AvatarFrame);
   StaticP3DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP3.AvatarFrame);
   StaticP4DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP4.AvatarFrame);
-  StaticP5DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP5DuetSixP);
+  StaticP5DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP5.AvatarFrame);
   StaticP6DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP6DuetSixP);
 
   TextP1DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP1.Name);
   TextP2DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP2.Name);
   TextP3DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP3.Name);
   TextP4DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP4.Name);
-  TextP5DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP5DuetSixP);
+  TextP5DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP5.Name);
   TextP6DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP6DuetSixP);
 
   // Sing Bars
@@ -1210,14 +1210,14 @@ begin
   ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture.Z := Theme.Sing.Duet6PP4.Avatar.Z;
   ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture.Alpha := Theme.Sing.Duet6PP4.Avatar.Alpha;
 
-  StaticP5DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP5DuetSixPAvatar);
+  StaticP5DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet6PP5.Avatar);
   ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture := AvatarPlayerTextures[5];
-  ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture.X  := Theme.Sing.StaticP5DuetSixPAvatar.X;
-  ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture.Y  := Theme.Sing.StaticP5DuetSixPAvatar.Y;
-  ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture.H  := Theme.Sing.StaticP5DuetSixPAvatar.H;
-  ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture.W  := Theme.Sing.StaticP5DuetSixPAvatar.W;
-  ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture.Z := Theme.Sing.StaticP5DuetSixPAvatar.Z;
-  ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture.Alpha := Theme.Sing.StaticP5DuetSixPAvatar.Alpha;
+  ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture.X  := Theme.Sing.Duet6PP5.Avatar.X;
+  ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture.Y  := Theme.Sing.Duet6PP5.Avatar.Y;
+  ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture.H  := Theme.Sing.Duet6PP5.Avatar.H;
+  ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture.W  := Theme.Sing.Duet6PP5.Avatar.W;
+  ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture.Z := Theme.Sing.Duet6PP5.Avatar.Z;
+  ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture.Alpha := Theme.Sing.Duet6PP5.Avatar.Alpha;
 
   StaticP6DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP6DuetSixPAvatar);
   ScreenSing.Statics[StaticP6DuetSixPAvatar].Texture := AvatarPlayerTextures[6];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -725,23 +725,23 @@ begin
   Theme.Sing.Solo6PP5.AvatarFrame.ColB := Col[5].B;
 
   // P6
-  Theme.Sing.StaticP6SixP.ColR := Col[6].R;
-  Theme.Sing.StaticP6SixP.ColG := Col[6].G;
-  Theme.Sing.StaticP6SixP.ColB := Col[6].B;
+  Theme.Sing.Solo6PP6.AvatarFrame.ColR := Col[6].R;
+  Theme.Sing.Solo6PP6.AvatarFrame.ColG := Col[6].G;
+  Theme.Sing.Solo6PP6.AvatarFrame.ColB := Col[6].B;
 
   StaticP1SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP1.AvatarFrame);
   StaticP2SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP2.AvatarFrame);
   StaticP3SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP3.AvatarFrame);
   StaticP4SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP4.AvatarFrame);
   StaticP5SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP5.AvatarFrame);
-  StaticP6SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP6SixP);
+  StaticP6SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP6.AvatarFrame);
 
   TextP1SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP1.Name);
   TextP2SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP2.Name);
   TextP3SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP3.Name);
   TextP4SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP4.Name);
   TextP5SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP5.Name);
-  TextP6SixP   := ScreenSing.AddText(Theme.Sing.TextP6SixP);
+  TextP6SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP6.Name);
 
 
   // 4/6 players duet in 1 screen
@@ -1165,14 +1165,14 @@ begin
   ScreenSing.Statics[StaticP5SixPAvatar].Texture.Z := Theme.Sing.Solo6PP5.Avatar.Z;
   ScreenSing.Statics[StaticP5SixPAvatar].Texture.Alpha := Theme.Sing.Solo6PP5.Avatar.Alpha;
 
-  StaticP6SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP6SixPAvatar);
+  StaticP6SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo6PP6.Avatar);
   ScreenSing.Statics[StaticP6SixPAvatar].Texture := AvatarPlayerTextures[6];
-  ScreenSing.Statics[StaticP6SixPAvatar].Texture.X  := Theme.Sing.StaticP6SixPAvatar.X;
-  ScreenSing.Statics[StaticP6SixPAvatar].Texture.Y  := Theme.Sing.StaticP6SixPAvatar.Y;
-  ScreenSing.Statics[StaticP6SixPAvatar].Texture.H  := Theme.Sing.StaticP6SixPAvatar.H;
-  ScreenSing.Statics[StaticP6SixPAvatar].Texture.W  := Theme.Sing.StaticP6SixPAvatar.W;
-  ScreenSing.Statics[StaticP6SixPAvatar].Texture.Z := Theme.Sing.StaticP6SixPAvatar.Z;
-  ScreenSing.Statics[StaticP6SixPAvatar].Texture.Alpha := Theme.Sing.StaticP6SixPAvatar.Alpha;
+  ScreenSing.Statics[StaticP6SixPAvatar].Texture.X  := Theme.Sing.Solo6PP6.Avatar.X;
+  ScreenSing.Statics[StaticP6SixPAvatar].Texture.Y  := Theme.Sing.Solo6PP6.Avatar.Y;
+  ScreenSing.Statics[StaticP6SixPAvatar].Texture.H  := Theme.Sing.Solo6PP6.Avatar.H;
+  ScreenSing.Statics[StaticP6SixPAvatar].Texture.W  := Theme.Sing.Solo6PP6.Avatar.W;
+  ScreenSing.Statics[StaticP6SixPAvatar].Texture.Z := Theme.Sing.Solo6PP6.Avatar.Z;
+  ScreenSing.Statics[StaticP6SixPAvatar].Texture.Alpha := Theme.Sing.Solo6PP6.Avatar.Alpha;
 
   StaticP1DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP1DuetSixPAvatar);
   ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture := AvatarPlayerTextures[1];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -746,9 +746,9 @@ begin
 
   // 4/6 players duet in 1 screen
   // P1
-  Theme.Sing.StaticP1DuetFourP.ColR := Col[1].R;
-  Theme.Sing.StaticP1DuetFourP.ColG := Col[1].G;
-  Theme.Sing.StaticP1DuetFourP.ColB := Col[1].B;
+  Theme.Sing.Duet4PP1.AvatarFrame.ColR := Col[1].R;
+  Theme.Sing.Duet4PP1.AvatarFrame.ColG := Col[1].G;
+  Theme.Sing.Duet4PP1.AvatarFrame.ColB := Col[1].B;
 
   // P2
   Theme.Sing.StaticP2DuetFourP.ColR := Col[2].R;
@@ -765,12 +765,12 @@ begin
   Theme.Sing.StaticP4DuetFourP.ColG := Col[4].G;
   Theme.Sing.StaticP4DuetFourP.ColB := Col[4].B;
 
-  StaticP1DuetFourP   := ScreenSing.AddStatic(Theme.Sing.StaticP1DuetFourP);
+  StaticP1DuetFourP   := ScreenSing.AddStatic(Theme.Sing.Duet4PP1.AvatarFrame);
   StaticP2DuetFourP   := ScreenSing.AddStatic(Theme.Sing.StaticP2DuetFourP);
   StaticP3DuetFourP   := ScreenSing.AddStatic(Theme.Sing.StaticP3DuetFourP);
   StaticP4DuetFourP   := ScreenSing.AddStatic(Theme.Sing.StaticP4DuetFourP);
 
-  TextP1DuetFourP   := ScreenSing.AddText(Theme.Sing.TextP1DuetFourP);
+  TextP1DuetFourP   := ScreenSing.AddText(Theme.Sing.Duet4PP1.Name);
   TextP2DuetFourP   := ScreenSing.AddText(Theme.Sing.TextP2DuetFourP);
   TextP3DuetFourP   := ScreenSing.AddText(Theme.Sing.TextP3DuetFourP);
   TextP4DuetFourP   := ScreenSing.AddText(Theme.Sing.TextP4DuetFourP);
@@ -1084,14 +1084,14 @@ begin
   ScreenSing.Statics[StaticP4FourPAvatar].Texture.Z := Theme.Sing.Solo4PP4.Avatar.Z;
   ScreenSing.Statics[StaticP4FourPAvatar].Texture.Alpha := Theme.Sing.Solo4PP4.Avatar.Alpha;
 
-  StaticP1DuetFourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP1DuetFourPAvatar);
+  StaticP1DuetFourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet4PP1.Avatar);
   ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture := AvatarPlayerTextures[1];
-  ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture.X  := Theme.Sing.StaticP1DuetFourPAvatar.X;
-  ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture.Y  := Theme.Sing.StaticP1DuetFourPAvatar.Y;
-  ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture.H  := Theme.Sing.StaticP1DuetFourPAvatar.H;
-  ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture.W  := Theme.Sing.StaticP1DuetFourPAvatar.W;
-  ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture.Z := Theme.Sing.StaticP1DuetFourPAvatar.Z;
-  ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture.Alpha := Theme.Sing.StaticP1DuetFourPAvatar.Alpha;
+  ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture.X  := Theme.Sing.Duet4PP1.Avatar.X;
+  ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture.Y  := Theme.Sing.Duet4PP1.Avatar.Y;
+  ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture.H  := Theme.Sing.Duet4PP1.Avatar.H;
+  ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture.W  := Theme.Sing.Duet4PP1.Avatar.W;
+  ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture.Z := Theme.Sing.Duet4PP1.Avatar.Z;
+  ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture.Alpha := Theme.Sing.Duet4PP1.Avatar.Alpha;
 
   StaticP2DuetFourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP2DuetFourPAvatar);
   ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture := AvatarPlayerTextures[2];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -680,9 +680,9 @@ begin
   Theme.Sing.Solo4PP2.AvatarFrame.ColB := Col[2].B;
 
   // P3
-  Theme.Sing.StaticP3FourP.ColR := Col[3].R;
-  Theme.Sing.StaticP3FourP.ColG := Col[3].G;
-  Theme.Sing.StaticP3FourP.ColB := Col[3].B;
+  Theme.Sing.Solo4PP3.AvatarFrame.ColR := Col[3].R;
+  Theme.Sing.Solo4PP3.AvatarFrame.ColG := Col[3].G;
+  Theme.Sing.Solo4PP3.AvatarFrame.ColB := Col[3].B;
 
   // P4
   Theme.Sing.StaticP4FourP.ColR := Col[4].R;
@@ -691,12 +691,12 @@ begin
 
   StaticP1FourP   := ScreenSing.AddStatic(Theme.Sing.Solo4PP1.AvatarFrame);
   StaticP2FourP   := ScreenSing.AddStatic(Theme.Sing.Solo4PP2.AvatarFrame);
-  StaticP3FourP   := ScreenSing.AddStatic(Theme.Sing.StaticP3FourP);
+  StaticP3FourP   := ScreenSing.AddStatic(Theme.Sing.Solo4PP3.AvatarFrame);
   StaticP4FourP   := ScreenSing.AddStatic(Theme.Sing.StaticP4FourP);
 
   TextP1FourP   := ScreenSing.AddText(Theme.Sing.Solo4PP1.Name);
   TextP2FourP   := ScreenSing.AddText(Theme.Sing.Solo4PP2.Name);
-  TextP3FourP   := ScreenSing.AddText(Theme.Sing.TextP3FourP);
+  TextP3FourP   := ScreenSing.AddText(Theme.Sing.Solo4PP3.Name);
   TextP4FourP   := ScreenSing.AddText(Theme.Sing.TextP4FourP);
 
   // P1
@@ -1066,14 +1066,14 @@ begin
   ScreenSing.Statics[StaticP2FourPAvatar].Texture.Z := Theme.Sing.Solo4PP2.Avatar.Z;
   ScreenSing.Statics[StaticP2FourPAvatar].Texture.Alpha := Theme.Sing.Solo4PP2.Avatar.Alpha;
 
-  StaticP3FourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP3FourPAvatar);
+  StaticP3FourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo4PP3.Avatar);
   ScreenSing.Statics[StaticP3FourPAvatar].Texture := AvatarPlayerTextures[3];
-  ScreenSing.Statics[StaticP3FourPAvatar].Texture.X  := Theme.Sing.StaticP3FourPAvatar.X;
-  ScreenSing.Statics[StaticP3FourPAvatar].Texture.Y  := Theme.Sing.StaticP3FourPAvatar.Y;
-  ScreenSing.Statics[StaticP3FourPAvatar].Texture.H  := Theme.Sing.StaticP3FourPAvatar.H;
-  ScreenSing.Statics[StaticP3FourPAvatar].Texture.W  := Theme.Sing.StaticP3FourPAvatar.W;
-  ScreenSing.Statics[StaticP3FourPAvatar].Texture.Z := Theme.Sing.StaticP3FourPAvatar.Z;
-  ScreenSing.Statics[StaticP3FourPAvatar].Texture.Alpha := Theme.Sing.StaticP3FourPAvatar.Alpha;
+  ScreenSing.Statics[StaticP3FourPAvatar].Texture.X  := Theme.Sing.Solo4PP3.Avatar.X;
+  ScreenSing.Statics[StaticP3FourPAvatar].Texture.Y  := Theme.Sing.Solo4PP3.Avatar.Y;
+  ScreenSing.Statics[StaticP3FourPAvatar].Texture.H  := Theme.Sing.Solo4PP3.Avatar.H;
+  ScreenSing.Statics[StaticP3FourPAvatar].Texture.W  := Theme.Sing.Solo4PP3.Avatar.W;
+  ScreenSing.Statics[StaticP3FourPAvatar].Texture.Z := Theme.Sing.Solo4PP3.Avatar.Z;
+  ScreenSing.Statics[StaticP3FourPAvatar].Texture.Alpha := Theme.Sing.Solo4PP3.Avatar.Alpha;
 
   StaticP4FourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP4FourPAvatar);
   ScreenSing.Statics[StaticP4FourPAvatar].Texture := AvatarPlayerTextures[4];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -700,9 +700,9 @@ begin
   TextP4FourP   := ScreenSing.AddText(Theme.Sing.Solo4PP4.Name);
 
   // P1
-  Theme.Sing.StaticP1SixP.ColR := Col[1].R;
-  Theme.Sing.StaticP1SixP.ColG := Col[1].G;
-  Theme.Sing.StaticP1SixP.ColB := Col[1].B;
+  Theme.Sing.Solo6PP1.AvatarFrame.ColR := Col[1].R;
+  Theme.Sing.Solo6PP1.AvatarFrame.ColG := Col[1].G;
+  Theme.Sing.Solo6PP1.AvatarFrame.ColB := Col[1].B;
 
   // P2
   Theme.Sing.StaticP2SixP.ColR := Col[2].R;
@@ -729,14 +729,14 @@ begin
   Theme.Sing.StaticP6SixP.ColG := Col[6].G;
   Theme.Sing.StaticP6SixP.ColB := Col[6].B;
 
-  StaticP1SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP1SixP);
+  StaticP1SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP1.AvatarFrame);
   StaticP2SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP2SixP);
   StaticP3SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP3SixP);
   StaticP4SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP4SixP);
   StaticP5SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP5SixP);
   StaticP6SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP6SixP);
 
-  TextP1SixP   := ScreenSing.AddText(Theme.Sing.TextP1SixP);
+  TextP1SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP1.Name);
   TextP2SixP   := ScreenSing.AddText(Theme.Sing.TextP2SixP);
   TextP3SixP   := ScreenSing.AddText(Theme.Sing.TextP3SixP);
   TextP4SixP   := ScreenSing.AddText(Theme.Sing.TextP4SixP);
@@ -1120,14 +1120,14 @@ begin
   ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture.Z := Theme.Sing.StaticP4DuetFourPAvatar.Z;
   ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture.Alpha := Theme.Sing.StaticP4DuetFourPAvatar.Alpha;
 
-  StaticP1SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP1SixPAvatar);
+  StaticP1SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo6PP1.Avatar);
   ScreenSing.Statics[StaticP1SixPAvatar].Texture := AvatarPlayerTextures[1];
-  ScreenSing.Statics[StaticP1SixPAvatar].Texture.X  := Theme.Sing.StaticP1SixPAvatar.X;
-  ScreenSing.Statics[StaticP1SixPAvatar].Texture.Y  := Theme.Sing.StaticP1SixPAvatar.Y;
-  ScreenSing.Statics[StaticP1SixPAvatar].Texture.H  := Theme.Sing.StaticP1SixPAvatar.H;
-  ScreenSing.Statics[StaticP1SixPAvatar].Texture.W  := Theme.Sing.StaticP1SixPAvatar.W;
-  ScreenSing.Statics[StaticP1SixPAvatar].Texture.Z := Theme.Sing.StaticP1SixPAvatar.Z;
-  ScreenSing.Statics[StaticP1SixPAvatar].Texture.Alpha := Theme.Sing.StaticP1SixPAvatar.Alpha;
+  ScreenSing.Statics[StaticP1SixPAvatar].Texture.X  := Theme.Sing.Solo6PP1.Avatar.X;
+  ScreenSing.Statics[StaticP1SixPAvatar].Texture.Y  := Theme.Sing.Solo6PP1.Avatar.Y;
+  ScreenSing.Statics[StaticP1SixPAvatar].Texture.H  := Theme.Sing.Solo6PP1.Avatar.H;
+  ScreenSing.Statics[StaticP1SixPAvatar].Texture.W  := Theme.Sing.Solo6PP1.Avatar.W;
+  ScreenSing.Statics[StaticP1SixPAvatar].Texture.Z := Theme.Sing.Solo6PP1.Avatar.Z;
+  ScreenSing.Statics[StaticP1SixPAvatar].Texture.Alpha := Theme.Sing.Solo6PP1.Avatar.Alpha;
 
   StaticP2SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP2SixPAvatar);
   ScreenSing.Statics[StaticP2SixPAvatar].Texture := AvatarPlayerTextures[2];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -685,19 +685,19 @@ begin
   Theme.Sing.Solo4PP3.AvatarFrame.ColB := Col[3].B;
 
   // P4
-  Theme.Sing.StaticP4FourP.ColR := Col[4].R;
-  Theme.Sing.StaticP4FourP.ColG := Col[4].G;
-  Theme.Sing.StaticP4FourP.ColB := Col[4].B;
+  Theme.Sing.Solo4PP4.AvatarFrame.ColR := Col[4].R;
+  Theme.Sing.Solo4PP4.AvatarFrame.ColG := Col[4].G;
+  Theme.Sing.Solo4PP4.AvatarFrame.ColB := Col[4].B;
 
   StaticP1FourP   := ScreenSing.AddStatic(Theme.Sing.Solo4PP1.AvatarFrame);
   StaticP2FourP   := ScreenSing.AddStatic(Theme.Sing.Solo4PP2.AvatarFrame);
   StaticP3FourP   := ScreenSing.AddStatic(Theme.Sing.Solo4PP3.AvatarFrame);
-  StaticP4FourP   := ScreenSing.AddStatic(Theme.Sing.StaticP4FourP);
+  StaticP4FourP   := ScreenSing.AddStatic(Theme.Sing.Solo4PP4.AvatarFrame);
 
   TextP1FourP   := ScreenSing.AddText(Theme.Sing.Solo4PP1.Name);
   TextP2FourP   := ScreenSing.AddText(Theme.Sing.Solo4PP2.Name);
   TextP3FourP   := ScreenSing.AddText(Theme.Sing.Solo4PP3.Name);
-  TextP4FourP   := ScreenSing.AddText(Theme.Sing.TextP4FourP);
+  TextP4FourP   := ScreenSing.AddText(Theme.Sing.Solo4PP4.Name);
 
   // P1
   Theme.Sing.StaticP1SixP.ColR := Col[1].R;
@@ -1075,14 +1075,14 @@ begin
   ScreenSing.Statics[StaticP3FourPAvatar].Texture.Z := Theme.Sing.Solo4PP3.Avatar.Z;
   ScreenSing.Statics[StaticP3FourPAvatar].Texture.Alpha := Theme.Sing.Solo4PP3.Avatar.Alpha;
 
-  StaticP4FourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP4FourPAvatar);
+  StaticP4FourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo4PP4.Avatar);
   ScreenSing.Statics[StaticP4FourPAvatar].Texture := AvatarPlayerTextures[4];
-  ScreenSing.Statics[StaticP4FourPAvatar].Texture.X  := Theme.Sing.StaticP4FourPAvatar.X;
-  ScreenSing.Statics[StaticP4FourPAvatar].Texture.Y  := Theme.Sing.StaticP4FourPAvatar.Y;
-  ScreenSing.Statics[StaticP4FourPAvatar].Texture.H  := Theme.Sing.StaticP4FourPAvatar.H;
-  ScreenSing.Statics[StaticP4FourPAvatar].Texture.W  := Theme.Sing.StaticP4FourPAvatar.W;
-  ScreenSing.Statics[StaticP4FourPAvatar].Texture.Z := Theme.Sing.StaticP4FourPAvatar.Z;
-  ScreenSing.Statics[StaticP4FourPAvatar].Texture.Alpha := Theme.Sing.StaticP4FourPAvatar.Alpha;
+  ScreenSing.Statics[StaticP4FourPAvatar].Texture.X  := Theme.Sing.Solo4PP4.Avatar.X;
+  ScreenSing.Statics[StaticP4FourPAvatar].Texture.Y  := Theme.Sing.Solo4PP4.Avatar.Y;
+  ScreenSing.Statics[StaticP4FourPAvatar].Texture.H  := Theme.Sing.Solo4PP4.Avatar.H;
+  ScreenSing.Statics[StaticP4FourPAvatar].Texture.W  := Theme.Sing.Solo4PP4.Avatar.W;
+  ScreenSing.Statics[StaticP4FourPAvatar].Texture.Z := Theme.Sing.Solo4PP4.Avatar.Z;
+  ScreenSing.Statics[StaticP4FourPAvatar].Texture.Alpha := Theme.Sing.Solo4PP4.Avatar.Alpha;
 
   StaticP1DuetFourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP1DuetFourPAvatar);
   ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture := AvatarPlayerTextures[1];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -801,23 +801,23 @@ begin
   Theme.Sing.Duet6PP5.AvatarFrame.ColB := Col[5].B;
 
   // P6
-  Theme.Sing.StaticP6DuetSixP.ColR := Col[6].R;
-  Theme.Sing.StaticP6DuetSixP.ColG := Col[6].G;
-  Theme.Sing.StaticP6DuetSixP.ColB := Col[6].B;
+  Theme.Sing.Duet6PP6.AvatarFrame.ColR := Col[6].R;
+  Theme.Sing.Duet6PP6.AvatarFrame.ColG := Col[6].G;
+  Theme.Sing.Duet6PP6.AvatarFrame.ColB := Col[6].B;
 
   StaticP1DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP1.AvatarFrame);
   StaticP2DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP2.AvatarFrame);
   StaticP3DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP3.AvatarFrame);
   StaticP4DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP4.AvatarFrame);
   StaticP5DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP5.AvatarFrame);
-  StaticP6DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP6DuetSixP);
+  StaticP6DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP6.AvatarFrame);
 
   TextP1DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP1.Name);
   TextP2DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP2.Name);
   TextP3DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP3.Name);
   TextP4DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP4.Name);
   TextP5DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP5.Name);
-  TextP6DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP6DuetSixP);
+  TextP6DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP6.Name);
 
   // Sing Bars
   // P1-6
@@ -1219,14 +1219,14 @@ begin
   ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture.Z := Theme.Sing.Duet6PP5.Avatar.Z;
   ScreenSing.Statics[StaticP5DuetSixPAvatar].Texture.Alpha := Theme.Sing.Duet6PP5.Avatar.Alpha;
 
-  StaticP6DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP6DuetSixPAvatar);
+  StaticP6DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet6PP6.Avatar);
   ScreenSing.Statics[StaticP6DuetSixPAvatar].Texture := AvatarPlayerTextures[6];
-  ScreenSing.Statics[StaticP6DuetSixPAvatar].Texture.X  := Theme.Sing.StaticP6DuetSixPAvatar.X;
-  ScreenSing.Statics[StaticP6DuetSixPAvatar].Texture.Y  := Theme.Sing.StaticP6DuetSixPAvatar.Y;
-  ScreenSing.Statics[StaticP6DuetSixPAvatar].Texture.H  := Theme.Sing.StaticP6DuetSixPAvatar.H;
-  ScreenSing.Statics[StaticP6DuetSixPAvatar].Texture.W  := Theme.Sing.StaticP6DuetSixPAvatar.W;
-  ScreenSing.Statics[StaticP6DuetSixPAvatar].Texture.Z := Theme.Sing.StaticP6DuetSixPAvatar.Z;
-  ScreenSing.Statics[StaticP6DuetSixPAvatar].Texture.Alpha := Theme.Sing.StaticP6DuetSixPAvatar.Alpha;
+  ScreenSing.Statics[StaticP6DuetSixPAvatar].Texture.X  := Theme.Sing.Duet6PP6.Avatar.X;
+  ScreenSing.Statics[StaticP6DuetSixPAvatar].Texture.Y  := Theme.Sing.Duet6PP6.Avatar.Y;
+  ScreenSing.Statics[StaticP6DuetSixPAvatar].Texture.H  := Theme.Sing.Duet6PP6.Avatar.H;
+  ScreenSing.Statics[StaticP6DuetSixPAvatar].Texture.W  := Theme.Sing.Duet6PP6.Avatar.W;
+  ScreenSing.Statics[StaticP6DuetSixPAvatar].Texture.Z := Theme.Sing.Duet6PP6.Avatar.Z;
+  ScreenSing.Statics[StaticP6DuetSixPAvatar].Texture.Alpha := Theme.Sing.Duet6PP6.Avatar.Alpha;
 
 end;
 

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -575,9 +575,9 @@ begin
 
   //                | P3 DUET
 
-  Theme.Sing.StaticDuetP3R.ColR := Col[3].R;
-  Theme.Sing.StaticDuetP3R.ColG := Col[3].G;
-  Theme.Sing.StaticDuetP3R.ColB := Col[3].B;
+  Theme.Sing.Duet3PP3.AvatarFrame.ColR := Col[3].R;
+  Theme.Sing.Duet3PP3.AvatarFrame.ColG := Col[3].G;
+  Theme.Sing.Duet3PP3.AvatarFrame.ColB := Col[3].B;
 
   StaticP1[0]       := ScreenSing.AddStatic(Theme.Sing.StaticP1);
   StaticP1TwoP[0]   := ScreenSing.AddStatic(Theme.Sing.StaticP1TwoP);
@@ -587,7 +587,7 @@ begin
   StaticP3R[0]      := ScreenSing.AddStatic(Theme.Sing.StaticP3R);
   StaticDuetP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.StaticDuetP1ThreeP);
   StaticDuetP2M[0]      := ScreenSing.AddStatic(Theme.Sing.StaticDuetP2M);
-  StaticDuetP3R[0]      := ScreenSing.AddStatic(Theme.Sing.StaticDuetP3R);
+  StaticDuetP3R[0]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP3.AvatarFrame);
 
   // SCREEN 2
   // 1 player       | P1
@@ -631,9 +631,9 @@ begin
   Theme.Sing.StaticDuetP2M.ColB := Col[5].B;
 
   //                | P3 DUET
-  Theme.Sing.StaticDuetP3R.ColR := Col[6].R;
-  Theme.Sing.StaticDuetP3R.ColG := Col[6].G;
-  Theme.Sing.StaticDuetP3R.ColB := Col[6].B;
+  Theme.Sing.Duet3PP3.AvatarFrame.ColR := Col[6].R;
+  Theme.Sing.Duet3PP3.AvatarFrame.ColG := Col[6].G;
+  Theme.Sing.Duet3PP3.AvatarFrame.ColB := Col[6].B;
 
   StaticP1[1]       := ScreenSing.AddStatic(Theme.Sing.StaticP1);
   StaticP1TwoP[1]   := ScreenSing.AddStatic(Theme.Sing.StaticP1TwoP);
@@ -643,7 +643,7 @@ begin
   StaticP3R[1]      := ScreenSing.AddStatic(Theme.Sing.StaticP3R);
   StaticDuetP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.StaticDuetP1ThreeP);
   StaticDuetP2M[1]      := ScreenSing.AddStatic(Theme.Sing.StaticDuetP2M);
-  StaticDuetP3R[1]      := ScreenSing.AddStatic(Theme.Sing.StaticDuetP3R);
+  StaticDuetP3R[1]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP3.AvatarFrame);
 
   TextP1   := ScreenSing.AddText(Theme.Sing.TextP1);
   TextP1TwoP   := ScreenSing.AddText(Theme.Sing.TextP1TwoP);
@@ -653,7 +653,7 @@ begin
   TextP3R   := ScreenSing.AddText(Theme.Sing.TextP3R);
   TextDuetP1ThreeP   := ScreenSing.AddText(Theme.Sing.TextDuetP1ThreeP);
   TextDuetP2M   := ScreenSing.AddText(Theme.Sing.TextDuetP2M);
-  TextDuetP3R   := ScreenSing.AddText(Theme.Sing.TextDuetP3R);
+  TextDuetP3R   := ScreenSing.AddText(Theme.Sing.Duet3PP3.Name);
 
   for I := 1 to PlayersPlay do
   begin
@@ -1030,23 +1030,23 @@ begin
   ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture.Z := Theme.Sing.StaticDuetP2MAvatar.Z;
   ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture.Alpha := Theme.Sing.StaticDuetP2MAvatar.Alpha;
 
-  StaticDuetP3RAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticDuetP3RAvatar);
+  StaticDuetP3RAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet3PP3.Avatar);
   ScreenSing.Statics[StaticDuetP3RAvatar[0]].Texture := AvatarPlayerTextures[3];
-  ScreenSing.Statics[StaticDuetP3RAvatar[0]].Texture.X  := Theme.Sing.StaticDuetP3RAvatar.X;
-  ScreenSing.Statics[StaticDuetP3RAvatar[0]].Texture.Y  := Theme.Sing.StaticDuetP3RAvatar.Y;
-  ScreenSing.Statics[StaticDuetP3RAvatar[0]].Texture.H  := Theme.Sing.StaticDuetP3RAvatar.H;
-  ScreenSing.Statics[StaticDuetP3RAvatar[0]].Texture.W  := Theme.Sing.StaticDuetP3RAvatar.W;
-  ScreenSing.Statics[StaticDuetP3RAvatar[0]].Texture.Z := Theme.Sing.StaticDuetP3RAvatar.Z;
-  ScreenSing.Statics[StaticDuetP3RAvatar[0]].Texture.Alpha := Theme.Sing.StaticDuetP3RAvatar.Alpha;
+  ScreenSing.Statics[StaticDuetP3RAvatar[0]].Texture.X  := Theme.Sing.Duet3PP3.Avatar.X;
+  ScreenSing.Statics[StaticDuetP3RAvatar[0]].Texture.Y  := Theme.Sing.Duet3PP3.Avatar.Y;
+  ScreenSing.Statics[StaticDuetP3RAvatar[0]].Texture.H  := Theme.Sing.Duet3PP3.Avatar.H;
+  ScreenSing.Statics[StaticDuetP3RAvatar[0]].Texture.W  := Theme.Sing.Duet3PP3.Avatar.W;
+  ScreenSing.Statics[StaticDuetP3RAvatar[0]].Texture.Z := Theme.Sing.Duet3PP3.Avatar.Z;
+  ScreenSing.Statics[StaticDuetP3RAvatar[0]].Texture.Alpha := Theme.Sing.Duet3PP3.Avatar.Alpha;
 
-  StaticDuetP3RAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticDuetP3RAvatar);
+  StaticDuetP3RAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet3PP3.Avatar);
   ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture := AvatarPlayerTextures[6];
-  ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture.X  := Theme.Sing.StaticDuetP3RAvatar.X;
-  ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture.Y  := Theme.Sing.StaticDuetP3RAvatar.Y;
-  ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture.H  := Theme.Sing.StaticDuetP3RAvatar.H;
-  ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture.W  := Theme.Sing.StaticDuetP3RAvatar.W;
-  ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture.Z := Theme.Sing.StaticDuetP3RAvatar.Z;
-  ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture.Alpha := Theme.Sing.StaticDuetP3RAvatar.Alpha;
+  ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture.X  := Theme.Sing.Duet3PP3.Avatar.X;
+  ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture.Y  := Theme.Sing.Duet3PP3.Avatar.Y;
+  ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture.H  := Theme.Sing.Duet3PP3.Avatar.H;
+  ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture.W  := Theme.Sing.Duet3PP3.Avatar.W;
+  ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture.Z := Theme.Sing.Duet3PP3.Avatar.Z;
+  ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture.Alpha := Theme.Sing.Duet3PP3.Avatar.Alpha;
 
   StaticP1FourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo4PP1.Avatar);
   ScreenSing.Statics[StaticP1FourPAvatar].Texture := AvatarPlayerTextures[1];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -786,9 +786,9 @@ begin
   Theme.Sing.Duet6PP2.AvatarFrame.ColB := Col[2].B;
 
   // P3
-  Theme.Sing.StaticP3DuetSixP.ColR := Col[3].R;
-  Theme.Sing.StaticP3DuetSixP.ColG := Col[3].G;
-  Theme.Sing.StaticP3DuetSixP.ColB := Col[3].B;
+  Theme.Sing.Duet6PP3.AvatarFrame.ColR := Col[3].R;
+  Theme.Sing.Duet6PP3.AvatarFrame.ColG := Col[3].G;
+  Theme.Sing.Duet6PP3.AvatarFrame.ColB := Col[3].B;
 
   // P4
   Theme.Sing.StaticP4DuetSixP.ColR := Col[4].R;
@@ -807,14 +807,14 @@ begin
 
   StaticP1DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP1.AvatarFrame);
   StaticP2DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP2.AvatarFrame);
-  StaticP3DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP3DuetSixP);
+  StaticP3DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP3.AvatarFrame);
   StaticP4DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP4DuetSixP);
   StaticP5DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP5DuetSixP);
   StaticP6DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP6DuetSixP);
 
   TextP1DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP1.Name);
   TextP2DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP2.Name);
-  TextP3DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP3DuetSixP);
+  TextP3DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP3.Name);
   TextP4DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP4DuetSixP);
   TextP5DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP5DuetSixP);
   TextP6DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP6DuetSixP);
@@ -1192,14 +1192,14 @@ begin
   ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture.Z := Theme.Sing.Duet6PP2.Avatar.Z;
   ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture.Alpha := Theme.Sing.Duet6PP2.Avatar.Alpha;
 
-  StaticP3DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP3DuetSixPAvatar);
+  StaticP3DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet6PP3.Avatar);
   ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture := AvatarPlayerTextures[3];
-  ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture.X  := Theme.Sing.StaticP3DuetSixPAvatar.X;
-  ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture.Y  := Theme.Sing.StaticP3DuetSixPAvatar.Y;
-  ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture.H  := Theme.Sing.StaticP3DuetSixPAvatar.H;
-  ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture.W  := Theme.Sing.StaticP3DuetSixPAvatar.W;
-  ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture.Z := Theme.Sing.StaticP3DuetSixPAvatar.Z;
-  ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture.Alpha := Theme.Sing.StaticP3DuetSixPAvatar.Alpha;
+  ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture.X  := Theme.Sing.Duet6PP3.Avatar.X;
+  ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture.Y  := Theme.Sing.Duet6PP3.Avatar.Y;
+  ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture.H  := Theme.Sing.Duet6PP3.Avatar.H;
+  ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture.W  := Theme.Sing.Duet6PP3.Avatar.W;
+  ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture.Z := Theme.Sing.Duet6PP3.Avatar.Z;
+  ScreenSing.Statics[StaticP3DuetSixPAvatar].Texture.Alpha := Theme.Sing.Duet6PP3.Avatar.Alpha;
 
   StaticP4DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP4DuetSixPAvatar);
   ScreenSing.Statics[StaticP4DuetSixPAvatar].Texture := AvatarPlayerTextures[4];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -559,9 +559,9 @@ begin
 
   //                | P3
 
-  Theme.Sing.StaticP3R.ColR := Col[3].R;
-  Theme.Sing.StaticP3R.ColG := Col[3].G;
-  Theme.Sing.StaticP3R.ColB := Col[3].B;
+  Theme.Sing.Solo3PP3.AvatarFrame.ColR := Col[3].R;
+  Theme.Sing.Solo3PP3.AvatarFrame.ColG := Col[3].G;
+  Theme.Sing.Solo3PP3.AvatarFrame.ColB := Col[3].B;
 
   // 3 or 6 players | P1 DUET
   Theme.Sing.Duet3PP1.AvatarFrame.ColR := Col[1].R;
@@ -584,7 +584,7 @@ begin
   StaticP2R[0]      := ScreenSing.AddStatic(Theme.Sing.StaticP2R);
   StaticP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.StaticP1ThreeP);
   StaticP2M[0]      := ScreenSing.AddStatic(Theme.Sing.StaticP2M);
-  StaticP3R[0]      := ScreenSing.AddStatic(Theme.Sing.StaticP3R);
+  StaticP3R[0]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP3.AvatarFrame);
   StaticDuetP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.Duet3PP1.AvatarFrame);
   StaticDuetP2M[0]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP2.AvatarFrame);
   StaticDuetP3R[0]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP3.AvatarFrame);
@@ -616,9 +616,9 @@ begin
   Theme.Sing.StaticP2M.ColB := Col[5].B;
 
   //                | P3
-  Theme.Sing.StaticP3R.ColR := Col[6].R;
-  Theme.Sing.StaticP3R.ColG := Col[6].G;
-  Theme.Sing.StaticP3R.ColB := Col[6].B;
+  Theme.Sing.Solo3PP3.AvatarFrame.ColR := Col[6].R;
+  Theme.Sing.Solo3PP3.AvatarFrame.ColG := Col[6].G;
+  Theme.Sing.Solo3PP3.AvatarFrame.ColB := Col[6].B;
 
     // 3 or 6 players | P1 DUET
   Theme.Sing.Duet3PP1.AvatarFrame.ColR := Col[4].R;
@@ -640,7 +640,7 @@ begin
   StaticP2R[1]      := ScreenSing.AddStatic(Theme.Sing.StaticP2R);
   StaticP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.StaticP1ThreeP);
   StaticP2M[1]      := ScreenSing.AddStatic(Theme.Sing.StaticP2M);
-  StaticP3R[1]      := ScreenSing.AddStatic(Theme.Sing.StaticP3R);
+  StaticP3R[1]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP3.AvatarFrame);
   StaticDuetP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.Duet3PP1.AvatarFrame);
   StaticDuetP2M[1]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP2.AvatarFrame);
   StaticDuetP3R[1]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP3.AvatarFrame);
@@ -650,7 +650,7 @@ begin
   TextP2R   := ScreenSing.AddText(Theme.Sing.TextP2R);
   TextP1ThreeP   := ScreenSing.AddText(Theme.Sing.TextP1ThreeP);
   TextP2M   := ScreenSing.AddText(Theme.Sing.TextP2M);
-  TextP3R   := ScreenSing.AddText(Theme.Sing.TextP3R);
+  TextP3R   := ScreenSing.AddText(Theme.Sing.Solo3PP3.Name);
   TextDuetP1ThreeP   := ScreenSing.AddText(Theme.Sing.Duet3PP1.Name);
   TextDuetP2M   := ScreenSing.AddText(Theme.Sing.Duet3PP2.Name);
   TextDuetP3R   := ScreenSing.AddText(Theme.Sing.Duet3PP3.Name);
@@ -976,23 +976,23 @@ begin
   ScreenSing.Statics[StaticP2MAvatar[1]].Texture.Z := Theme.Sing.StaticP2MAvatar.Z;
   ScreenSing.Statics[StaticP2MAvatar[1]].Texture.Alpha := Theme.Sing.StaticP2MAvatar.Alpha;
 
-  StaticP3RAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP3RAvatar);
+  StaticP3RAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo3PP3.Avatar);
   ScreenSing.Statics[StaticP3RAvatar[0]].Texture := AvatarPlayerTextures[3];
-  ScreenSing.Statics[StaticP3RAvatar[0]].Texture.X  := Theme.Sing.StaticP3RAvatar.X;
-  ScreenSing.Statics[StaticP3RAvatar[0]].Texture.Y  := Theme.Sing.StaticP3RAvatar.Y;
-  ScreenSing.Statics[StaticP3RAvatar[0]].Texture.H  := Theme.Sing.StaticP3RAvatar.H;
-  ScreenSing.Statics[StaticP3RAvatar[0]].Texture.W  := Theme.Sing.StaticP3RAvatar.W;
-  ScreenSing.Statics[StaticP3RAvatar[0]].Texture.Z := Theme.Sing.StaticP3RAvatar.Z;
-  ScreenSing.Statics[StaticP3RAvatar[0]].Texture.Alpha := Theme.Sing.StaticP3RAvatar.Alpha;
+  ScreenSing.Statics[StaticP3RAvatar[0]].Texture.X  := Theme.Sing.Solo3PP3.Avatar.X;
+  ScreenSing.Statics[StaticP3RAvatar[0]].Texture.Y  := Theme.Sing.Solo3PP3.Avatar.Y;
+  ScreenSing.Statics[StaticP3RAvatar[0]].Texture.H  := Theme.Sing.Solo3PP3.Avatar.H;
+  ScreenSing.Statics[StaticP3RAvatar[0]].Texture.W  := Theme.Sing.Solo3PP3.Avatar.W;
+  ScreenSing.Statics[StaticP3RAvatar[0]].Texture.Z := Theme.Sing.Solo3PP3.Avatar.Z;
+  ScreenSing.Statics[StaticP3RAvatar[0]].Texture.Alpha := Theme.Sing.Solo3PP3.Avatar.Alpha;
 
-  StaticP3RAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP3RAvatar);
+  StaticP3RAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo3PP3.Avatar);
   ScreenSing.Statics[StaticP3RAvatar[1]].Texture := AvatarPlayerTextures[6];
-  ScreenSing.Statics[StaticP3RAvatar[1]].Texture.X  := Theme.Sing.StaticP3RAvatar.X;
-  ScreenSing.Statics[StaticP3RAvatar[1]].Texture.Y  := Theme.Sing.StaticP3RAvatar.Y;
-  ScreenSing.Statics[StaticP3RAvatar[1]].Texture.H  := Theme.Sing.StaticP3RAvatar.H;
-  ScreenSing.Statics[StaticP3RAvatar[1]].Texture.W  := Theme.Sing.StaticP3RAvatar.W;
-  ScreenSing.Statics[StaticP3RAvatar[1]].Texture.Z := Theme.Sing.StaticP3RAvatar.Z;
-  ScreenSing.Statics[StaticP3RAvatar[1]].Texture.Alpha := Theme.Sing.StaticP3RAvatar.Alpha;
+  ScreenSing.Statics[StaticP3RAvatar[1]].Texture.X  := Theme.Sing.Solo3PP3.Avatar.X;
+  ScreenSing.Statics[StaticP3RAvatar[1]].Texture.Y  := Theme.Sing.Solo3PP3.Avatar.Y;
+  ScreenSing.Statics[StaticP3RAvatar[1]].Texture.H  := Theme.Sing.Solo3PP3.Avatar.H;
+  ScreenSing.Statics[StaticP3RAvatar[1]].Texture.W  := Theme.Sing.Solo3PP3.Avatar.W;
+  ScreenSing.Statics[StaticP3RAvatar[1]].Texture.Z := Theme.Sing.Solo3PP3.Avatar.Z;
+  ScreenSing.Statics[StaticP3RAvatar[1]].Texture.Alpha := Theme.Sing.Solo3PP3.Avatar.Alpha;
 
   StaticDuetP1ThreePAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet3PP1.Avatar);
   ScreenSing.Statics[StaticDuetP1ThreePAvatar[0]].Texture := AvatarPlayerTextures[1];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -705,9 +705,9 @@ begin
   Theme.Sing.Solo6PP1.AvatarFrame.ColB := Col[1].B;
 
   // P2
-  Theme.Sing.StaticP2SixP.ColR := Col[2].R;
-  Theme.Sing.StaticP2SixP.ColG := Col[2].G;
-  Theme.Sing.StaticP2SixP.ColB := Col[2].B;
+  Theme.Sing.Solo6PP2.AvatarFrame.ColR := Col[2].R;
+  Theme.Sing.Solo6PP2.AvatarFrame.ColG := Col[2].G;
+  Theme.Sing.Solo6PP2.AvatarFrame.ColB := Col[2].B;
 
   // P3
   Theme.Sing.StaticP3SixP.ColR := Col[3].R;
@@ -730,14 +730,14 @@ begin
   Theme.Sing.StaticP6SixP.ColB := Col[6].B;
 
   StaticP1SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP1.AvatarFrame);
-  StaticP2SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP2SixP);
+  StaticP2SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP2.AvatarFrame);
   StaticP3SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP3SixP);
   StaticP4SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP4SixP);
   StaticP5SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP5SixP);
   StaticP6SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP6SixP);
 
   TextP1SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP1.Name);
-  TextP2SixP   := ScreenSing.AddText(Theme.Sing.TextP2SixP);
+  TextP2SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP2.Name);
   TextP3SixP   := ScreenSing.AddText(Theme.Sing.TextP3SixP);
   TextP4SixP   := ScreenSing.AddText(Theme.Sing.TextP4SixP);
   TextP5SixP   := ScreenSing.AddText(Theme.Sing.TextP5SixP);
@@ -1129,14 +1129,14 @@ begin
   ScreenSing.Statics[StaticP1SixPAvatar].Texture.Z := Theme.Sing.Solo6PP1.Avatar.Z;
   ScreenSing.Statics[StaticP1SixPAvatar].Texture.Alpha := Theme.Sing.Solo6PP1.Avatar.Alpha;
 
-  StaticP2SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP2SixPAvatar);
+  StaticP2SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo6PP2.Avatar);
   ScreenSing.Statics[StaticP2SixPAvatar].Texture := AvatarPlayerTextures[2];
-  ScreenSing.Statics[StaticP2SixPAvatar].Texture.X  := Theme.Sing.StaticP2SixPAvatar.X;
-  ScreenSing.Statics[StaticP2SixPAvatar].Texture.Y  := Theme.Sing.StaticP2SixPAvatar.Y;
-  ScreenSing.Statics[StaticP2SixPAvatar].Texture.H  := Theme.Sing.StaticP2SixPAvatar.H;
-  ScreenSing.Statics[StaticP2SixPAvatar].Texture.W  := Theme.Sing.StaticP2SixPAvatar.W;
-  ScreenSing.Statics[StaticP2SixPAvatar].Texture.Z := Theme.Sing.StaticP2SixPAvatar.Z;
-  ScreenSing.Statics[StaticP2SixPAvatar].Texture.Alpha := Theme.Sing.StaticP2SixPAvatar.Alpha;
+  ScreenSing.Statics[StaticP2SixPAvatar].Texture.X  := Theme.Sing.Solo6PP2.Avatar.X;
+  ScreenSing.Statics[StaticP2SixPAvatar].Texture.Y  := Theme.Sing.Solo6PP2.Avatar.Y;
+  ScreenSing.Statics[StaticP2SixPAvatar].Texture.H  := Theme.Sing.Solo6PP2.Avatar.H;
+  ScreenSing.Statics[StaticP2SixPAvatar].Texture.W  := Theme.Sing.Solo6PP2.Avatar.W;
+  ScreenSing.Statics[StaticP2SixPAvatar].Texture.Z := Theme.Sing.Solo6PP2.Avatar.Z;
+  ScreenSing.Statics[StaticP2SixPAvatar].Texture.Alpha := Theme.Sing.Solo6PP2.Avatar.Alpha;
 
   StaticP3SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP3SixPAvatar);
   ScreenSing.Statics[StaticP3SixPAvatar].Texture := AvatarPlayerTextures[3];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -543,9 +543,9 @@ begin
   Theme.Sing.StaticP1TwoP.ColB := Col[1].B;
 
   //                | P2
-  Theme.Sing.StaticP2R.ColR := Col[2].R;
-  Theme.Sing.StaticP2R.ColG := Col[2].G;
-  Theme.Sing.StaticP2R.ColB := Col[2].B;
+  Theme.Sing.Solo2PP2.AvatarFrame.ColR := Col[2].R;
+  Theme.Sing.Solo2PP2.AvatarFrame.ColG := Col[2].G;
+  Theme.Sing.Solo2PP2.AvatarFrame.ColB := Col[2].B;
 
   // 3 or 6 players | P1
   Theme.Sing.StaticP1ThreeP.ColR := Col[1].R;
@@ -581,7 +581,7 @@ begin
 
   StaticP1[0]       := ScreenSing.AddStatic(Theme.Sing.StaticP1);
   StaticP1TwoP[0]   := ScreenSing.AddStatic(Theme.Sing.StaticP1TwoP);
-  StaticP2R[0]      := ScreenSing.AddStatic(Theme.Sing.StaticP2R);
+  StaticP2R[0]      := ScreenSing.AddStatic(Theme.Sing.Solo2PP2.AvatarFrame);
   StaticP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.StaticP1ThreeP);
   StaticP2M[0]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP2.AvatarFrame);
   StaticP3R[0]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP3.AvatarFrame);
@@ -601,9 +601,9 @@ begin
   Theme.Sing.StaticP1TwoP.ColB := Col[3].B;
 
   //                | P2
-  Theme.Sing.StaticP2R.ColR := Col[4].R;
-  Theme.Sing.StaticP2R.ColG := Col[4].G;
-  Theme.Sing.StaticP2R.ColB := Col[4].B;
+  Theme.Sing.Solo2PP2.AvatarFrame.ColR := Col[4].R;
+  Theme.Sing.Solo2PP2.AvatarFrame.ColG := Col[4].G;
+  Theme.Sing.Solo2PP2.AvatarFrame.ColB := Col[4].B;
 
   // 3 or 6 players | P1
   Theme.Sing.StaticP1ThreeP.ColR := Col[4].R;
@@ -637,7 +637,7 @@ begin
 
   StaticP1[1]       := ScreenSing.AddStatic(Theme.Sing.StaticP1);
   StaticP1TwoP[1]   := ScreenSing.AddStatic(Theme.Sing.StaticP1TwoP);
-  StaticP2R[1]      := ScreenSing.AddStatic(Theme.Sing.StaticP2R);
+  StaticP2R[1]      := ScreenSing.AddStatic(Theme.Sing.Solo2PP2.AvatarFrame);
   StaticP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.StaticP1ThreeP);
   StaticP2M[1]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP2.AvatarFrame);
   StaticP3R[1]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP3.AvatarFrame);
@@ -647,7 +647,7 @@ begin
 
   TextP1   := ScreenSing.AddText(Theme.Sing.TextP1);
   TextP1TwoP   := ScreenSing.AddText(Theme.Sing.TextP1TwoP);
-  TextP2R   := ScreenSing.AddText(Theme.Sing.TextP2R);
+  TextP2R   := ScreenSing.AddText(Theme.Sing.Solo2PP2.Name);
   TextP1ThreeP   := ScreenSing.AddText(Theme.Sing.TextP1ThreeP);
   TextP2M   := ScreenSing.AddText(Theme.Sing.Solo3PP2.Name);
   TextP3R   := ScreenSing.AddText(Theme.Sing.Solo3PP3.Name);
@@ -922,23 +922,23 @@ begin
   ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture.Z := Theme.Sing.StaticP1TwoPAvatar.Z;
   ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture.Alpha := Theme.Sing.StaticP1TwoPAvatar.Alpha;
 
-  StaticP2RAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP2RAvatar);
+  StaticP2RAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo2PP2.Avatar);
   ScreenSing.Statics[StaticP2RAvatar[0]].Texture := AvatarPlayerTextures[2];
-  ScreenSing.Statics[StaticP2RAvatar[0]].Texture.X  := Theme.Sing.StaticP2RAvatar.X;
-  ScreenSing.Statics[StaticP2RAvatar[0]].Texture.Y  := Theme.Sing.StaticP2RAvatar.Y;
-  ScreenSing.Statics[StaticP2RAvatar[0]].Texture.H  := Theme.Sing.StaticP2RAvatar.H;
-  ScreenSing.Statics[StaticP2RAvatar[0]].Texture.W  := Theme.Sing.StaticP2RAvatar.W;
-  ScreenSing.Statics[StaticP2RAvatar[0]].Texture.Z := Theme.Sing.StaticP2RAvatar.Z;
-  ScreenSing.Statics[StaticP2RAvatar[0]].Texture.Alpha := Theme.Sing.StaticP2RAvatar.Alpha;
+  ScreenSing.Statics[StaticP2RAvatar[0]].Texture.X  := Theme.Sing.Solo2PP2.Avatar.X;
+  ScreenSing.Statics[StaticP2RAvatar[0]].Texture.Y  := Theme.Sing.Solo2PP2.Avatar.Y;
+  ScreenSing.Statics[StaticP2RAvatar[0]].Texture.H  := Theme.Sing.Solo2PP2.Avatar.H;
+  ScreenSing.Statics[StaticP2RAvatar[0]].Texture.W  := Theme.Sing.Solo2PP2.Avatar.W;
+  ScreenSing.Statics[StaticP2RAvatar[0]].Texture.Z := Theme.Sing.Solo2PP2.Avatar.Z;
+  ScreenSing.Statics[StaticP2RAvatar[0]].Texture.Alpha := Theme.Sing.Solo2PP2.Avatar.Alpha;
 
-  StaticP2RAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP2RAvatar);
+  StaticP2RAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo2PP2.Avatar);
   ScreenSing.Statics[StaticP2RAvatar[1]].Texture := AvatarPlayerTextures[4];
-  ScreenSing.Statics[StaticP2RAvatar[1]].Texture.X  := Theme.Sing.StaticP2RAvatar.X;
-  ScreenSing.Statics[StaticP2RAvatar[1]].Texture.Y  := Theme.Sing.StaticP2RAvatar.Y;
-  ScreenSing.Statics[StaticP2RAvatar[1]].Texture.H  := Theme.Sing.StaticP2RAvatar.H;
-  ScreenSing.Statics[StaticP2RAvatar[1]].Texture.W  := Theme.Sing.StaticP2RAvatar.W;
-  ScreenSing.Statics[StaticP2RAvatar[1]].Texture.Z := Theme.Sing.StaticP2RAvatar.Z;
-  ScreenSing.Statics[StaticP2RAvatar[1]].Texture.Alpha := Theme.Sing.StaticP2RAvatar.Alpha;
+  ScreenSing.Statics[StaticP2RAvatar[1]].Texture.X  := Theme.Sing.Solo2PP2.Avatar.X;
+  ScreenSing.Statics[StaticP2RAvatar[1]].Texture.Y  := Theme.Sing.Solo2PP2.Avatar.Y;
+  ScreenSing.Statics[StaticP2RAvatar[1]].Texture.H  := Theme.Sing.Solo2PP2.Avatar.H;
+  ScreenSing.Statics[StaticP2RAvatar[1]].Texture.W  := Theme.Sing.Solo2PP2.Avatar.W;
+  ScreenSing.Statics[StaticP2RAvatar[1]].Texture.Z := Theme.Sing.Solo2PP2.Avatar.Z;
+  ScreenSing.Statics[StaticP2RAvatar[1]].Texture.Alpha := Theme.Sing.Solo2PP2.Avatar.Alpha;
 
   StaticP1ThreePAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP1ThreePAvatar);
   ScreenSing.Statics[StaticP1ThreePAvatar[0]].Texture := AvatarPlayerTextures[1];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -675,9 +675,9 @@ begin
   Theme.Sing.Solo4PP1.AvatarFrame.ColB := Col[1].B;
 
   // P2
-  Theme.Sing.StaticP2FourP.ColR := Col[2].R;
-  Theme.Sing.StaticP2FourP.ColG := Col[2].G;
-  Theme.Sing.StaticP2FourP.ColB := Col[2].B;
+  Theme.Sing.Solo4PP2.AvatarFrame.ColR := Col[2].R;
+  Theme.Sing.Solo4PP2.AvatarFrame.ColG := Col[2].G;
+  Theme.Sing.Solo4PP2.AvatarFrame.ColB := Col[2].B;
 
   // P3
   Theme.Sing.StaticP3FourP.ColR := Col[3].R;
@@ -690,12 +690,12 @@ begin
   Theme.Sing.StaticP4FourP.ColB := Col[4].B;
 
   StaticP1FourP   := ScreenSing.AddStatic(Theme.Sing.Solo4PP1.AvatarFrame);
-  StaticP2FourP   := ScreenSing.AddStatic(Theme.Sing.StaticP2FourP);
+  StaticP2FourP   := ScreenSing.AddStatic(Theme.Sing.Solo4PP2.AvatarFrame);
   StaticP3FourP   := ScreenSing.AddStatic(Theme.Sing.StaticP3FourP);
   StaticP4FourP   := ScreenSing.AddStatic(Theme.Sing.StaticP4FourP);
 
   TextP1FourP   := ScreenSing.AddText(Theme.Sing.Solo4PP1.Name);
-  TextP2FourP   := ScreenSing.AddText(Theme.Sing.TextP2FourP);
+  TextP2FourP   := ScreenSing.AddText(Theme.Sing.Solo4PP2.Name);
   TextP3FourP   := ScreenSing.AddText(Theme.Sing.TextP3FourP);
   TextP4FourP   := ScreenSing.AddText(Theme.Sing.TextP4FourP);
 
@@ -1057,14 +1057,14 @@ begin
   ScreenSing.Statics[StaticP1FourPAvatar].Texture.Z := Theme.Sing.Solo4PP1.Avatar.Z;
   ScreenSing.Statics[StaticP1FourPAvatar].Texture.Alpha := Theme.Sing.Solo4PP1.Avatar.Alpha;
 
-  StaticP2FourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP2FourPAvatar);
+  StaticP2FourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo4PP2.Avatar);
   ScreenSing.Statics[StaticP2FourPAvatar].Texture := AvatarPlayerTextures[2];
-  ScreenSing.Statics[StaticP2FourPAvatar].Texture.X  := Theme.Sing.StaticP2FourPAvatar.X;
-  ScreenSing.Statics[StaticP2FourPAvatar].Texture.Y  := Theme.Sing.StaticP2FourPAvatar.Y;
-  ScreenSing.Statics[StaticP2FourPAvatar].Texture.H  := Theme.Sing.StaticP2FourPAvatar.H;
-  ScreenSing.Statics[StaticP2FourPAvatar].Texture.W  := Theme.Sing.StaticP2FourPAvatar.W;
-  ScreenSing.Statics[StaticP2FourPAvatar].Texture.Z := Theme.Sing.StaticP2FourPAvatar.Z;
-  ScreenSing.Statics[StaticP2FourPAvatar].Texture.Alpha := Theme.Sing.StaticP2FourPAvatar.Alpha;
+  ScreenSing.Statics[StaticP2FourPAvatar].Texture.X  := Theme.Sing.Solo4PP2.Avatar.X;
+  ScreenSing.Statics[StaticP2FourPAvatar].Texture.Y  := Theme.Sing.Solo4PP2.Avatar.Y;
+  ScreenSing.Statics[StaticP2FourPAvatar].Texture.H  := Theme.Sing.Solo4PP2.Avatar.H;
+  ScreenSing.Statics[StaticP2FourPAvatar].Texture.W  := Theme.Sing.Solo4PP2.Avatar.W;
+  ScreenSing.Statics[StaticP2FourPAvatar].Texture.Z := Theme.Sing.Solo4PP2.Avatar.Z;
+  ScreenSing.Statics[StaticP2FourPAvatar].Texture.Alpha := Theme.Sing.Solo4PP2.Avatar.Alpha;
 
   StaticP3FourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP3FourPAvatar);
   ScreenSing.Statics[StaticP3FourPAvatar].Texture := AvatarPlayerTextures[3];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -761,19 +761,19 @@ begin
   Theme.Sing.Duet4PP3.AvatarFrame.ColB := Col[3].B;
 
   // P4
-  Theme.Sing.StaticP4DuetFourP.ColR := Col[4].R;
-  Theme.Sing.StaticP4DuetFourP.ColG := Col[4].G;
-  Theme.Sing.StaticP4DuetFourP.ColB := Col[4].B;
+  Theme.Sing.Duet4PP4.AvatarFrame.ColR := Col[4].R;
+  Theme.Sing.Duet4PP4.AvatarFrame.ColG := Col[4].G;
+  Theme.Sing.Duet4PP4.AvatarFrame.ColB := Col[4].B;
 
   StaticP1DuetFourP   := ScreenSing.AddStatic(Theme.Sing.Duet4PP1.AvatarFrame);
   StaticP2DuetFourP   := ScreenSing.AddStatic(Theme.Sing.Duet4PP2.AvatarFrame);
   StaticP3DuetFourP   := ScreenSing.AddStatic(Theme.Sing.Duet4PP3.AvatarFrame);
-  StaticP4DuetFourP   := ScreenSing.AddStatic(Theme.Sing.StaticP4DuetFourP);
+  StaticP4DuetFourP   := ScreenSing.AddStatic(Theme.Sing.Duet4PP4.AvatarFrame);
 
   TextP1DuetFourP   := ScreenSing.AddText(Theme.Sing.Duet4PP1.Name);
   TextP2DuetFourP   := ScreenSing.AddText(Theme.Sing.Duet4PP2.Name);
   TextP3DuetFourP   := ScreenSing.AddText(Theme.Sing.Duet4PP3.Name);
-  TextP4DuetFourP   := ScreenSing.AddText(Theme.Sing.TextP4DuetFourP);
+  TextP4DuetFourP   := ScreenSing.AddText(Theme.Sing.Duet4PP4.Name);
 
   // P1
   Theme.Sing.StaticP1DuetSixP.ColR := Col[1].R;
@@ -1111,14 +1111,14 @@ begin
   ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture.Z := Theme.Sing.Duet4PP3.Avatar.Z;
   ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture.Alpha := Theme.Sing.Duet4PP3.Avatar.Alpha;
 
-  StaticP4DuetFourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP4DuetFourPAvatar);
+  StaticP4DuetFourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet4PP4.Avatar);
   ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture := AvatarPlayerTextures[4];
-  ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture.X  := Theme.Sing.StaticP4DuetFourPAvatar.X;
-  ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture.Y  := Theme.Sing.StaticP4DuetFourPAvatar.Y;
-  ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture.H  := Theme.Sing.StaticP4DuetFourPAvatar.H;
-  ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture.W  := Theme.Sing.StaticP4DuetFourPAvatar.W;
-  ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture.Z := Theme.Sing.StaticP4DuetFourPAvatar.Z;
-  ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture.Alpha := Theme.Sing.StaticP4DuetFourPAvatar.Alpha;
+  ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture.X  := Theme.Sing.Duet4PP4.Avatar.X;
+  ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture.Y  := Theme.Sing.Duet4PP4.Avatar.Y;
+  ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture.H  := Theme.Sing.Duet4PP4.Avatar.H;
+  ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture.W  := Theme.Sing.Duet4PP4.Avatar.W;
+  ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture.Z := Theme.Sing.Duet4PP4.Avatar.Z;
+  ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture.Alpha := Theme.Sing.Duet4PP4.Avatar.Alpha;
 
   StaticP1SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo6PP1.Avatar);
   ScreenSing.Statics[StaticP1SixPAvatar].Texture := AvatarPlayerTextures[1];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -538,9 +538,9 @@ begin
   Theme.Sing.StaticP1.ColB := Col[1].B;
 
   // 2 or 4 players | P1
-  Theme.Sing.StaticP1TwoP.ColR := Col[1].R;
-  Theme.Sing.StaticP1TwoP.ColG := Col[1].G;
-  Theme.Sing.StaticP1TwoP.ColB := Col[1].B;
+  Theme.Sing.Solo2PP1.AvatarFrame.ColR := Col[1].R;
+  Theme.Sing.Solo2PP1.AvatarFrame.ColG := Col[1].G;
+  Theme.Sing.Solo2PP1.AvatarFrame.ColB := Col[1].B;
 
   //                | P2
   Theme.Sing.Solo2PP2.AvatarFrame.ColR := Col[2].R;
@@ -580,7 +580,7 @@ begin
   Theme.Sing.Duet3PP3.AvatarFrame.ColB := Col[3].B;
 
   StaticP1[0]       := ScreenSing.AddStatic(Theme.Sing.StaticP1);
-  StaticP1TwoP[0]   := ScreenSing.AddStatic(Theme.Sing.StaticP1TwoP);
+  StaticP1TwoP[0]   := ScreenSing.AddStatic(Theme.Sing.Solo2PP1.AvatarFrame);
   StaticP2R[0]      := ScreenSing.AddStatic(Theme.Sing.Solo2PP2.AvatarFrame);
   StaticP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.Solo3PP1.AvatarFrame);
   StaticP2M[0]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP2.AvatarFrame);
@@ -596,9 +596,9 @@ begin
   Theme.Sing.StaticP1.ColB := Col[1].B;
 
   // 2 or 4 players | P1
-  Theme.Sing.StaticP1TwoP.ColR := Col[3].R;
-  Theme.Sing.StaticP1TwoP.ColG := Col[3].G;
-  Theme.Sing.StaticP1TwoP.ColB := Col[3].B;
+  Theme.Sing.Solo2PP1.AvatarFrame.ColR := Col[3].R;
+  Theme.Sing.Solo2PP1.AvatarFrame.ColG := Col[3].G;
+  Theme.Sing.Solo2PP1.AvatarFrame.ColB := Col[3].B;
 
   //                | P2
   Theme.Sing.Solo2PP2.AvatarFrame.ColR := Col[4].R;
@@ -636,7 +636,7 @@ begin
   Theme.Sing.Duet3PP3.AvatarFrame.ColB := Col[6].B;
 
   StaticP1[1]       := ScreenSing.AddStatic(Theme.Sing.StaticP1);
-  StaticP1TwoP[1]   := ScreenSing.AddStatic(Theme.Sing.StaticP1TwoP);
+  StaticP1TwoP[1]   := ScreenSing.AddStatic(Theme.Sing.Solo2PP1.AvatarFrame);
   StaticP2R[1]      := ScreenSing.AddStatic(Theme.Sing.Solo2PP2.AvatarFrame);
   StaticP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.Solo3PP1.AvatarFrame);
   StaticP2M[1]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP2.AvatarFrame);
@@ -646,7 +646,7 @@ begin
   StaticDuetP3R[1]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP3.AvatarFrame);
 
   TextP1   := ScreenSing.AddText(Theme.Sing.TextP1);
-  TextP1TwoP   := ScreenSing.AddText(Theme.Sing.TextP1TwoP);
+  TextP1TwoP   := ScreenSing.AddText(Theme.Sing.Solo2PP1.Name);
   TextP2R   := ScreenSing.AddText(Theme.Sing.Solo2PP2.Name);
   TextP1ThreeP   := ScreenSing.AddText(Theme.Sing.Solo3PP1.Name);
   TextP2M   := ScreenSing.AddText(Theme.Sing.Solo3PP2.Name);
@@ -904,23 +904,23 @@ begin
   ScreenSing.Statics[StaticP1Avatar[1]].Texture.Z := Theme.Sing.StaticP1Avatar.Z;
   ScreenSing.Statics[StaticP1Avatar[1]].Texture.Alpha := Theme.Sing.StaticP1Avatar.Alpha;
 
-  StaticP1TwoPAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP1TwoPAvatar);
+  StaticP1TwoPAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo2PP1.Avatar);
   ScreenSing.Statics[StaticP1TwoPAvatar[0]].Texture := AvatarPlayerTextures[1];
-  ScreenSing.Statics[StaticP1TwoPAvatar[0]].Texture.X  := Theme.Sing.StaticP1TwoPAvatar.X;
-  ScreenSing.Statics[StaticP1TwoPAvatar[0]].Texture.Y  := Theme.Sing.StaticP1TwoPAvatar.Y;
-  ScreenSing.Statics[StaticP1TwoPAvatar[0]].Texture.H  := Theme.Sing.StaticP1TwoPAvatar.H;
-  ScreenSing.Statics[StaticP1TwoPAvatar[0]].Texture.W  := Theme.Sing.StaticP1TwoPAvatar.W;
-  ScreenSing.Statics[StaticP1TwoPAvatar[0]].Texture.Z := Theme.Sing.StaticP1TwoPAvatar.Z;
-  ScreenSing.Statics[StaticP1TwoPAvatar[0]].Texture.Alpha := Theme.Sing.StaticP1TwoPAvatar.Alpha;
+  ScreenSing.Statics[StaticP1TwoPAvatar[0]].Texture.X  := Theme.Sing.Solo2PP1.Avatar.X;
+  ScreenSing.Statics[StaticP1TwoPAvatar[0]].Texture.Y  := Theme.Sing.Solo2PP1.Avatar.Y;
+  ScreenSing.Statics[StaticP1TwoPAvatar[0]].Texture.H  := Theme.Sing.Solo2PP1.Avatar.H;
+  ScreenSing.Statics[StaticP1TwoPAvatar[0]].Texture.W  := Theme.Sing.Solo2PP1.Avatar.W;
+  ScreenSing.Statics[StaticP1TwoPAvatar[0]].Texture.Z := Theme.Sing.Solo2PP1.Avatar.Z;
+  ScreenSing.Statics[StaticP1TwoPAvatar[0]].Texture.Alpha := Theme.Sing.Solo2PP1.Avatar.Alpha;
 
-  StaticP1TwoPAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP1TwoPAvatar);
+  StaticP1TwoPAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo2PP1.Avatar);
   ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture := AvatarPlayerTextures[3];
-  ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture.X  := Theme.Sing.StaticP1TwoPAvatar.X;
-  ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture.Y  := Theme.Sing.StaticP1TwoPAvatar.Y;
-  ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture.H  := Theme.Sing.StaticP1TwoPAvatar.H;
-  ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture.W  := Theme.Sing.StaticP1TwoPAvatar.W;
-  ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture.Z := Theme.Sing.StaticP1TwoPAvatar.Z;
-  ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture.Alpha := Theme.Sing.StaticP1TwoPAvatar.Alpha;
+  ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture.X  := Theme.Sing.Solo2PP1.Avatar.X;
+  ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture.Y  := Theme.Sing.Solo2PP1.Avatar.Y;
+  ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture.H  := Theme.Sing.Solo2PP1.Avatar.H;
+  ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture.W  := Theme.Sing.Solo2PP1.Avatar.W;
+  ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture.Z := Theme.Sing.Solo2PP1.Avatar.Z;
+  ScreenSing.Statics[StaticP1TwoPAvatar[1]].Texture.Alpha := Theme.Sing.Solo2PP1.Avatar.Alpha;
 
   StaticP2RAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo2PP2.Avatar);
   ScreenSing.Statics[StaticP2RAvatar[0]].Texture := AvatarPlayerTextures[2];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -720,9 +720,9 @@ begin
   Theme.Sing.Solo6PP4.AvatarFrame.ColB := Col[4].B;
 
   // P5
-  Theme.Sing.StaticP5SixP.ColR := Col[5].R;
-  Theme.Sing.StaticP5SixP.ColG := Col[5].G;
-  Theme.Sing.StaticP5SixP.ColB := Col[5].B;
+  Theme.Sing.Solo6PP5.AvatarFrame.ColR := Col[5].R;
+  Theme.Sing.Solo6PP5.AvatarFrame.ColG := Col[5].G;
+  Theme.Sing.Solo6PP5.AvatarFrame.ColB := Col[5].B;
 
   // P6
   Theme.Sing.StaticP6SixP.ColR := Col[6].R;
@@ -733,14 +733,14 @@ begin
   StaticP2SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP2.AvatarFrame);
   StaticP3SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP3.AvatarFrame);
   StaticP4SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP4.AvatarFrame);
-  StaticP5SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP5SixP);
+  StaticP5SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP5.AvatarFrame);
   StaticP6SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP6SixP);
 
   TextP1SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP1.Name);
   TextP2SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP2.Name);
   TextP3SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP3.Name);
   TextP4SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP4.Name);
-  TextP5SixP   := ScreenSing.AddText(Theme.Sing.TextP5SixP);
+  TextP5SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP5.Name);
   TextP6SixP   := ScreenSing.AddText(Theme.Sing.TextP6SixP);
 
 
@@ -1156,14 +1156,14 @@ begin
   ScreenSing.Statics[StaticP4SixPAvatar].Texture.Z := Theme.Sing.Solo6PP4.Avatar.Z;
   ScreenSing.Statics[StaticP4SixPAvatar].Texture.Alpha := Theme.Sing.Solo6PP4.Avatar.Alpha;
 
-  StaticP5SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP5SixPAvatar);
+  StaticP5SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo6PP5.Avatar);
   ScreenSing.Statics[StaticP5SixPAvatar].Texture := AvatarPlayerTextures[5];
-  ScreenSing.Statics[StaticP5SixPAvatar].Texture.X  := Theme.Sing.StaticP5SixPAvatar.X;
-  ScreenSing.Statics[StaticP5SixPAvatar].Texture.Y  := Theme.Sing.StaticP5SixPAvatar.Y;
-  ScreenSing.Statics[StaticP5SixPAvatar].Texture.H  := Theme.Sing.StaticP5SixPAvatar.H;
-  ScreenSing.Statics[StaticP5SixPAvatar].Texture.W  := Theme.Sing.StaticP5SixPAvatar.W;
-  ScreenSing.Statics[StaticP5SixPAvatar].Texture.Z := Theme.Sing.StaticP5SixPAvatar.Z;
-  ScreenSing.Statics[StaticP5SixPAvatar].Texture.Alpha := Theme.Sing.StaticP5SixPAvatar.Alpha;
+  ScreenSing.Statics[StaticP5SixPAvatar].Texture.X  := Theme.Sing.Solo6PP5.Avatar.X;
+  ScreenSing.Statics[StaticP5SixPAvatar].Texture.Y  := Theme.Sing.Solo6PP5.Avatar.Y;
+  ScreenSing.Statics[StaticP5SixPAvatar].Texture.H  := Theme.Sing.Solo6PP5.Avatar.H;
+  ScreenSing.Statics[StaticP5SixPAvatar].Texture.W  := Theme.Sing.Solo6PP5.Avatar.W;
+  ScreenSing.Statics[StaticP5SixPAvatar].Texture.Z := Theme.Sing.Solo6PP5.Avatar.Z;
+  ScreenSing.Statics[StaticP5SixPAvatar].Texture.Alpha := Theme.Sing.Solo6PP5.Avatar.Alpha;
 
   StaticP6SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP6SixPAvatar);
   ScreenSing.Statics[StaticP6SixPAvatar].Texture := AvatarPlayerTextures[6];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -710,9 +710,9 @@ begin
   Theme.Sing.Solo6PP2.AvatarFrame.ColB := Col[2].B;
 
   // P3
-  Theme.Sing.StaticP3SixP.ColR := Col[3].R;
-  Theme.Sing.StaticP3SixP.ColG := Col[3].G;
-  Theme.Sing.StaticP3SixP.ColB := Col[3].B;
+  Theme.Sing.Solo6PP3.AvatarFrame.ColR := Col[3].R;
+  Theme.Sing.Solo6PP3.AvatarFrame.ColG := Col[3].G;
+  Theme.Sing.Solo6PP3.AvatarFrame.ColB := Col[3].B;
 
   // P4
   Theme.Sing.StaticP4SixP.ColR := Col[4].R;
@@ -731,14 +731,14 @@ begin
 
   StaticP1SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP1.AvatarFrame);
   StaticP2SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP2.AvatarFrame);
-  StaticP3SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP3SixP);
+  StaticP3SixP  := ScreenSing.AddStatic(Theme.Sing.Solo6PP3.AvatarFrame);
   StaticP4SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP4SixP);
   StaticP5SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP5SixP);
   StaticP6SixP  := ScreenSing.AddStatic(Theme.Sing.StaticP6SixP);
 
   TextP1SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP1.Name);
   TextP2SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP2.Name);
-  TextP3SixP   := ScreenSing.AddText(Theme.Sing.TextP3SixP);
+  TextP3SixP   := ScreenSing.AddText(Theme.Sing.Solo6PP3.Name);
   TextP4SixP   := ScreenSing.AddText(Theme.Sing.TextP4SixP);
   TextP5SixP   := ScreenSing.AddText(Theme.Sing.TextP5SixP);
   TextP6SixP   := ScreenSing.AddText(Theme.Sing.TextP6SixP);
@@ -1138,14 +1138,14 @@ begin
   ScreenSing.Statics[StaticP2SixPAvatar].Texture.Z := Theme.Sing.Solo6PP2.Avatar.Z;
   ScreenSing.Statics[StaticP2SixPAvatar].Texture.Alpha := Theme.Sing.Solo6PP2.Avatar.Alpha;
 
-  StaticP3SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP3SixPAvatar);
+  StaticP3SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo6PP3.Avatar);
   ScreenSing.Statics[StaticP3SixPAvatar].Texture := AvatarPlayerTextures[3];
-  ScreenSing.Statics[StaticP3SixPAvatar].Texture.X  := Theme.Sing.StaticP3SixPAvatar.X;
-  ScreenSing.Statics[StaticP3SixPAvatar].Texture.Y  := Theme.Sing.StaticP3SixPAvatar.Y;
-  ScreenSing.Statics[StaticP3SixPAvatar].Texture.H  := Theme.Sing.StaticP3SixPAvatar.H;
-  ScreenSing.Statics[StaticP3SixPAvatar].Texture.W  := Theme.Sing.StaticP3SixPAvatar.W;
-  ScreenSing.Statics[StaticP3SixPAvatar].Texture.Z := Theme.Sing.StaticP3SixPAvatar.Z;
-  ScreenSing.Statics[StaticP3SixPAvatar].Texture.Alpha := Theme.Sing.StaticP3SixPAvatar.Alpha;
+  ScreenSing.Statics[StaticP3SixPAvatar].Texture.X  := Theme.Sing.Solo6PP3.Avatar.X;
+  ScreenSing.Statics[StaticP3SixPAvatar].Texture.Y  := Theme.Sing.Solo6PP3.Avatar.Y;
+  ScreenSing.Statics[StaticP3SixPAvatar].Texture.H  := Theme.Sing.Solo6PP3.Avatar.H;
+  ScreenSing.Statics[StaticP3SixPAvatar].Texture.W  := Theme.Sing.Solo6PP3.Avatar.W;
+  ScreenSing.Statics[StaticP3SixPAvatar].Texture.Z := Theme.Sing.Solo6PP3.Avatar.Z;
+  ScreenSing.Statics[StaticP3SixPAvatar].Texture.Alpha := Theme.Sing.Solo6PP3.Avatar.Alpha;
 
   StaticP4SixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP4SixPAvatar);
   ScreenSing.Statics[StaticP4SixPAvatar].Texture := AvatarPlayerTextures[4];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -533,9 +533,9 @@ begin
 
   // SCREEN 1
   // 1 player       | P1
-  Theme.Sing.StaticP1.ColR := Col[1].R;
-  Theme.Sing.StaticP1.ColG := Col[1].G;
-  Theme.Sing.StaticP1.ColB := Col[1].B;
+  Theme.Sing.Solo1PP1.AvatarFrame.ColR := Col[1].R;
+  Theme.Sing.Solo1PP1.AvatarFrame.ColG := Col[1].G;
+  Theme.Sing.Solo1PP1.AvatarFrame.ColB := Col[1].B;
 
   // 2 or 4 players | P1
   Theme.Sing.Solo2PP1.AvatarFrame.ColR := Col[1].R;
@@ -579,7 +579,7 @@ begin
   Theme.Sing.Duet3PP3.AvatarFrame.ColG := Col[3].G;
   Theme.Sing.Duet3PP3.AvatarFrame.ColB := Col[3].B;
 
-  StaticP1[0]       := ScreenSing.AddStatic(Theme.Sing.StaticP1);
+  StaticP1[0]       := ScreenSing.AddStatic(Theme.Sing.Solo1PP1.AvatarFrame);
   StaticP1TwoP[0]   := ScreenSing.AddStatic(Theme.Sing.Solo2PP1.AvatarFrame);
   StaticP2R[0]      := ScreenSing.AddStatic(Theme.Sing.Solo2PP2.AvatarFrame);
   StaticP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.Solo3PP1.AvatarFrame);
@@ -591,9 +591,9 @@ begin
 
   // SCREEN 2
   // 1 player       | P1
-  Theme.Sing.StaticP1.ColR := Col[1].R;
-  Theme.Sing.StaticP1.ColG := Col[1].G;
-  Theme.Sing.StaticP1.ColB := Col[1].B;
+  Theme.Sing.Solo1PP1.AvatarFrame.ColR := Col[1].R;
+  Theme.Sing.Solo1PP1.AvatarFrame.ColG := Col[1].G;
+  Theme.Sing.Solo1PP1.AvatarFrame.ColB := Col[1].B;
 
   // 2 or 4 players | P1
   Theme.Sing.Solo2PP1.AvatarFrame.ColR := Col[3].R;
@@ -635,7 +635,7 @@ begin
   Theme.Sing.Duet3PP3.AvatarFrame.ColG := Col[6].G;
   Theme.Sing.Duet3PP3.AvatarFrame.ColB := Col[6].B;
 
-  StaticP1[1]       := ScreenSing.AddStatic(Theme.Sing.StaticP1);
+  StaticP1[1]       := ScreenSing.AddStatic(Theme.Sing.Solo1PP1.AvatarFrame);
   StaticP1TwoP[1]   := ScreenSing.AddStatic(Theme.Sing.Solo2PP1.AvatarFrame);
   StaticP2R[1]      := ScreenSing.AddStatic(Theme.Sing.Solo2PP2.AvatarFrame);
   StaticP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.Solo3PP1.AvatarFrame);
@@ -645,7 +645,7 @@ begin
   StaticDuetP2M[1]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP2.AvatarFrame);
   StaticDuetP3R[1]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP3.AvatarFrame);
 
-  TextP1   := ScreenSing.AddText(Theme.Sing.TextP1);
+  TextP1   := ScreenSing.AddText(Theme.Sing.Solo1PP1.Name);
   TextP1TwoP   := ScreenSing.AddText(Theme.Sing.Solo2PP1.Name);
   TextP2R   := ScreenSing.AddText(Theme.Sing.Solo2PP2.Name);
   TextP1ThreeP   := ScreenSing.AddText(Theme.Sing.Solo3PP1.Name);
@@ -886,23 +886,23 @@ begin
   ScreenSing.InfoMessageText := ScreenSing.AddText(Theme.Sing.InfoMessageText);
 
   // avatars
-  StaticP1Avatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP1Avatar);
+  StaticP1Avatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo1PP1.Avatar);
   ScreenSing.Statics[StaticP1Avatar[0]].Texture := AvatarPlayerTextures[1];
-  ScreenSing.Statics[StaticP1Avatar[0]].Texture.X  := Theme.Sing.StaticP1Avatar.X;
-  ScreenSing.Statics[StaticP1Avatar[0]].Texture.Y  := Theme.Sing.StaticP1Avatar.Y;
-  ScreenSing.Statics[StaticP1Avatar[0]].Texture.H  := Theme.Sing.StaticP1Avatar.H;
-  ScreenSing.Statics[StaticP1Avatar[0]].Texture.W  := Theme.Sing.StaticP1Avatar.W;
-  ScreenSing.Statics[StaticP1Avatar[0]].Texture.Z := Theme.Sing.StaticP1Avatar.Z;
-  ScreenSing.Statics[StaticP1Avatar[0]].Texture.Alpha := Theme.Sing.StaticP1Avatar.Alpha;
+  ScreenSing.Statics[StaticP1Avatar[0]].Texture.X  := Theme.Sing.Solo1PP1.Avatar.X;
+  ScreenSing.Statics[StaticP1Avatar[0]].Texture.Y  := Theme.Sing.Solo1PP1.Avatar.Y;
+  ScreenSing.Statics[StaticP1Avatar[0]].Texture.H  := Theme.Sing.Solo1PP1.Avatar.H;
+  ScreenSing.Statics[StaticP1Avatar[0]].Texture.W  := Theme.Sing.Solo1PP1.Avatar.W;
+  ScreenSing.Statics[StaticP1Avatar[0]].Texture.Z := Theme.Sing.Solo1PP1.Avatar.Z;
+  ScreenSing.Statics[StaticP1Avatar[0]].Texture.Alpha := Theme.Sing.Solo1PP1.Avatar.Alpha;
 
-  StaticP1Avatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP1Avatar);
+  StaticP1Avatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo1PP1.Avatar);
   ScreenSing.Statics[StaticP1Avatar[1]].Texture := AvatarPlayerTextures[2];
-  ScreenSing.Statics[StaticP1Avatar[1]].Texture.X  := Theme.Sing.StaticP1Avatar.X;
-  ScreenSing.Statics[StaticP1Avatar[1]].Texture.Y  := Theme.Sing.StaticP1Avatar.Y;
-  ScreenSing.Statics[StaticP1Avatar[1]].Texture.H  := Theme.Sing.StaticP1Avatar.H;
-  ScreenSing.Statics[StaticP1Avatar[1]].Texture.W  := Theme.Sing.StaticP1Avatar.W;
-  ScreenSing.Statics[StaticP1Avatar[1]].Texture.Z := Theme.Sing.StaticP1Avatar.Z;
-  ScreenSing.Statics[StaticP1Avatar[1]].Texture.Alpha := Theme.Sing.StaticP1Avatar.Alpha;
+  ScreenSing.Statics[StaticP1Avatar[1]].Texture.X  := Theme.Sing.Solo1PP1.Avatar.X;
+  ScreenSing.Statics[StaticP1Avatar[1]].Texture.Y  := Theme.Sing.Solo1PP1.Avatar.Y;
+  ScreenSing.Statics[StaticP1Avatar[1]].Texture.H  := Theme.Sing.Solo1PP1.Avatar.H;
+  ScreenSing.Statics[StaticP1Avatar[1]].Texture.W  := Theme.Sing.Solo1PP1.Avatar.W;
+  ScreenSing.Statics[StaticP1Avatar[1]].Texture.Z := Theme.Sing.Solo1PP1.Avatar.Z;
+  ScreenSing.Statics[StaticP1Avatar[1]].Texture.Alpha := Theme.Sing.Solo1PP1.Avatar.Alpha;
 
   StaticP1TwoPAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo2PP1.Avatar);
   ScreenSing.Statics[StaticP1TwoPAvatar[0]].Texture := AvatarPlayerTextures[1];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -751,9 +751,9 @@ begin
   Theme.Sing.Duet4PP1.AvatarFrame.ColB := Col[1].B;
 
   // P2
-  Theme.Sing.StaticP2DuetFourP.ColR := Col[2].R;
-  Theme.Sing.StaticP2DuetFourP.ColG := Col[2].G;
-  Theme.Sing.StaticP2DuetFourP.ColB := Col[2].B;
+  Theme.Sing.Duet4PP2.AvatarFrame.ColR := Col[2].R;
+  Theme.Sing.Duet4PP2.AvatarFrame.ColG := Col[2].G;
+  Theme.Sing.Duet4PP2.AvatarFrame.ColB := Col[2].B;
 
   // P3
   Theme.Sing.StaticP3DuetFourP.ColR := Col[3].R;
@@ -766,12 +766,12 @@ begin
   Theme.Sing.StaticP4DuetFourP.ColB := Col[4].B;
 
   StaticP1DuetFourP   := ScreenSing.AddStatic(Theme.Sing.Duet4PP1.AvatarFrame);
-  StaticP2DuetFourP   := ScreenSing.AddStatic(Theme.Sing.StaticP2DuetFourP);
+  StaticP2DuetFourP   := ScreenSing.AddStatic(Theme.Sing.Duet4PP2.AvatarFrame);
   StaticP3DuetFourP   := ScreenSing.AddStatic(Theme.Sing.StaticP3DuetFourP);
   StaticP4DuetFourP   := ScreenSing.AddStatic(Theme.Sing.StaticP4DuetFourP);
 
   TextP1DuetFourP   := ScreenSing.AddText(Theme.Sing.Duet4PP1.Name);
-  TextP2DuetFourP   := ScreenSing.AddText(Theme.Sing.TextP2DuetFourP);
+  TextP2DuetFourP   := ScreenSing.AddText(Theme.Sing.Duet4PP2.Name);
   TextP3DuetFourP   := ScreenSing.AddText(Theme.Sing.TextP3DuetFourP);
   TextP4DuetFourP   := ScreenSing.AddText(Theme.Sing.TextP4DuetFourP);
 
@@ -1093,14 +1093,14 @@ begin
   ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture.Z := Theme.Sing.Duet4PP1.Avatar.Z;
   ScreenSing.Statics[StaticP1DuetFourPAvatar].Texture.Alpha := Theme.Sing.Duet4PP1.Avatar.Alpha;
 
-  StaticP2DuetFourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP2DuetFourPAvatar);
+  StaticP2DuetFourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet4PP2.Avatar);
   ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture := AvatarPlayerTextures[2];
-  ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture.X  := Theme.Sing.StaticP2DuetFourPAvatar.X;
-  ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture.Y  := Theme.Sing.StaticP2DuetFourPAvatar.Y;
-  ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture.H  := Theme.Sing.StaticP2DuetFourPAvatar.H;
-  ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture.W  := Theme.Sing.StaticP2DuetFourPAvatar.W;
-  ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture.Z := Theme.Sing.StaticP2DuetFourPAvatar.Z;
-  ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture.Alpha := Theme.Sing.StaticP2DuetFourPAvatar.Alpha;
+  ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture.X  := Theme.Sing.Duet4PP2.Avatar.X;
+  ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture.Y  := Theme.Sing.Duet4PP2.Avatar.Y;
+  ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture.H  := Theme.Sing.Duet4PP2.Avatar.H;
+  ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture.W  := Theme.Sing.Duet4PP2.Avatar.W;
+  ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture.Z := Theme.Sing.Duet4PP2.Avatar.Z;
+  ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture.Alpha := Theme.Sing.Duet4PP2.Avatar.Alpha;
 
   StaticP3DuetFourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP3DuetFourPAvatar);
   ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture := AvatarPlayerTextures[3];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -548,9 +548,9 @@ begin
   Theme.Sing.Solo2PP2.AvatarFrame.ColB := Col[2].B;
 
   // 3 or 6 players | P1
-  Theme.Sing.StaticP1ThreeP.ColR := Col[1].R;
-  Theme.Sing.StaticP1ThreeP.ColG := Col[1].G;
-  Theme.Sing.StaticP1ThreeP.ColB := Col[1].B;
+  Theme.Sing.Solo3PP1.AvatarFrame.ColR := Col[1].R;
+  Theme.Sing.Solo3PP1.AvatarFrame.ColG := Col[1].G;
+  Theme.Sing.Solo3PP1.AvatarFrame.ColB := Col[1].B;
 
   //                | P2
   Theme.Sing.Solo3PP2.AvatarFrame.ColR := Col[2].R;
@@ -582,7 +582,7 @@ begin
   StaticP1[0]       := ScreenSing.AddStatic(Theme.Sing.StaticP1);
   StaticP1TwoP[0]   := ScreenSing.AddStatic(Theme.Sing.StaticP1TwoP);
   StaticP2R[0]      := ScreenSing.AddStatic(Theme.Sing.Solo2PP2.AvatarFrame);
-  StaticP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.StaticP1ThreeP);
+  StaticP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.Solo3PP1.AvatarFrame);
   StaticP2M[0]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP2.AvatarFrame);
   StaticP3R[0]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP3.AvatarFrame);
   StaticDuetP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.Duet3PP1.AvatarFrame);
@@ -606,9 +606,9 @@ begin
   Theme.Sing.Solo2PP2.AvatarFrame.ColB := Col[4].B;
 
   // 3 or 6 players | P1
-  Theme.Sing.StaticP1ThreeP.ColR := Col[4].R;
-  Theme.Sing.StaticP1ThreeP.ColG := Col[4].G;
-  Theme.Sing.StaticP1ThreeP.ColB := Col[4].B;
+  Theme.Sing.Solo3PP1.AvatarFrame.ColR := Col[4].R;
+  Theme.Sing.Solo3PP1.AvatarFrame.ColG := Col[4].G;
+  Theme.Sing.Solo3PP1.AvatarFrame.ColB := Col[4].B;
 
   //                | P2
   Theme.Sing.Solo3PP2.AvatarFrame.ColR := Col[5].R;
@@ -638,7 +638,7 @@ begin
   StaticP1[1]       := ScreenSing.AddStatic(Theme.Sing.StaticP1);
   StaticP1TwoP[1]   := ScreenSing.AddStatic(Theme.Sing.StaticP1TwoP);
   StaticP2R[1]      := ScreenSing.AddStatic(Theme.Sing.Solo2PP2.AvatarFrame);
-  StaticP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.StaticP1ThreeP);
+  StaticP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.Solo3PP1.AvatarFrame);
   StaticP2M[1]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP2.AvatarFrame);
   StaticP3R[1]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP3.AvatarFrame);
   StaticDuetP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.Duet3PP1.AvatarFrame);
@@ -648,7 +648,7 @@ begin
   TextP1   := ScreenSing.AddText(Theme.Sing.TextP1);
   TextP1TwoP   := ScreenSing.AddText(Theme.Sing.TextP1TwoP);
   TextP2R   := ScreenSing.AddText(Theme.Sing.Solo2PP2.Name);
-  TextP1ThreeP   := ScreenSing.AddText(Theme.Sing.TextP1ThreeP);
+  TextP1ThreeP   := ScreenSing.AddText(Theme.Sing.Solo3PP1.Name);
   TextP2M   := ScreenSing.AddText(Theme.Sing.Solo3PP2.Name);
   TextP3R   := ScreenSing.AddText(Theme.Sing.Solo3PP3.Name);
   TextDuetP1ThreeP   := ScreenSing.AddText(Theme.Sing.Duet3PP1.Name);
@@ -940,23 +940,23 @@ begin
   ScreenSing.Statics[StaticP2RAvatar[1]].Texture.Z := Theme.Sing.Solo2PP2.Avatar.Z;
   ScreenSing.Statics[StaticP2RAvatar[1]].Texture.Alpha := Theme.Sing.Solo2PP2.Avatar.Alpha;
 
-  StaticP1ThreePAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP1ThreePAvatar);
+  StaticP1ThreePAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo3PP1.Avatar);
   ScreenSing.Statics[StaticP1ThreePAvatar[0]].Texture := AvatarPlayerTextures[1];
-  ScreenSing.Statics[StaticP1ThreePAvatar[0]].Texture.X  := Theme.Sing.StaticP1ThreePAvatar.X;
-  ScreenSing.Statics[StaticP1ThreePAvatar[0]].Texture.Y  := Theme.Sing.StaticP1ThreePAvatar.Y;
-  ScreenSing.Statics[StaticP1ThreePAvatar[0]].Texture.H  := Theme.Sing.StaticP1ThreePAvatar.H;
-  ScreenSing.Statics[StaticP1ThreePAvatar[0]].Texture.W  := Theme.Sing.StaticP1ThreePAvatar.W;
-  ScreenSing.Statics[StaticP1ThreePAvatar[0]].Texture.Z := Theme.Sing.StaticP1ThreePAvatar.Z;
-  ScreenSing.Statics[StaticP1ThreePAvatar[0]].Texture.Alpha := Theme.Sing.StaticP1ThreePAvatar.Alpha;
+  ScreenSing.Statics[StaticP1ThreePAvatar[0]].Texture.X  := Theme.Sing.Solo3PP1.Avatar.X;
+  ScreenSing.Statics[StaticP1ThreePAvatar[0]].Texture.Y  := Theme.Sing.Solo3PP1.Avatar.Y;
+  ScreenSing.Statics[StaticP1ThreePAvatar[0]].Texture.H  := Theme.Sing.Solo3PP1.Avatar.H;
+  ScreenSing.Statics[StaticP1ThreePAvatar[0]].Texture.W  := Theme.Sing.Solo3PP1.Avatar.W;
+  ScreenSing.Statics[StaticP1ThreePAvatar[0]].Texture.Z := Theme.Sing.Solo3PP1.Avatar.Z;
+  ScreenSing.Statics[StaticP1ThreePAvatar[0]].Texture.Alpha := Theme.Sing.Solo3PP1.Avatar.Alpha;
 
-  StaticP1ThreePAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP1ThreePAvatar);
+  StaticP1ThreePAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo3PP1.Avatar);
   ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture := AvatarPlayerTextures[4];
-  ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture.X  := Theme.Sing.StaticP1ThreePAvatar.X;
-  ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture.Y  := Theme.Sing.StaticP1ThreePAvatar.Y;
-  ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture.H  := Theme.Sing.StaticP1ThreePAvatar.H;
-  ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture.W  := Theme.Sing.StaticP1ThreePAvatar.W;
-  ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture.Z := Theme.Sing.StaticP1ThreePAvatar.Z;
-  ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture.Alpha := Theme.Sing.StaticP1ThreePAvatar.Alpha;
+  ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture.X  := Theme.Sing.Solo3PP1.Avatar.X;
+  ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture.Y  := Theme.Sing.Solo3PP1.Avatar.Y;
+  ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture.H  := Theme.Sing.Solo3PP1.Avatar.H;
+  ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture.W  := Theme.Sing.Solo3PP1.Avatar.W;
+  ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture.Z := Theme.Sing.Solo3PP1.Avatar.Z;
+  ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture.Alpha := Theme.Sing.Solo3PP1.Avatar.Alpha;
 
   StaticP2MAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo3PP2.Avatar);
   ScreenSing.Statics[StaticP2MAvatar[0]].Texture := AvatarPlayerTextures[2];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -569,9 +569,9 @@ begin
   Theme.Sing.StaticDuetP1ThreeP.ColB := Col[1].B;
 
   //                | P2 DUET
-  Theme.Sing.StaticDuetP2M.ColR := Col[2].R;
-  Theme.Sing.StaticDuetP2M.ColG := Col[2].G;
-  Theme.Sing.StaticDuetP2M.ColB := Col[2].B;
+  Theme.Sing.Duet3PP2.AvatarFrame.ColR := Col[2].R;
+  Theme.Sing.Duet3PP2.AvatarFrame.ColG := Col[2].G;
+  Theme.Sing.Duet3PP2.AvatarFrame.ColB := Col[2].B;
 
   //                | P3 DUET
 
@@ -586,7 +586,7 @@ begin
   StaticP2M[0]      := ScreenSing.AddStatic(Theme.Sing.StaticP2M);
   StaticP3R[0]      := ScreenSing.AddStatic(Theme.Sing.StaticP3R);
   StaticDuetP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.StaticDuetP1ThreeP);
-  StaticDuetP2M[0]      := ScreenSing.AddStatic(Theme.Sing.StaticDuetP2M);
+  StaticDuetP2M[0]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP2.AvatarFrame);
   StaticDuetP3R[0]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP3.AvatarFrame);
 
   // SCREEN 2
@@ -626,9 +626,9 @@ begin
   Theme.Sing.StaticDuetP1ThreeP.ColB := Col[4].B;
 
   //                | P2 DUET
-  Theme.Sing.StaticDuetP2M.ColR := Col[5].R;
-  Theme.Sing.StaticDuetP2M.ColG := Col[5].G;
-  Theme.Sing.StaticDuetP2M.ColB := Col[5].B;
+  Theme.Sing.Duet3PP2.AvatarFrame.ColR := Col[5].R;
+  Theme.Sing.Duet3PP2.AvatarFrame.ColG := Col[5].G;
+  Theme.Sing.Duet3PP2.AvatarFrame.ColB := Col[5].B;
 
   //                | P3 DUET
   Theme.Sing.Duet3PP3.AvatarFrame.ColR := Col[6].R;
@@ -642,7 +642,7 @@ begin
   StaticP2M[1]      := ScreenSing.AddStatic(Theme.Sing.StaticP2M);
   StaticP3R[1]      := ScreenSing.AddStatic(Theme.Sing.StaticP3R);
   StaticDuetP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.StaticDuetP1ThreeP);
-  StaticDuetP2M[1]      := ScreenSing.AddStatic(Theme.Sing.StaticDuetP2M);
+  StaticDuetP2M[1]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP2.AvatarFrame);
   StaticDuetP3R[1]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP3.AvatarFrame);
 
   TextP1   := ScreenSing.AddText(Theme.Sing.TextP1);
@@ -652,7 +652,7 @@ begin
   TextP2M   := ScreenSing.AddText(Theme.Sing.TextP2M);
   TextP3R   := ScreenSing.AddText(Theme.Sing.TextP3R);
   TextDuetP1ThreeP   := ScreenSing.AddText(Theme.Sing.TextDuetP1ThreeP);
-  TextDuetP2M   := ScreenSing.AddText(Theme.Sing.TextDuetP2M);
+  TextDuetP2M   := ScreenSing.AddText(Theme.Sing.Duet3PP2.Name);
   TextDuetP3R   := ScreenSing.AddText(Theme.Sing.Duet3PP3.Name);
 
   for I := 1 to PlayersPlay do
@@ -1012,23 +1012,23 @@ begin
   ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture.Z := Theme.Sing.StaticDuetP1ThreePAvatar.Z;
   ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture.Alpha := Theme.Sing.StaticDuetP1ThreePAvatar.Alpha;
 
-  StaticDuetP2MAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticDuetP2MAvatar);
+  StaticDuetP2MAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet3PP2.Avatar);
   ScreenSing.Statics[StaticDuetP2MAvatar[0]].Texture := AvatarPlayerTextures[2];
-  ScreenSing.Statics[StaticDuetP2MAvatar[0]].Texture.X  := Theme.Sing.StaticDuetP2MAvatar.X;
-  ScreenSing.Statics[StaticDuetP2MAvatar[0]].Texture.Y  := Theme.Sing.StaticDuetP2MAvatar.Y;
-  ScreenSing.Statics[StaticDuetP2MAvatar[0]].Texture.H  := Theme.Sing.StaticDuetP2MAvatar.H;
-  ScreenSing.Statics[StaticDuetP2MAvatar[0]].Texture.W  := Theme.Sing.StaticDuetP2MAvatar.W;
-  ScreenSing.Statics[StaticDuetP2MAvatar[0]].Texture.Z := Theme.Sing.StaticDuetP2MAvatar.Z;
-  ScreenSing.Statics[StaticDuetP2MAvatar[0]].Texture.Alpha := Theme.Sing.StaticDuetP2MAvatar.Alpha;
+  ScreenSing.Statics[StaticDuetP2MAvatar[0]].Texture.X  := Theme.Sing.Duet3PP2.Avatar.X;
+  ScreenSing.Statics[StaticDuetP2MAvatar[0]].Texture.Y  := Theme.Sing.Duet3PP2.Avatar.Y;
+  ScreenSing.Statics[StaticDuetP2MAvatar[0]].Texture.H  := Theme.Sing.Duet3PP2.Avatar.H;
+  ScreenSing.Statics[StaticDuetP2MAvatar[0]].Texture.W  := Theme.Sing.Duet3PP2.Avatar.W;
+  ScreenSing.Statics[StaticDuetP2MAvatar[0]].Texture.Z := Theme.Sing.Duet3PP2.Avatar.Z;
+  ScreenSing.Statics[StaticDuetP2MAvatar[0]].Texture.Alpha := Theme.Sing.Duet3PP2.Avatar.Alpha;
 
-  StaticDuetP2MAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticDuetP2MAvatar);
+  StaticDuetP2MAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet3PP2.Avatar);
   ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture := AvatarPlayerTextures[5];
-  ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture.X  := Theme.Sing.StaticDuetP2MAvatar.X;
-  ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture.Y  := Theme.Sing.StaticDuetP2MAvatar.Y;
-  ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture.H  := Theme.Sing.StaticDuetP2MAvatar.H;
-  ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture.W  := Theme.Sing.StaticDuetP2MAvatar.W;
-  ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture.Z := Theme.Sing.StaticDuetP2MAvatar.Z;
-  ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture.Alpha := Theme.Sing.StaticDuetP2MAvatar.Alpha;
+  ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture.X  := Theme.Sing.Duet3PP2.Avatar.X;
+  ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture.Y  := Theme.Sing.Duet3PP2.Avatar.Y;
+  ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture.H  := Theme.Sing.Duet3PP2.Avatar.H;
+  ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture.W  := Theme.Sing.Duet3PP2.Avatar.W;
+  ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture.Z := Theme.Sing.Duet3PP2.Avatar.Z;
+  ScreenSing.Statics[StaticDuetP2MAvatar[1]].Texture.Alpha := Theme.Sing.Duet3PP2.Avatar.Alpha;
 
   StaticDuetP3RAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet3PP3.Avatar);
   ScreenSing.Statics[StaticDuetP3RAvatar[0]].Texture := AvatarPlayerTextures[3];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -670,9 +670,9 @@ begin
 
   // 4/6 players in 1 screen
   // P1
-  Theme.Sing.StaticP1FourP.ColR := Col[1].R;
-  Theme.Sing.StaticP1FourP.ColG := Col[1].G;
-  Theme.Sing.StaticP1FourP.ColB := Col[1].B;
+  Theme.Sing.Solo4PP1.AvatarFrame.ColR := Col[1].R;
+  Theme.Sing.Solo4PP1.AvatarFrame.ColG := Col[1].G;
+  Theme.Sing.Solo4PP1.AvatarFrame.ColB := Col[1].B;
 
   // P2
   Theme.Sing.StaticP2FourP.ColR := Col[2].R;
@@ -689,12 +689,12 @@ begin
   Theme.Sing.StaticP4FourP.ColG := Col[4].G;
   Theme.Sing.StaticP4FourP.ColB := Col[4].B;
 
-  StaticP1FourP   := ScreenSing.AddStatic(Theme.Sing.StaticP1FourP);
+  StaticP1FourP   := ScreenSing.AddStatic(Theme.Sing.Solo4PP1.AvatarFrame);
   StaticP2FourP   := ScreenSing.AddStatic(Theme.Sing.StaticP2FourP);
   StaticP3FourP   := ScreenSing.AddStatic(Theme.Sing.StaticP3FourP);
   StaticP4FourP   := ScreenSing.AddStatic(Theme.Sing.StaticP4FourP);
 
-  TextP1FourP   := ScreenSing.AddText(Theme.Sing.TextP1FourP);
+  TextP1FourP   := ScreenSing.AddText(Theme.Sing.Solo4PP1.Name);
   TextP2FourP   := ScreenSing.AddText(Theme.Sing.TextP2FourP);
   TextP3FourP   := ScreenSing.AddText(Theme.Sing.TextP3FourP);
   TextP4FourP   := ScreenSing.AddText(Theme.Sing.TextP4FourP);
@@ -1048,14 +1048,14 @@ begin
   ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture.Z := Theme.Sing.StaticDuetP3RAvatar.Z;
   ScreenSing.Statics[StaticDuetP3RAvatar[1]].Texture.Alpha := Theme.Sing.StaticDuetP3RAvatar.Alpha;
 
-  StaticP1FourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP1FourPAvatar);
+  StaticP1FourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo4PP1.Avatar);
   ScreenSing.Statics[StaticP1FourPAvatar].Texture := AvatarPlayerTextures[1];
-  ScreenSing.Statics[StaticP1FourPAvatar].Texture.X  := Theme.Sing.StaticP1FourPAvatar.X;
-  ScreenSing.Statics[StaticP1FourPAvatar].Texture.Y  := Theme.Sing.StaticP1FourPAvatar.Y;
-  ScreenSing.Statics[StaticP1FourPAvatar].Texture.H  := Theme.Sing.StaticP1FourPAvatar.H;
-  ScreenSing.Statics[StaticP1FourPAvatar].Texture.W  := Theme.Sing.StaticP1FourPAvatar.W;
-  ScreenSing.Statics[StaticP1FourPAvatar].Texture.Z := Theme.Sing.StaticP1FourPAvatar.Z;
-  ScreenSing.Statics[StaticP1FourPAvatar].Texture.Alpha := Theme.Sing.StaticP1FourPAvatar.Alpha;
+  ScreenSing.Statics[StaticP1FourPAvatar].Texture.X  := Theme.Sing.Solo4PP1.Avatar.X;
+  ScreenSing.Statics[StaticP1FourPAvatar].Texture.Y  := Theme.Sing.Solo4PP1.Avatar.Y;
+  ScreenSing.Statics[StaticP1FourPAvatar].Texture.H  := Theme.Sing.Solo4PP1.Avatar.H;
+  ScreenSing.Statics[StaticP1FourPAvatar].Texture.W  := Theme.Sing.Solo4PP1.Avatar.W;
+  ScreenSing.Statics[StaticP1FourPAvatar].Texture.Z := Theme.Sing.Solo4PP1.Avatar.Z;
+  ScreenSing.Statics[StaticP1FourPAvatar].Texture.Alpha := Theme.Sing.Solo4PP1.Avatar.Alpha;
 
   StaticP2FourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP2FourPAvatar);
   ScreenSing.Statics[StaticP2FourPAvatar].Texture := AvatarPlayerTextures[2];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -553,9 +553,9 @@ begin
   Theme.Sing.StaticP1ThreeP.ColB := Col[1].B;
 
   //                | P2
-  Theme.Sing.StaticP2M.ColR := Col[2].R;
-  Theme.Sing.StaticP2M.ColG := Col[2].G;
-  Theme.Sing.StaticP2M.ColB := Col[2].B;
+  Theme.Sing.Solo3PP2.AvatarFrame.ColR := Col[2].R;
+  Theme.Sing.Solo3PP2.AvatarFrame.ColG := Col[2].G;
+  Theme.Sing.Solo3PP2.AvatarFrame.ColB := Col[2].B;
 
   //                | P3
 
@@ -583,7 +583,7 @@ begin
   StaticP1TwoP[0]   := ScreenSing.AddStatic(Theme.Sing.StaticP1TwoP);
   StaticP2R[0]      := ScreenSing.AddStatic(Theme.Sing.StaticP2R);
   StaticP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.StaticP1ThreeP);
-  StaticP2M[0]      := ScreenSing.AddStatic(Theme.Sing.StaticP2M);
+  StaticP2M[0]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP2.AvatarFrame);
   StaticP3R[0]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP3.AvatarFrame);
   StaticDuetP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.Duet3PP1.AvatarFrame);
   StaticDuetP2M[0]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP2.AvatarFrame);
@@ -611,9 +611,9 @@ begin
   Theme.Sing.StaticP1ThreeP.ColB := Col[4].B;
 
   //                | P2
-  Theme.Sing.StaticP2M.ColR := Col[5].R;
-  Theme.Sing.StaticP2M.ColG := Col[5].G;
-  Theme.Sing.StaticP2M.ColB := Col[5].B;
+  Theme.Sing.Solo3PP2.AvatarFrame.ColR := Col[5].R;
+  Theme.Sing.Solo3PP2.AvatarFrame.ColG := Col[5].G;
+  Theme.Sing.Solo3PP2.AvatarFrame.ColB := Col[5].B;
 
   //                | P3
   Theme.Sing.Solo3PP3.AvatarFrame.ColR := Col[6].R;
@@ -639,7 +639,7 @@ begin
   StaticP1TwoP[1]   := ScreenSing.AddStatic(Theme.Sing.StaticP1TwoP);
   StaticP2R[1]      := ScreenSing.AddStatic(Theme.Sing.StaticP2R);
   StaticP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.StaticP1ThreeP);
-  StaticP2M[1]      := ScreenSing.AddStatic(Theme.Sing.StaticP2M);
+  StaticP2M[1]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP2.AvatarFrame);
   StaticP3R[1]      := ScreenSing.AddStatic(Theme.Sing.Solo3PP3.AvatarFrame);
   StaticDuetP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.Duet3PP1.AvatarFrame);
   StaticDuetP2M[1]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP2.AvatarFrame);
@@ -649,7 +649,7 @@ begin
   TextP1TwoP   := ScreenSing.AddText(Theme.Sing.TextP1TwoP);
   TextP2R   := ScreenSing.AddText(Theme.Sing.TextP2R);
   TextP1ThreeP   := ScreenSing.AddText(Theme.Sing.TextP1ThreeP);
-  TextP2M   := ScreenSing.AddText(Theme.Sing.TextP2M);
+  TextP2M   := ScreenSing.AddText(Theme.Sing.Solo3PP2.Name);
   TextP3R   := ScreenSing.AddText(Theme.Sing.Solo3PP3.Name);
   TextDuetP1ThreeP   := ScreenSing.AddText(Theme.Sing.Duet3PP1.Name);
   TextDuetP2M   := ScreenSing.AddText(Theme.Sing.Duet3PP2.Name);
@@ -958,23 +958,23 @@ begin
   ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture.Z := Theme.Sing.StaticP1ThreePAvatar.Z;
   ScreenSing.Statics[StaticP1ThreePAvatar[1]].Texture.Alpha := Theme.Sing.StaticP1ThreePAvatar.Alpha;
 
-  StaticP2MAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP2MAvatar);
+  StaticP2MAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo3PP2.Avatar);
   ScreenSing.Statics[StaticP2MAvatar[0]].Texture := AvatarPlayerTextures[2];
-  ScreenSing.Statics[StaticP2MAvatar[0]].Texture.X  := Theme.Sing.StaticP2MAvatar.X;
-  ScreenSing.Statics[StaticP2MAvatar[0]].Texture.Y  := Theme.Sing.StaticP2MAvatar.Y;
-  ScreenSing.Statics[StaticP2MAvatar[0]].Texture.H  := Theme.Sing.StaticP2MAvatar.H;
-  ScreenSing.Statics[StaticP2MAvatar[0]].Texture.W  := Theme.Sing.StaticP2MAvatar.W;
-  ScreenSing.Statics[StaticP2MAvatar[0]].Texture.Z := Theme.Sing.StaticP2MAvatar.Z;
-  ScreenSing.Statics[StaticP2MAvatar[0]].Texture.Alpha := Theme.Sing.StaticP2MAvatar.Alpha;
+  ScreenSing.Statics[StaticP2MAvatar[0]].Texture.X  := Theme.Sing.Solo3PP2.Avatar.X;
+  ScreenSing.Statics[StaticP2MAvatar[0]].Texture.Y  := Theme.Sing.Solo3PP2.Avatar.Y;
+  ScreenSing.Statics[StaticP2MAvatar[0]].Texture.H  := Theme.Sing.Solo3PP2.Avatar.H;
+  ScreenSing.Statics[StaticP2MAvatar[0]].Texture.W  := Theme.Sing.Solo3PP2.Avatar.W;
+  ScreenSing.Statics[StaticP2MAvatar[0]].Texture.Z := Theme.Sing.Solo3PP2.Avatar.Z;
+  ScreenSing.Statics[StaticP2MAvatar[0]].Texture.Alpha := Theme.Sing.Solo3PP2.Avatar.Alpha;
 
-  StaticP2MAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP2MAvatar);
+  StaticP2MAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo3PP2.Avatar);
   ScreenSing.Statics[StaticP2MAvatar[1]].Texture := AvatarPlayerTextures[5];
-  ScreenSing.Statics[StaticP2MAvatar[1]].Texture.X  := Theme.Sing.StaticP2MAvatar.X;
-  ScreenSing.Statics[StaticP2MAvatar[1]].Texture.Y  := Theme.Sing.StaticP2MAvatar.Y;
-  ScreenSing.Statics[StaticP2MAvatar[1]].Texture.H  := Theme.Sing.StaticP2MAvatar.H;
-  ScreenSing.Statics[StaticP2MAvatar[1]].Texture.W  := Theme.Sing.StaticP2MAvatar.W;
-  ScreenSing.Statics[StaticP2MAvatar[1]].Texture.Z := Theme.Sing.StaticP2MAvatar.Z;
-  ScreenSing.Statics[StaticP2MAvatar[1]].Texture.Alpha := Theme.Sing.StaticP2MAvatar.Alpha;
+  ScreenSing.Statics[StaticP2MAvatar[1]].Texture.X  := Theme.Sing.Solo3PP2.Avatar.X;
+  ScreenSing.Statics[StaticP2MAvatar[1]].Texture.Y  := Theme.Sing.Solo3PP2.Avatar.Y;
+  ScreenSing.Statics[StaticP2MAvatar[1]].Texture.H  := Theme.Sing.Solo3PP2.Avatar.H;
+  ScreenSing.Statics[StaticP2MAvatar[1]].Texture.W  := Theme.Sing.Solo3PP2.Avatar.W;
+  ScreenSing.Statics[StaticP2MAvatar[1]].Texture.Z := Theme.Sing.Solo3PP2.Avatar.Z;
+  ScreenSing.Statics[StaticP2MAvatar[1]].Texture.Alpha := Theme.Sing.Solo3PP2.Avatar.Alpha;
 
   StaticP3RAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Solo3PP3.Avatar);
   ScreenSing.Statics[StaticP3RAvatar[0]].Texture := AvatarPlayerTextures[3];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -776,9 +776,9 @@ begin
   TextP4DuetFourP   := ScreenSing.AddText(Theme.Sing.Duet4PP4.Name);
 
   // P1
-  Theme.Sing.StaticP1DuetSixP.ColR := Col[1].R;
-  Theme.Sing.StaticP1DuetSixP.ColG := Col[1].G;
-  Theme.Sing.StaticP1DuetSixP.ColB := Col[1].B;
+  Theme.Sing.Duet6PP1.AvatarFrame.ColR := Col[1].R;
+  Theme.Sing.Duet6PP1.AvatarFrame.ColG := Col[1].G;
+  Theme.Sing.Duet6PP1.AvatarFrame.ColB := Col[1].B;
 
   // P2
   Theme.Sing.StaticP2DuetSixP.ColR := Col[2].R;
@@ -805,14 +805,14 @@ begin
   Theme.Sing.StaticP6DuetSixP.ColG := Col[6].G;
   Theme.Sing.StaticP6DuetSixP.ColB := Col[6].B;
 
-  StaticP1DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP1DuetSixP);
+  StaticP1DuetSixP  := ScreenSing.AddStatic(Theme.Sing.Duet6PP1.AvatarFrame);
   StaticP2DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP2DuetSixP);
   StaticP3DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP3DuetSixP);
   StaticP4DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP4DuetSixP);
   StaticP5DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP5DuetSixP);
   StaticP6DuetSixP  := ScreenSing.AddStatic(Theme.Sing.StaticP6DuetSixP);
 
-  TextP1DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP1DuetSixP);
+  TextP1DuetSixP   := ScreenSing.AddText(Theme.Sing.Duet6PP1.Name);
   TextP2DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP2DuetSixP);
   TextP3DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP3DuetSixP);
   TextP4DuetSixP   := ScreenSing.AddText(Theme.Sing.TextP4DuetSixP);
@@ -1174,14 +1174,14 @@ begin
   ScreenSing.Statics[StaticP6SixPAvatar].Texture.Z := Theme.Sing.Solo6PP6.Avatar.Z;
   ScreenSing.Statics[StaticP6SixPAvatar].Texture.Alpha := Theme.Sing.Solo6PP6.Avatar.Alpha;
 
-  StaticP1DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP1DuetSixPAvatar);
+  StaticP1DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet6PP1.Avatar);
   ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture := AvatarPlayerTextures[1];
-  ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture.X  := Theme.Sing.StaticP1DuetSixPAvatar.X;
-  ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture.Y  := Theme.Sing.StaticP1DuetSixPAvatar.Y;
-  ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture.H  := Theme.Sing.StaticP1DuetSixPAvatar.H;
-  ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture.W  := Theme.Sing.StaticP1DuetSixPAvatar.W;
-  ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture.Z := Theme.Sing.StaticP1DuetSixPAvatar.Z;
-  ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture.Alpha := Theme.Sing.StaticP1DuetSixPAvatar.Alpha;
+  ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture.X  := Theme.Sing.Duet6PP1.Avatar.X;
+  ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture.Y  := Theme.Sing.Duet6PP1.Avatar.Y;
+  ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture.H  := Theme.Sing.Duet6PP1.Avatar.H;
+  ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture.W  := Theme.Sing.Duet6PP1.Avatar.W;
+  ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture.Z := Theme.Sing.Duet6PP1.Avatar.Z;
+  ScreenSing.Statics[StaticP1DuetSixPAvatar].Texture.Alpha := Theme.Sing.Duet6PP1.Avatar.Alpha;
 
   StaticP2DuetSixPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP2DuetSixPAvatar);
   ScreenSing.Statics[StaticP2DuetSixPAvatar].Texture := AvatarPlayerTextures[2];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -756,9 +756,9 @@ begin
   Theme.Sing.Duet4PP2.AvatarFrame.ColB := Col[2].B;
 
   // P3
-  Theme.Sing.StaticP3DuetFourP.ColR := Col[3].R;
-  Theme.Sing.StaticP3DuetFourP.ColG := Col[3].G;
-  Theme.Sing.StaticP3DuetFourP.ColB := Col[3].B;
+  Theme.Sing.Duet4PP3.AvatarFrame.ColR := Col[3].R;
+  Theme.Sing.Duet4PP3.AvatarFrame.ColG := Col[3].G;
+  Theme.Sing.Duet4PP3.AvatarFrame.ColB := Col[3].B;
 
   // P4
   Theme.Sing.StaticP4DuetFourP.ColR := Col[4].R;
@@ -767,12 +767,12 @@ begin
 
   StaticP1DuetFourP   := ScreenSing.AddStatic(Theme.Sing.Duet4PP1.AvatarFrame);
   StaticP2DuetFourP   := ScreenSing.AddStatic(Theme.Sing.Duet4PP2.AvatarFrame);
-  StaticP3DuetFourP   := ScreenSing.AddStatic(Theme.Sing.StaticP3DuetFourP);
+  StaticP3DuetFourP   := ScreenSing.AddStatic(Theme.Sing.Duet4PP3.AvatarFrame);
   StaticP4DuetFourP   := ScreenSing.AddStatic(Theme.Sing.StaticP4DuetFourP);
 
   TextP1DuetFourP   := ScreenSing.AddText(Theme.Sing.Duet4PP1.Name);
   TextP2DuetFourP   := ScreenSing.AddText(Theme.Sing.Duet4PP2.Name);
-  TextP3DuetFourP   := ScreenSing.AddText(Theme.Sing.TextP3DuetFourP);
+  TextP3DuetFourP   := ScreenSing.AddText(Theme.Sing.Duet4PP3.Name);
   TextP4DuetFourP   := ScreenSing.AddText(Theme.Sing.TextP4DuetFourP);
 
   // P1
@@ -1102,14 +1102,14 @@ begin
   ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture.Z := Theme.Sing.Duet4PP2.Avatar.Z;
   ScreenSing.Statics[StaticP2DuetFourPAvatar].Texture.Alpha := Theme.Sing.Duet4PP2.Avatar.Alpha;
 
-  StaticP3DuetFourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP3DuetFourPAvatar);
+  StaticP3DuetFourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet4PP3.Avatar);
   ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture := AvatarPlayerTextures[3];
-  ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture.X  := Theme.Sing.StaticP3DuetFourPAvatar.X;
-  ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture.Y  := Theme.Sing.StaticP3DuetFourPAvatar.Y;
-  ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture.H  := Theme.Sing.StaticP3DuetFourPAvatar.H;
-  ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture.W  := Theme.Sing.StaticP3DuetFourPAvatar.W;
-  ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture.Z := Theme.Sing.StaticP3DuetFourPAvatar.Z;
-  ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture.Alpha := Theme.Sing.StaticP3DuetFourPAvatar.Alpha;
+  ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture.X  := Theme.Sing.Duet4PP3.Avatar.X;
+  ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture.Y  := Theme.Sing.Duet4PP3.Avatar.Y;
+  ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture.H  := Theme.Sing.Duet4PP3.Avatar.H;
+  ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture.W  := Theme.Sing.Duet4PP3.Avatar.W;
+  ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture.Z := Theme.Sing.Duet4PP3.Avatar.Z;
+  ScreenSing.Statics[StaticP3DuetFourPAvatar].Texture.Alpha := Theme.Sing.Duet4PP3.Avatar.Alpha;
 
   StaticP4DuetFourPAvatar := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticP4DuetFourPAvatar);
   ScreenSing.Statics[StaticP4DuetFourPAvatar].Texture := AvatarPlayerTextures[4];

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -564,9 +564,9 @@ begin
   Theme.Sing.StaticP3R.ColB := Col[3].B;
 
   // 3 or 6 players | P1 DUET
-  Theme.Sing.StaticDuetP1ThreeP.ColR := Col[1].R;
-  Theme.Sing.StaticDuetP1ThreeP.ColG := Col[1].G;
-  Theme.Sing.StaticDuetP1ThreeP.ColB := Col[1].B;
+  Theme.Sing.Duet3PP1.AvatarFrame.ColR := Col[1].R;
+  Theme.Sing.Duet3PP1.AvatarFrame.ColG := Col[1].G;
+  Theme.Sing.Duet3PP1.AvatarFrame.ColB := Col[1].B;
 
   //                | P2 DUET
   Theme.Sing.Duet3PP2.AvatarFrame.ColR := Col[2].R;
@@ -585,7 +585,7 @@ begin
   StaticP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.StaticP1ThreeP);
   StaticP2M[0]      := ScreenSing.AddStatic(Theme.Sing.StaticP2M);
   StaticP3R[0]      := ScreenSing.AddStatic(Theme.Sing.StaticP3R);
-  StaticDuetP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.StaticDuetP1ThreeP);
+  StaticDuetP1ThreeP[0] := ScreenSing.AddStatic(Theme.Sing.Duet3PP1.AvatarFrame);
   StaticDuetP2M[0]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP2.AvatarFrame);
   StaticDuetP3R[0]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP3.AvatarFrame);
 
@@ -621,9 +621,9 @@ begin
   Theme.Sing.StaticP3R.ColB := Col[6].B;
 
     // 3 or 6 players | P1 DUET
-  Theme.Sing.StaticDuetP1ThreeP.ColR := Col[4].R;
-  Theme.Sing.StaticDuetP1ThreeP.ColG := Col[4].G;
-  Theme.Sing.StaticDuetP1ThreeP.ColB := Col[4].B;
+  Theme.Sing.Duet3PP1.AvatarFrame.ColR := Col[4].R;
+  Theme.Sing.Duet3PP1.AvatarFrame.ColG := Col[4].G;
+  Theme.Sing.Duet3PP1.AvatarFrame.ColB := Col[4].B;
 
   //                | P2 DUET
   Theme.Sing.Duet3PP2.AvatarFrame.ColR := Col[5].R;
@@ -641,7 +641,7 @@ begin
   StaticP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.StaticP1ThreeP);
   StaticP2M[1]      := ScreenSing.AddStatic(Theme.Sing.StaticP2M);
   StaticP3R[1]      := ScreenSing.AddStatic(Theme.Sing.StaticP3R);
-  StaticDuetP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.StaticDuetP1ThreeP);
+  StaticDuetP1ThreeP[1] := ScreenSing.AddStatic(Theme.Sing.Duet3PP1.AvatarFrame);
   StaticDuetP2M[1]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP2.AvatarFrame);
   StaticDuetP3R[1]      := ScreenSing.AddStatic(Theme.Sing.Duet3PP3.AvatarFrame);
 
@@ -651,7 +651,7 @@ begin
   TextP1ThreeP   := ScreenSing.AddText(Theme.Sing.TextP1ThreeP);
   TextP2M   := ScreenSing.AddText(Theme.Sing.TextP2M);
   TextP3R   := ScreenSing.AddText(Theme.Sing.TextP3R);
-  TextDuetP1ThreeP   := ScreenSing.AddText(Theme.Sing.TextDuetP1ThreeP);
+  TextDuetP1ThreeP   := ScreenSing.AddText(Theme.Sing.Duet3PP1.Name);
   TextDuetP2M   := ScreenSing.AddText(Theme.Sing.Duet3PP2.Name);
   TextDuetP3R   := ScreenSing.AddText(Theme.Sing.Duet3PP3.Name);
 
@@ -994,23 +994,23 @@ begin
   ScreenSing.Statics[StaticP3RAvatar[1]].Texture.Z := Theme.Sing.StaticP3RAvatar.Z;
   ScreenSing.Statics[StaticP3RAvatar[1]].Texture.Alpha := Theme.Sing.StaticP3RAvatar.Alpha;
 
-  StaticDuetP1ThreePAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticDuetP1ThreePAvatar);
+  StaticDuetP1ThreePAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet3PP1.Avatar);
   ScreenSing.Statics[StaticDuetP1ThreePAvatar[0]].Texture := AvatarPlayerTextures[1];
-  ScreenSing.Statics[StaticDuetP1ThreePAvatar[0]].Texture.X  := Theme.Sing.StaticDuetP1ThreePAvatar.X;
-  ScreenSing.Statics[StaticDuetP1ThreePAvatar[0]].Texture.Y  := Theme.Sing.StaticDuetP1ThreePAvatar.Y;
-  ScreenSing.Statics[StaticDuetP1ThreePAvatar[0]].Texture.H  := Theme.Sing.StaticDuetP1ThreePAvatar.H;
-  ScreenSing.Statics[StaticDuetP1ThreePAvatar[0]].Texture.W  := Theme.Sing.StaticDuetP1ThreePAvatar.W;
-  ScreenSing.Statics[StaticDuetP1ThreePAvatar[0]].Texture.Z := Theme.Sing.StaticDuetP1ThreePAvatar.Z;
-  ScreenSing.Statics[StaticDuetP1ThreePAvatar[0]].Texture.Alpha := Theme.Sing.StaticDuetP1ThreePAvatar.Alpha;
+  ScreenSing.Statics[StaticDuetP1ThreePAvatar[0]].Texture.X  := Theme.Sing.Duet3PP1.Avatar.X;
+  ScreenSing.Statics[StaticDuetP1ThreePAvatar[0]].Texture.Y  := Theme.Sing.Duet3PP1.Avatar.Y;
+  ScreenSing.Statics[StaticDuetP1ThreePAvatar[0]].Texture.H  := Theme.Sing.Duet3PP1.Avatar.H;
+  ScreenSing.Statics[StaticDuetP1ThreePAvatar[0]].Texture.W  := Theme.Sing.Duet3PP1.Avatar.W;
+  ScreenSing.Statics[StaticDuetP1ThreePAvatar[0]].Texture.Z := Theme.Sing.Duet3PP1.Avatar.Z;
+  ScreenSing.Statics[StaticDuetP1ThreePAvatar[0]].Texture.Alpha := Theme.Sing.Duet3PP1.Avatar.Alpha;
 
-  StaticDuetP1ThreePAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.StaticDuetP1ThreePAvatar);
+  StaticDuetP1ThreePAvatar[1] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet3PP1.Avatar);
   ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture := AvatarPlayerTextures[4];
-  ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture.X  := Theme.Sing.StaticDuetP1ThreePAvatar.X;
-  ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture.Y  := Theme.Sing.StaticDuetP1ThreePAvatar.Y;
-  ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture.H  := Theme.Sing.StaticDuetP1ThreePAvatar.H;
-  ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture.W  := Theme.Sing.StaticDuetP1ThreePAvatar.W;
-  ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture.Z := Theme.Sing.StaticDuetP1ThreePAvatar.Z;
-  ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture.Alpha := Theme.Sing.StaticDuetP1ThreePAvatar.Alpha;
+  ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture.X  := Theme.Sing.Duet3PP1.Avatar.X;
+  ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture.Y  := Theme.Sing.Duet3PP1.Avatar.Y;
+  ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture.H  := Theme.Sing.Duet3PP1.Avatar.H;
+  ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture.W  := Theme.Sing.Duet3PP1.Avatar.W;
+  ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture.Z := Theme.Sing.Duet3PP1.Avatar.Z;
+  ScreenSing.Statics[StaticDuetP1ThreePAvatar[1]].Texture.Alpha := Theme.Sing.Duet3PP1.Avatar.Alpha;
 
   StaticDuetP2MAvatar[0] := ScreenSing.AddStaticAlphaRectangle(Theme.Sing.Duet3PP2.Avatar);
   ScreenSing.Statics[StaticDuetP2MAvatar[0]].Texture := AvatarPlayerTextures[2];


### PR DESCRIPTION
This PR generally changes nothing, except for two 'breaking' changes. The quotes are deliberaty because the breakage only applies to 5 out of 7 elements, so it never applied to the other 2.

What it breaks is that you will now have to define the `SingP1TwoPStatic` and `SingP1ThreePStatic` (and related) sections. Previously if these weren't defined it would just fall back to `SingP1Static` but considering this fallback never worked for the SingBar and the Oscilloscope anyway, so I don't think it's really an issue.
If you want to review this, look for the quite obvious commit message.

For the rest it just massively simplifies `UThemes.pas`, other files only have updated references. Those are for a future PR.