### PR TITLE
fix SDL double input

### DIFF
--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -45,6 +45,9 @@ var
 procedure Main;
 procedure MainLoop;
 procedure CheckEvents;
+procedure StartTextInput;
+procedure StopTextInput;
+procedure SetTextInput(enabled: boolean);
 
 type
   TMainThreadExecProc = procedure(Data: Pointer);
@@ -299,6 +302,21 @@ begin
   {$ENDIF}
 end;
 
+procedure StartTextInput;
+begin
+  SDL_StartTextInput;
+end;
+
+procedure StopTextInput;
+begin
+  SDL_StopTextInput;
+end;
+
+procedure SetTextInput(enabled: boolean);
+begin
+  if enabled then StartTextInput else StopTextInput;
+end;
+
 procedure MainLoop;
 var
   Delay:            integer;
@@ -309,7 +327,8 @@ var
   I,J: Integer;
 begin
   Max_FPS := Ini.MaxFramerateGet;
-  SDL_StartTextInput;
+  // need to explicitly stop this because it appears to be started by default
+  SDL_StopTextInput;
   Done := false;
   J := 1;
   CountSkipTime();

--- a/src/screens/UScreenAbout.pas
+++ b/src/screens/UScreenAbout.pas
@@ -77,14 +77,14 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('C'):
+    case PressedKey of
+      SDLK_C:
         begin
           FadeTo(@ScreenCredits, SoundLib.Start);
           Exit;
         end;
 
-      Ord('Q'):
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenCredits.pas
+++ b/src/screens/UScreenCredits.pas
@@ -268,8 +268,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenEdit.pas
+++ b/src/screens/UScreenEdit.pas
@@ -77,8 +77,8 @@ begin
   if (PressedDown) then
   begin // Key Down
         // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenEditConvert.pas
+++ b/src/screens/UScreenEditConvert.pas
@@ -229,8 +229,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -39,6 +39,7 @@ uses
   UFilesystem,
   UGraphicClasses,
   UIni,
+  UMain,
   UMenu,
   UMenuText,
   UMusic,
@@ -497,14 +498,14 @@ begin
   if (PressedDown) then  // Key Down
   begin
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;
         end;
       {
-      Ord('S'):
+      SDLK_S:
         begin
           if SDL_ModState = KMOD_LSHIFT then
           begin
@@ -536,7 +537,7 @@ begin
 
         end;
       }
-      Ord('S'):
+      SDLK_S:
         begin
           // handle medley tags first
           if CurrentSong.isDuet then
@@ -608,7 +609,7 @@ begin
         end;
 
       // set PreviewStart tag
-      Ord('I'):
+      SDLK_I:
         begin
           CopyToUndo;
           if SDL_ModState and KMOD_SHIFT <> 0 then
@@ -699,7 +700,7 @@ begin
         end;
 
       // set Medley tags
-      Ord('A'):
+      SDLK_A:
         begin
           CopyToUndo;
           if CurrentSong.Relative then
@@ -798,7 +799,7 @@ begin
         end;
 
       // jump to Medley tags
-      Ord('J'):
+      SDLK_J:
         begin
           if CurrentSong.Relative then
           begin
@@ -894,7 +895,7 @@ begin
           Exit;
         end;
 
-      Ord('R'):   //reload
+      SDLK_R:   //reload
         begin
           AudioPlayback.Stop;
           {$IFDEF UseMIDIPort}
@@ -906,7 +907,7 @@ begin
           Text[TextInfo].Text := Language.Translate('EDIT_INFO_SONG_RELOADED');
         end;
 
-      Ord('D'):
+      SDLK_D:
         begin
           // Divide lengths by 2
           if (SDL_ModState = KMOD_LSHIFT) then
@@ -935,7 +936,7 @@ begin
           end;
         end;
 
-      Ord('M'):
+      SDLK_M:
         begin
           // Multiply lengths by 2
           if (SDL_ModState = KMOD_LSHIFT) then
@@ -948,7 +949,7 @@ begin
           end;
         end;
 
-      Ord('C'):
+      SDLK_C:
         begin
           // Capitalize letter at the beginning of line
           if SDL_ModState = 0 then
@@ -978,7 +979,7 @@ begin
           Exit;
         end;
 
-      Ord('V'):
+      SDLK_V:
         begin
           if (SDL_ModState = 0) or (SDL_ModState = KMOD_LALT) then // play current line/remainder of song with video
           begin
@@ -1047,7 +1048,7 @@ begin
           ShowInteractiveBackground;
         end;
 
