### PR TITLE
Accept both #AUDIO and #MP3 as header tag for the audio file.

### DIFF
--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -1124,8 +1124,8 @@ begin
         Done := Done or 2;
       end
 
-      //MP3 File
-      else if (Identifier = 'MP3') then
+      //Audio File (MP3 is deprecated in favor of AUDIO)
+      else if (Identifier = 'AUDIO') or (Identifier = 'MP3') then
       begin
         EncFile := DecodeFilename(Value);
         if (Self.Path.Append(EncFile).IsFile) then


### PR DESCRIPTION
Since USDX supports many different audio formats (encodings + containers), the original #MP3 header tag should be superseded by the more general #AUDIO header tag. While #MP3 is not deprecated, USDX should support both tags for specifying the audio file.