### PR TITLE
use full option names instead of the 1-letter options

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -7,9 +7,9 @@ test -n "$srcdir" && cd "$srcdir"
 
 echo "Updating build configuration files for USDX, please wait..."
 
-autoreconf -isfv
+autoreconf --verbose --install --symlink --force
 if ! [ -e dists/autogen/config.sub ] ; then
 	# autoreconf < 2.70 relied on automake to install aux files
 	# but didn't run it in projects that don't use automake macros
-	automake -a 2>&1 | grep installing || true
+	automake --add-missing 2>&1 | grep installing || true
 fi


### PR DESCRIPTION
usecase:
bohning PM'd me that something in his build system had broken and `configure` nor `autogen.sh` were fixing it. was probably some permission issue (not worth looking into further) but while looking into it it would have been useful if I didn't have to pull up man-pages to figure out what `autogen.sh` was _supposed_ to be doing in the first place.

there's really no reason to use short options for these kind of things.