-      Ord('T'):
+      SDLK_T:
         begin
           // Fixes timings between sentences
           CopyToUndo;
@@ -1056,7 +1057,7 @@ begin
           Exit;
         end;
 
-      Ord('P'):
+      SDLK_P:
         begin
           if SDL_ModState = 0 then
           begin
@@ -1118,7 +1119,7 @@ begin
         end;
 
       // Golden Note
-      Ord('G'):
+      SDLK_G:
         begin
           CopyToUndo;
           if (Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].NoteType = ntGolden) then
@@ -1141,7 +1142,7 @@ begin
         end;
 
       // Freestyle Note
-      Ord('F'):
+      SDLK_F:
         begin
           CopyToUndo;
           if (Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].NoteType = ntFreestyle) then
@@ -1168,7 +1169,7 @@ begin
         end;
 
       // undo
-      Ord('Z'):
+      SDLK_Z:
         begin
           if SDL_ModState = KMOD_LCTRL then
           begin
@@ -1468,6 +1469,7 @@ begin
           TextPosition := LengthUTF8(BackupEditText);
           editLengthText := LengthUTF8(BackupEditText);
           TextEditMode := true;
+          StartTextInput;
         end;
 
       SDLK_F5:
@@ -1479,6 +1481,7 @@ begin
           TextPosition := LengthUTF8(BackupEditText);
           editLengthText := LengthUTF8(BackupEditText);
           BPMEditMode := true;
+          StartTextInput;
         end;
 
       SDLK_SPACE:
@@ -1533,6 +1536,7 @@ begin
              CurrentSlideId := TitleSlideId;
              TextPosition := LengthUTF8(BackupEditText);
              TitleEditMode := true;
+             StartTextInput;
            end;
 
            if Interaction = ArtistSlideId then
@@ -1543,6 +1547,7 @@ begin
              CurrentSlideId := ArtistSlideId;
              TextPosition := LengthUTF8(BackupEditText);
              ArtistEditMode := true;
+             StartTextInput;
            end;
 
            if Interaction = LanguageSlideId then
@@ -1553,6 +1558,7 @@ begin
              CurrentSlideId := LanguageSlideId;
              TextPosition := LengthUTF8(BackupEditText);
              LanguageEditMode := true;
+             StartTextInput;
            end;
 
            if Interaction = EditionSlideId then
@@ -1563,6 +1569,7 @@ begin
              CurrentSlideId := EditionSlideId;
              TextPosition := LengthUTF8(BackupEditText);
              EditionEditMode := true;
+             StartTextInput;
            end;
 
            if Interaction = GenreSlideId then
@@ -1573,6 +1580,7 @@ begin
              CurrentSlideId := GenreSlideId;
              TextPosition := LengthUTF8(BackupEditText);
              GenreEditMode := true;
+             StartTextInput;
            end;
 
            if Interaction = YearSlideId then
@@ -1583,6 +1591,7 @@ begin
              CurrentSlideId := YearSlideId;
              TextPosition := LengthUTF8(BackupEditText);
              YearEditMode := true;
+             StartTextInput;
            end;
 
            if Interaction = CreatorSlideId then
@@ -1593,6 +1602,7 @@ begin
              CurrentSlideId := CreatorSlideId;
              TextPosition := LengthUTF8(BackupEditText);
              CreatorEditMode := true;
+             StartTextInput;
            end;
 
            // Interaction = 7 // Mp3SlideId
@@ -1609,6 +1619,7 @@ begin
              CurrentSlideId := BPMSlideId;
              TextPosition := LengthUTF8(BackupEditText);
              BPMEditMode := true;
+             StartTextInput;
            end;
 
            // Interaction = 13 // GAPSlideId
@@ -1625,6 +1636,7 @@ begin
              CurrentSlideId := MedleyStartSlideId;
              TextPosition := LengthUTF8(BackupEditText);
              P1EditMode := true;
+             StartTextInput;
            end;
 
            if Interaction = MedleyEndSlideId then
@@ -1635,6 +1647,7 @@ begin
              CurrentSlideId := MedleyEndSlideId;
              TextPosition := LengthUTF8(BackupEditText);
              P2EditMode := true;
+             StartTextInput;
            end;
 
            // Interaction = 20 // StartSlideId
@@ -1649,6 +1662,7 @@ begin
              CurrentSlideId := LyricSlideId;
              TextPosition := LengthUTF8(BackupEditText);
              TextEditMode := true;
+             StartTextInput;
            end;
 
            if Interaction = 24 then // UndoButtonId
@@ -2230,6 +2244,7 @@ begin
           CreatorEditMode := false;
           P1EditMode := false;
           P2EditMode := false;
