### PR TITLE
Fix audio playback buffer

### DIFF
--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -285,7 +285,7 @@ type
       function IsEOF(): boolean;            virtual; abstract;
       function IsError(): boolean;          virtual; abstract;
     public
-      function ReadData(Buffer: PByteArray; BufferSize: integer): integer; virtual; abstract;
+      function ReadData(Buffer: PByte; BufferSize: integer): integer; virtual; abstract;
 
       property EOF: boolean read IsEOF;
       property Error: boolean read IsError;

--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -790,7 +790,7 @@ begin
     CurrentAudioDecoder := InterfaceList[i] as IAudioDecoder;
     if (not CurrentAudioDecoder.InitializeDecoder()) then
     begin
-      Log.LogError('Initialize failed, Removing - '+ CurrentAudioDecoder.GetName);
+      Log.LogError('Initialize failed, Removing decoder: '+ CurrentAudioDecoder.GetName);
       MediaManager.Remove(CurrentAudioDecoder);
     end;
   end;
@@ -810,7 +810,7 @@ begin
       DefaultAudioPlayback := CurrentAudioPlayback;
       break;
     end;
-    Log.LogError('Initialize failed, Removing - '+ CurrentAudioPlayback.GetName);
+    Log.LogError('Initialize failed, Removing playback: '+ CurrentAudioPlayback.GetName);
     MediaManager.Remove(CurrentAudioPlayback);
   end;
 
@@ -825,7 +825,7 @@ begin
       DefaultAudioInput := CurrentAudioInput;
       break;
     end;
-    Log.LogError('Initialize failed, Removing - '+ CurrentAudioInput.GetName);
+    Log.LogError('Initialize failed, Removing input: '+ CurrentAudioInput.GetName);
     MediaManager.Remove(CurrentAudioInput);
   end;
 

--- a/src/base/URingBuffer.pas
+++ b/src/base/URingBuffer.pas
@@ -47,7 +47,7 @@ type
     public
       constructor Create(Size: integer);
       destructor Destroy; override;
-      function Read(Buffer: PByteArray; Count: integer): integer;
+      function Read(Buffer: PByte; Count: integer): integer;
       function Write(Buffer: PByteArray; Count: integer): integer;
       function Size(): integer;
       function Available(): integer;
@@ -73,7 +73,7 @@ begin
   FreeMem(RingBuffer);
 end;
 
-function TRingBuffer.Read(Buffer: PByteArray; Count: integer): integer;
+function TRingBuffer.Read(Buffer: PByte; Count: integer): integer;
 var
   PartCount: integer;
 begin

--- a/src/media/UAudioDecoder_Bass.pas
+++ b/src/media/UAudioDecoder_Bass.pas
@@ -66,7 +66,7 @@ type
       function IsEOF(): boolean;             override;
       function IsError(): boolean;           override;
 
-      function ReadData(Buffer: PByteArray; BufSize: integer): integer; override;
+      function ReadData(Buffer: PByte; BufSize: integer): integer; override;
   end;
 
 type
@@ -194,7 +194,7 @@ begin
   Result := Error;
 end;
 
-function TBassDecodeStream.ReadData(Buffer: PByteArray; BufSize: integer): integer;
+function TBassDecodeStream.ReadData(Buffer: PByte; BufSize: integer): integer;
 var
   Report: string;
   I: Integer;

--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -204,7 +204,7 @@ type
       function IsEOF(): boolean;             override;
       function IsError(): boolean;           override;
 
-      function ReadData(Buffer: PByteArray; BufferSize: integer): integer; override;
+      function ReadData(Buffer: PByte; BufferSize: integer): integer; override;
   end;
 
 type
@@ -1302,7 +1302,7 @@ begin
   end;
 end;
 
-function TFFmpegDecodeStream.ReadData(Buffer: PByteArray; BufferSize: integer): integer;
+function TFFmpegDecodeStream.ReadData(Buffer: PByte; BufferSize: integer): integer;
 var
   CopyByteCount:   integer; // number of bytes to copy
   RemainByteCount: integer; // number of bytes left (remain) to read

