### PR TITLE
Add the typographer’s apostrophe (U+2019) to the set of punctuation characters

### DIFF
--- a/src/base/UUnicodeUtils.pas
+++ b/src/base/UUnicodeUtils.pas
@@ -284,7 +284,7 @@ function IsPunctuationChar(ch: WideChar): boolean;
 begin
   // TODO: add chars > 255 (or replace with libxml2 functions?)
   case ch of
-    ' '..'/',':'..'@','['..'`','{'..'~',
+    ' '..'/',':'..'@','['..'`','{'..'~',widechar($2019),
     #160..#191,#215,#247:
       Result := true;
     else


### PR DESCRIPTION
Currently, the search field (a.k.a. jump to) does not allow entering this apostrophe because it is neither recognized as alphanumeric nor as punctuation character.

This PR adds the typographers apostrophe (’) to the list of punctuation characters to allow searching for songs that use this apostrophe (e.g. "Let’s Twist Again").