+          StopTextInput;
           editLengthText := 0;
           TextPosition := -1;
         end;
@@ -2349,6 +2364,7 @@ begin
           P1EditMode := false;
           P2EditMode := false;
           TextEditMode := false;
+          StopTextInput;
           editLengthText := 0;
           TextPosition := -1;
           CurrentSlideId := -1;
@@ -2408,6 +2424,7 @@ begin
             // divide note
             DivideNote(false);
             TextEditMode := false;
+            StopTextInput;
             EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
             EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
             GoldenRec.KillAll;
@@ -2449,6 +2466,7 @@ begin
           // exit BPM edit mode, restore previous BPM value
           SelectsS[CurrentSlideId].TextOpt[0].Text := FloatToStr(CurrentSong.BPM[0].BPM / 4);
           BPMEditMode := false;
+          StopTextInput;
           editLengthText := 0;
           TextPosition := -1;
         end;
@@ -2472,6 +2490,7 @@ begin
           end;
 
           BPMEditMode := false;
+          StopTextInput;
           editLengthText := 0;
           TextPosition := -1;
           CurrentSlideId := -1;
@@ -5000,6 +5019,7 @@ begin
   P1EditMode := false;
   P2EditMode := false;
   BPMEditMode := false;
+  StopTextInput;
 
   editLengthText := 0;
   TextPosition := -1;

--- a/src/screens/UScreenJukebox.pas
+++ b/src/screens/UScreenJukebox.pas
@@ -1371,8 +1371,8 @@ begin
     end
     else
     begin
-      case UCS4UpperCase(CharCode) of
-        Ord('Q'):
+      case PressedKey of
+        SDLK_Q:
         begin
           // when not ask before exit then finish now
           if (Ini.AskbeforeDel <> 1) then
@@ -1386,7 +1386,7 @@ begin
         end;
 
         // show visualization
-        Ord('V'):
+        SDLK_V:
         begin
           if fShowWebcam then
           begin
@@ -1431,7 +1431,7 @@ begin
         end;
 
         // show Webcam
-      Ord('W'):
+      SDLK_W:
       begin
         if (fShowWebCam = false) then
         begin
@@ -1461,7 +1461,7 @@ begin
       end;
 
         // allow search for songs
-        Ord('J'):
+        SDLK_J:
         begin
           if (SongListVisible) then
           begin
@@ -1490,7 +1490,7 @@ begin
         end;
 
         // skip intro
-        Ord('S'):
+        SDLK_S:
         begin
           if (AudioPlayback.Position < CurrentSong.gap / 1000 - 6) then
           begin
@@ -1502,13 +1502,13 @@ begin
         end;
 
         // pause
-        Ord('P'):
+        SDLK_P:
         begin
           Pause;
           Exit;
         end;
 
-        Ord('R'):
+        SDLK_R:
         begin
           if (SongListVisible) then
           begin
@@ -1517,7 +1517,7 @@ begin
         end;
 
         // toggle time display
-        Ord('T'):
+        SDLK_T:
         begin
           LastTick := SDL_GetTicks();
 

--- a/src/screens/UScreenJukebox.pas
+++ b/src/screens/UScreenJukebox.pas
@@ -278,6 +278,7 @@ uses
   UHelp,
   ULanguage,
   ULog,
+  UMain,
   UMenuButton,
   UMenuInteract,
   UNote,
@@ -692,6 +693,7 @@ begin
   Button[JukeboxRandomSongList].SetSelect(false);
   Button[JukeboxRepeatSongList].SetSelect(false);
   Button[JukeboxFindSong].SetSelect(false);
+  StopTextInput;
   Button[JukeboxPlayPause].SetSelect(false);
   Button[JukeboxFindSong].Text[0].Selected := false;
 end;
@@ -759,6 +761,7 @@ begin
 
   if (SongListVisible) then
   begin
+    // SetTextInput(Button[JukeboxFindSong].Selected);
 
     if (BtnDown) then //and (MouseButton = SDL_BUTTON_LEFT) then
     begin
@@ -968,6 +971,7 @@ begin
             end;
 
             Button[JukeboxFindSong].SetSelect(FindSongList);
+            SetTextInput(FindSongList);
 
             if not (FindSongList) and (Length(JukeboxSongsList) <> Length(JukeboxVisibleSongs)) then
             begin
@@ -990,6 +994,7 @@ begin
           begin
             SongMenuVisible := false;
             SongListVisible := false;
+            StopTextInput;
 
             Button[JukeboxOptions].SetSelect(false);
             ScreenJukeboxOptions.Visible := true;