--- a/src/media/UAudioPlaybackBase.pas
+++ b/src/media/UAudioPlaybackBase.pas
@@ -122,7 +122,7 @@ type
       procedure SetLoop(Enabled: boolean); override;
     public
       constructor Create(Buffer: TStream; Format: TAudioFormatInfo);
-      function ReadData(Buffer: PByteArray; BufferSize: integer): integer; override;
+      function ReadData(Buffer: PByte; BufferSize: integer): integer; override;
       function GetAudioFormatInfo(): TAudioFormatInfo; override;
       procedure Close(); override;
   end;
@@ -432,7 +432,7 @@ begin
   fLoop := Enabled;
 end;
 
-function TAudioBufferSourceStream.ReadData(Buffer: PByteArray; BufferSize: integer): integer;
+function TAudioBufferSourceStream.ReadData(Buffer: PByte; BufferSize: integer): integer;
 var
   BufSizeLeft: integer;
   NumRead: integer;

--- a/src/media/UAudioPlayback_Bass.pas
+++ b/src/media/UAudioPlayback_Bass.pas
@@ -93,7 +93,7 @@ type
 
       function GetAudioFormatInfo(): TAudioFormatInfo; override;
 
-      function ReadData(Buffer: PByteArray; BufferSize: integer): integer;
+      function ReadData(Buffer: PByte; BufferSize: integer): integer;
 
       property EOF: boolean READ IsEOF;
   end;
@@ -110,7 +110,7 @@ type
       procedure Close(); override;
 
       procedure WriteData(Buffer: PByteArray; BufferSize: integer); override;
-      function ReadData(Buffer: PByteArray; BufferSize: integer): integer; override;
+      function ReadData(Buffer: PByte; BufferSize: integer): integer; override;
       function IsEOF(): boolean; override;
       function IsError(): boolean; override;
   end;
@@ -185,7 +185,7 @@ begin
     Result := BytesRead;
 end;
 
-function TBassPlaybackStream.ReadData(Buffer: PByteArray; BufferSize: integer): integer;
+function TBassPlaybackStream.ReadData(Buffer: PByte; BufferSize: integer): integer;
 var
   AdjustedSize: integer;
   RequestedSourceSize, SourceSize: integer;
@@ -655,7 +655,7 @@ begin
 end;
 
 // Note: we do not need the read-function for the BASS implementation
-function TBassVoiceStream.ReadData(Buffer: PByteArray; BufferSize: integer): integer;
+function TBassVoiceStream.ReadData(Buffer: PByte; BufferSize: integer): integer;
 begin
   Result := -1;
 end;

--- a/src/media/UAudioPlayback_SoftMixer.pas
+++ b/src/media/UAudioPlayback_SoftMixer.pas
@@ -175,7 +175,7 @@ type
       function Open(ChannelMap: integer; FormatInfo: TAudioFormatInfo): boolean; override;
       procedure Close(); override;
       procedure WriteData(Buffer: PByteArray; BufferSize: integer); override;
-      function ReadData(Buffer: PByteArray; BufferSize: integer): integer; override;
+      function ReadData(Buffer: PByte; BufferSize: integer): integer; override;
       function IsEOF(): boolean; override;
       function IsError(): boolean; override;
   end;
@@ -1026,7 +1026,7 @@ begin
   end;
 end;
 
-function TGenericVoiceStream.ReadData(Buffer: PByteArray; BufferSize: integer): integer;
+function TGenericVoiceStream.ReadData(Buffer: PByte; BufferSize: integer): integer;
 begin
   Result := -1;
 


### PR DESCRIPTION
fixes #750 

I changed it to PByte in the one place I knew needed to be changed, then just propagated from the compile errors from there. I tested on Linux and Windows, no idea about Mac (you'll know at compile time -- maybe Mac uses some file that never gets compiled on the other platforms).

This needed changes in quite a lot of places (all of which seem to have buffer size parameters though, so it _should_ be fine?).

I've deliberately not included the fixes for the Makefile, see #786.