@@ -1098,9 +1103,15 @@ begin
         Button[JukeboxOptions].SetSelect(false);
 
       if InRegion(X, Y, Button[JukeboxFindSong].GetMouseOverArea) then
-        Button[JukeboxFindSong].SetSelect(true)
+      begin
+        Button[JukeboxFindSong].SetSelect(true);
+        StartTextInput;
+      end
       else
+      begin
         Button[JukeboxFindSong].SetSelect(FindSongList);
+        SetTextInput(FindSongList);
+      end;
 
     end;
   end;
@@ -1150,6 +1161,7 @@ begin
       begin
         SongMenuVisible := false;
         SongListVisible := false;
+        StopTextInput;
 
         Button[JukeboxSongMenuOptions].SetSelect(false);
 
@@ -1470,6 +1482,7 @@ begin
             if (Filter = '') and (FindSongList) then
                 Button[JukeboxFindSong].Text[0].Text := '';
             Button[JukeboxFindSong].SetSelect(FindSongList);
+            SetTextInput(FindSongList);
             if FindSongList then
               FilterSongList(Filter)
             else
@@ -1484,6 +1497,7 @@ begin
             if (Filter = '') then
                 Button[JukeboxFindSong].Text[0].Text := '';
             Button[JukeboxFindSong].SetSelect(FindSongList);
+            SetTextInput(FindSongList);
             FilterSongList(Filter);
             Exit;
           end;
@@ -1618,6 +1632,7 @@ begin
             end;
 
             Button[JukeboxFindSong].SetSelect(FindSongList);
+            SetTextInput(FindSongList);
 
             if not (FindSongList) then
             begin
@@ -1661,6 +1676,7 @@ begin
             begin
               FindSongList:=false;
               Button[JukeboxFindSong].SetSelect(FindSongList);
+              SetTextInput(FindSongList);
               Exit;
             end;
             Button[JukeboxFindSong].Text[0].DeleteLastLetter();
@@ -1707,6 +1723,7 @@ begin
             begin
               FindSongList:=false;
               Button[JukeboxFindSong].SetSelect(FindSongList);
+              SetTextInput(FindSongList);
             end;
             if (High(JukeboxVisibleSongs) < 0) then
             begin

--- a/src/screens/UScreenJukeboxPlaylist.pas
+++ b/src/screens/UScreenJukeboxPlaylist.pas
@@ -93,8 +93,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenLevel.pas
+++ b/src/screens/UScreenLevel.pas
@@ -72,8 +72,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenMain.pas
+++ b/src/screens/UScreenMain.pas
@@ -97,13 +97,13 @@ begin
   if (PressedDown) then
   begin // Key Down
         // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('S'): begin
+    case PressedKey of
+      SDLK_S: begin
         FadeTo(@ScreenName, SoundLib.Start);
         Exit;
       end;
 
-      Ord('P'): begin
+      SDLK_P: begin
         if (Ini.Players >= 1) and (Party.ModesAvailable) then
         begin
           FadeTo(@ScreenPartyOptions, SoundLib.Start);
@@ -111,43 +111,43 @@ begin
         end;
       end;
 
-      Ord('J'): begin
+      SDLK_J: begin
         FadeTo(@ScreenJukeboxPlaylist, SoundLib.Start);
         Exit;
       end;
 
-      Ord('R'): begin
+      SDLK_R: begin
         UGraphic.UnLoadScreens();
         Theme.LoadTheme(Ini.Theme, Ini.Color);
         UGraphic.LoadScreens(USDXVersionStr);
       end;
 
-      Ord('T'): begin
+      SDLK_T: begin
         FadeTo(@ScreenStatMain, SoundLib.Start);
         Exit;
       end;
 
-      Ord('E'): begin
+      SDLK_E: begin
         FadeTo(@ScreenEdit, SoundLib.Start);
         Exit;
       end;
 
-      Ord('O'): begin
+      SDLK_O: begin
         FadeTo(@ScreenOptions, SoundLib.Start);
         Exit;
       end;
 
-      Ord('A'): begin
+      SDLK_A: begin
         FadeTo(@ScreenAbout, SoundLib.Start);
         Exit;
       end;
 
-      Ord('C'): begin
+      SDLK_C: begin
          FadeTo(@ScreenCredits, SoundLib.Start);
          Exit;
       end;
 
-      Ord('Q'): begin
+      SDLK_Q: begin
         Result := false;
         Exit;
       end;

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -148,6 +148,7 @@ begin
   Result := true;
 
   inherited ParseMouse(MouseButton, BtnDown, X, Y);
+  SetTextInput(Button[PlayerName].Selected);
 
   // transfer mousecords to the 800x600 raster we use to draw
   X := Round((X / (ScreenW / Screens)) * RenderW);

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -131,6 +131,7 @@ uses
   UHelp,
   ULanguage,
   ULog,
+  UMain,
   UMenuButton,
   UPath,
   USkins,
@@ -294,8 +295,8 @@ begin
     if (not Button[PlayerName].Selected) then
     begin
       // check normal keys
-      case UCS4UpperCase(CharCode) of
-        Ord('Q'):
+      case PressedKey of
+        SDLK_Q:
           begin
             Result := false;
             Exit;
@@ -347,6 +348,7 @@ begin
 
       SDLK_ESCAPE :
         begin
+          StopTextInput;
           Ini.SaveNames;
           AudioPlayback.PlaySound(SoundLib.Back);
           if GoTo_SingScreen then
@@ -357,6 +359,7 @@ begin
 
       SDLK_RETURN:
         begin
+          StopTextInput;
           Ini.Players := CountIndex;
           PlayersPlay:= UIni.IPlayersVals[CountIndex];
 
@@ -427,11 +430,13 @@ begin
       SDLK_DOWN:
       begin
         InteractNext;
+        SetTextInput(Button[PlayerName].Selected);
       end;
 
       SDLK_UP:
       begin
         InteractPrev;
+        SetTextInput(Button[PlayerName].Selected);
       end;
 
       SDLK_RIGHT:

--- a/src/screens/UScreenOptions.pas
+++ b/src/screens/UScreenOptions.pas
@@ -93,56 +93,56 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('G'):
+    case PressedKey of
+      SDLK_G:
         begin
           FadeTo(@ScreenOptionsGame, SoundLib.Start);
           Exit;
         end;
 
-      Ord('H'):
+      SDLK_H:
         begin
           FadeTo(@ScreenOptionsGraphics, SoundLib.Start);
           Exit;
         end;
 
-      Ord('S'):
+      SDLK_S:
         begin
           FadeTo(@ScreenOptionsSound, SoundLib.Start);
           Exit;
         end;
 
-      Ord('I'):
+      SDLK_I:
         begin
           FadeTo(@ScreenOptionsInput, SoundLib.Start);
           Exit;
         end;
 
-      Ord('L'):
+      SDLK_L:
         begin
           FadeTo(@ScreenOptionsLyrics, SoundLib.Start);
           Exit;
         end;
 
-      Ord('T'):
+      SDLK_T:
         begin
           FadeTo(@ScreenOptionsThemes, SoundLib.Start);
           Exit;
         end;
 
-      Ord('R'):
+      SDLK_R:
         begin
           FadeTo(@ScreenOptionsRecord, SoundLib.Start);
           Exit;
         end;
 
-      Ord('A'):
+      SDLK_A:
         begin
           FadeTo(@ScreenOptionsAdvanced, SoundLib.Start);
           Exit;
         end;
 
-      Ord('N'):
+      SDLK_N:
         begin
           if (High(DataBase.NetworkUser) = -1) then
             ScreenPopupError.ShowPopup(Language.Translate('SING_OPTIONS_NETWORK_NO_DLL'))
@@ -154,19 +154,19 @@ begin
           Exit;
         end;
 
-      Ord('W'):
+      SDLK_W:
         begin
           FadeTo(@ScreenOptionsWebcam, SoundLib.Start);
           Exit;
         end;
 
-      Ord('J'):
+      SDLK_J:
         begin
           FadeTo(@ScreenOptionsJukebox, SoundLib.Start);
           Exit;
         end;
 
-      Ord('Q'):
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenOptionsAdvanced.pas
+++ b/src/screens/UScreenOptionsAdvanced.pas
@@ -68,8 +68,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenOptionsGame.pas
+++ b/src/screens/UScreenOptionsGame.pas
@@ -92,8 +92,8 @@ begin
   if PressedDown then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenOptionsGraphics.pas
+++ b/src/screens/UScreenOptionsGraphics.pas
@@ -82,8 +82,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenOptionsInput.pas
+++ b/src/screens/UScreenOptionsInput.pas
@@ -92,8 +92,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenOptionsJukebox.pas
+++ b/src/screens/UScreenOptionsJukebox.pas
@@ -128,8 +128,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenOptionsLyrics.pas
+++ b/src/screens/UScreenOptionsLyrics.pas
@@ -77,8 +77,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenOptionsRecord.pas
+++ b/src/screens/UScreenOptionsRecord.pas
@@ -139,25 +139,25 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;
         end;
-      Ord('+'):
+      SDLK_PLUS:
         begin
           // FIXME: add a nice volume-slider instead
           // or at least provide visualization and acceleration if the user holds the key pressed.
           ChangeVolume(0.02);
         end;
-      Ord('-'):
+      SDLK_MINUS:
         begin
           // FIXME: add a nice volume-slider instead
           // or at least provide visualization and acceleration if the user holds the key pressed.
           ChangeVolume(-0.02);
         end;
-      Ord('T'):
+      SDLK_T:
         begin
           if ((SDL_GetModState() and KMOD_SHIFT) <> 0) then
             Ini.ThresholdIndex := (Ini.ThresholdIndex + Length(IThresholdVals) - 1) mod Length(IThresholdVals)

--- a/src/screens/UScreenOptionsSound.pas
+++ b/src/screens/UScreenOptionsSound.pas
@@ -70,8 +70,8 @@ begin
   if (PressedDown) then
   begin // Key Down
         // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
       begin
         Result := false;
         Exit;

--- a/src/screens/UScreenOptionsThemes.pas
+++ b/src/screens/UScreenOptionsThemes.pas
@@ -84,8 +84,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenOptionsWebcam.pas
+++ b/src/screens/UScreenOptionsWebcam.pas
@@ -85,8 +85,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           if (PreVisualization) then Webcam.Release;
           Result := false;

--- a/src/screens/UScreenPartyNewRound.pas
+++ b/src/screens/UScreenPartyNewRound.pas
@@ -113,8 +113,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenPartyOptions.pas
+++ b/src/screens/UScreenPartyOptions.pas
@@ -103,8 +103,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenPartyPlayer.pas
+++ b/src/screens/UScreenPartyPlayer.pas
@@ -316,8 +316,8 @@ begin
   else
   begin
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenPartyPlayer.pas
+++ b/src/screens/UScreenPartyPlayer.pas
@@ -80,6 +80,7 @@ type
       constructor Create; override;
       function ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean; out SuppressKey: boolean): boolean; override;
       function ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean; override;
+      function ParseMouse(MouseButton: integer; BtnDown: boolean; X, Y: integer): boolean; override;
       procedure OnShow; override;
       
       procedure SetAnimationProgress(Progress: real); override;
@@ -250,6 +251,7 @@ function TScreenPartyPlayer.ParseInput(PressedKey: cardinal; CharCode: UCS4Char;
     until ((Interactions[Interaction].Typ = iSelectS) and
       SelectsS[Interactions[Interaction].Num].Visible) or
       (Button[Interactions[Interaction].Num].Visible);
+    SetTextInput(Interactions[Interaction].Typ = iButton);
   end;
   procedure IntPrev;
   begin
@@ -258,6 +260,7 @@ function TScreenPartyPlayer.ParseInput(PressedKey: cardinal; CharCode: UCS4Char;
     until ((Interactions[Interaction].Typ = iSelectS) and
       SelectsS[Interactions[Interaction].Num].Visible) or
       (Button[Interactions[Interaction].Num].Visible);
+    SetTextInput(Interactions[Interaction].Typ = iButton);
   end;
   procedure HandleNameTemplate(const index: integer);
   var
@@ -455,6 +458,13 @@ begin
         end;
       end;
   end;
+end;
+
+function TScreenPartyPlayer.ParseMouse(MouseButton: integer; BtnDown: boolean; X, Y: integer): boolean;
+begin
+  Result := true;
+  inherited ParseMouse(MouseButton, BtnDown, X, Y);
+  SetTextInput(Interactions[Interaction].Typ = iButton);
 end;
 
 constructor TScreenPartyPlayer.Create;

--- a/src/screens/UScreenPartyRounds.pas
+++ b/src/screens/UScreenPartyRounds.pas
@@ -172,8 +172,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenPartyScore.pas
+++ b/src/screens/UScreenPartyScore.pas
@@ -98,8 +98,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenPartyTournamentOptions.pas
+++ b/src/screens/UScreenPartyTournamentOptions.pas
@@ -108,8 +108,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenPartyTournamentPlayer.pas
+++ b/src/screens/UScreenPartyTournamentPlayer.pas
@@ -333,8 +333,8 @@ begin
   else
   begin
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenPartyTournamentRounds.pas
+++ b/src/screens/UScreenPartyTournamentRounds.pas
@@ -148,8 +148,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenPartyTournamentWin.pas
+++ b/src/screens/UScreenPartyTournamentWin.pas
@@ -84,8 +84,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenPartyWin.pas
+++ b/src/screens/UScreenPartyWin.pas
@@ -87,8 +87,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenPopup.pas
+++ b/src/screens/UScreenPopup.pas
@@ -398,6 +398,7 @@ begin
         begin
           Value := false;
           Visible := false;
+          StopTextInput;
           Result := false;
         end;
 
@@ -430,6 +431,7 @@ begin
           Value := (Interaction = 2);
           if (Interaction = 3) then
             Visible := false;
+            StopTextInput;
           Result := false;
         end;
 
@@ -498,6 +500,7 @@ procedure TScreenPopupInsertUser.ShowPopup(const Title: UTF8String; Msg: UTF8Str
 begin
 
   Visible := true;  //Set Visible
+  StartTextInput;
   fHandler := Handler;
   fHandlerData := HandlerData;
 
@@ -558,6 +561,7 @@ begin
         begin
           Value := 0;
           Visible := false;
+          StopTextInput;
           Result := false;
         end;
 
@@ -583,6 +587,7 @@ begin
           begin
             Value := 0;
             Visible := false;
+            StopTextInput;
             Result := false;
           end;
         end;
@@ -594,12 +599,14 @@ begin
           begin
             Value := 1;
             Visible := false;
+            StopTextInput;
           end;
 
           if (Interaction = 6) then
           begin
             Value := 2;
             Visible := false;
+            StopTextInput;
           end;
 
           Result := false;
@@ -792,6 +799,7 @@ var
 begin
 
   Visible := true;  //Set Visible
+  StartTextInput;
   fHandler := Handler;
   fHandlerData := HandlerData;
   Password := '';

--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -364,8 +364,8 @@ begin
   if (PressedDown) then
   begin
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -778,14 +778,14 @@ begin
     // **********************
 
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;
         end;
 
-      Ord('F'):
+      SDLK_F:
         begin
           if (Mode = smNormal) and (SDL_ModState = KMOD_LSHIFT) and MakeMedley then
           begin
@@ -805,7 +805,7 @@ begin
           end;
         end;
 
-      Ord('M'): //Show SongMenu
+      SDLK_M: //Show SongMenu
         begin
           if (Songs.SongList.Count > 0) then
           begin
@@ -862,7 +862,7 @@ begin
           Exit;
         end;
 
-      Ord('P'): //Show Playlist Menu
+      SDLK_P: //Show Playlist Menu
         begin
           if (Songs.SongList.Count > 0) and (FreeListMode) then
           begin
@@ -872,7 +872,7 @@ begin
           Exit;
         end;
 
-      Ord('J'): //Show Jumpto Menu
+      SDLK_J: //Show Jumpto Menu
         begin
           if (Songs.SongList.Count > 0) and (FreeListMode) then
           begin
@@ -881,13 +881,13 @@ begin
           Exit;
         end;
 
-      Ord('E'):
+      SDLK_E:
         begin
           OpenEditor;
           Exit;
         end;
 
-      Ord('S'):
+      SDLK_S:
         begin
           if not (SDL_ModState = KMOD_LSHIFT) and (CatSongs.Song[Interaction].Medley.Source>=msTag)
             and not MakeMedley and (Mode = smNormal) then
@@ -898,7 +898,7 @@ begin
             StartMedley(0, msCalculated);
         end;
 
-      Ord('D'):
+      SDLK_D:
         begin
           if not (SDL_ModState = KMOD_LSHIFT) and (Mode = smNormal) and
             (Length(getVisibleMedleyArr(msTag)) > 0) and not MakeMedley then
@@ -908,7 +908,7 @@ begin
             StartMedley(5, msCalculated);
         end;
 
-      Ord('R'):
+      SDLK_R:
         begin
           Randomize;
           if (Songs.SongList.Count > 0) and
@@ -987,7 +987,7 @@ begin
           Exit;
         end;
 
-      Ord('W'):
+      SDLK_W:
         begin
 
           if not CatSongs.Song[Interaction].Main then

--- a/src/screens/UScreenSongJumpto.pas
+++ b/src/screens/UScreenSongJumpto.pas
@@ -196,6 +196,7 @@ begin
   if (fVisible = false) and (Value = true) then
     OnShow;
 
+  SetTextInput(Value);
   fVisible := Value;
 end;
 

--- a/src/screens/UScreenSongMenu.pas
+++ b/src/screens/UScreenSongMenu.pas
@@ -143,8 +143,8 @@ begin
     end;
 
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenStatDetail.pas
+++ b/src/screens/UScreenStatDetail.pas
@@ -83,8 +83,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenStatMain.pas
+++ b/src/screens/UScreenStatMain.pas
@@ -83,8 +83,8 @@ begin
   if (PressedDown) then
   begin // Key Down
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/UScreenTop5.pas
+++ b/src/screens/UScreenTop5.pas
@@ -86,8 +86,8 @@ begin
   if PressedDown then
   begin
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
         begin
           Result := false;
           Exit;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -234,8 +234,8 @@ begin
     + KMOD_LCTRL + KMOD_RCTRL + KMOD_LALT  + KMOD_RALT);
 
     // check normal keys
-    case UCS4UpperCase(CharCode) of
-      Ord('Q'):
+    case PressedKey of
+      SDLK_Q:
       begin
         // when not ask before exit then finish now
         if (Ini.AskbeforeDel <> 1) then
@@ -249,7 +249,7 @@ begin
       end;
 
       //Restart and pause song
-      Ord('R'):
+      SDLK_R:
       begin
         if ScreenSong.Mode = smMedley then Exit;
         for i1 := 0 to High(Player) do
@@ -289,7 +289,7 @@ begin
       end;
 
       // show visualization
-      Ord('V'):
+      SDLK_V:
       begin
         if fShowWebcam then
         begin
@@ -334,7 +334,7 @@ begin
       end;
 
       // show Webcam
-      Ord('W'):
+      SDLK_W:
       begin
         if (fShowWebCam = false) then
         begin
@@ -364,14 +364,14 @@ begin
       end;
 
       // pause
-      Ord('P'):
+      SDLK_P:
       begin
         Pause;
         Exit;
       end;
 
       // toggle time display: running time/remaining time/total time / SHIFT: show/hide time bar
-      Ord('T'):
+      SDLK_T:
       begin
         if (SDL_ModState = KMOD_LSHIFT) then
         begin
@@ -395,7 +395,7 @@ begin
       end;
 
       // skip intro / SHIFT: show/hide score display
-      Ord('S'):
+      SDLK_S:
       begin
         if (SDL_ModState = KMOD_LSHIFT) then
         begin
@@ -420,7 +420,7 @@ begin
       end;
 
       // SHIFT: show/hide oscilloscope
-      Ord('O'):
+      SDLK_O:
       begin
         if (SDL_ModState = KMOD_LSHIFT) then
         begin
@@ -433,7 +433,7 @@ begin
       end;
 
       // SHIFT: show/hide notes
-      Ord('N'):
+      SDLK_N:
       begin
         if (SDL_ModState = KMOD_LSHIFT) then
         begin
@@ -446,7 +446,7 @@ begin
       end;
 
       // SHIFT: show/hide notes
-      Ord('L'):
+      SDLK_L:
       begin
         if (SDL_ModState = KMOD_LSHIFT) then
         begin
@@ -459,7 +459,7 @@ begin
       end;
 
       // SHIFT: show/hide avatars and player names
-      Ord('A'):
+      SDLK_A:
       begin
         if (SDL_ModState = KMOD_LSHIFT) then
         begin
@@ -480,7 +480,7 @@ begin
       end;
 
       // SHIFT: show/hide microphone input/sung notes
-      Ord('I'):
+      SDLK_I:
       begin
         if (SDL_ModState = KMOD_LSHIFT) then
         begin
@@ -493,7 +493,7 @@ begin
       end;
 
       // SHIFT: show/hide (toggle) all display elements
-      Ord('H'):
+      SDLK_H:
       begin
         if (SDL_ModState = KMOD_LSHIFT) then
         begin


### PR DESCRIPTION
fixes #743 

this attempts to fix the double keypresses that cause issues like "pause not working" by defaulting to `SDL_StopTextInput` and _only_ explicitly enabling (and subsequently disabling) it when we actually need it. Drawbacks are that manual disabling is required, although it will eventually fix itself if you go through a couple of screens/fields.

**FOR THE TIME BEING THIS IS A DRAFT UNTIL MORE TESTING HAS BEEN DONE.** Currently, at least the following unchecked areas still need attention:

- [x] Party mode
- [x] Jukebox mode
- [x] Web highscore plugins (you need to enter username/password at some point)
- [x] Mouse interaction/navigation (in items already fixed at time of creating this PR, ie: player name, song jumpto, editor) -- for other items do it when fixing it for keyboard

However, the upside is that it will generally manifest as "I can't edit field x on screen y". If you discover a non-working input field not covered by any of the _un_checked items above, please report them as a comment on this ticket.

I still don't like the `SDL_KEYDOWN, SDL_TEXTINPUT:` handler in UMain, but rewriting _that_ is something I wouldn't consider until this has been merged for a while.