### PR TITLE
SoftMixer: use libswresample if available

### DIFF
--- a/src/media/UAudioPlayback_SoftMixer.pas
+++ b/src/media/UAudioPlayback_SoftMixer.pas
@@ -441,8 +441,8 @@ begin
   Converter := TAudioConverter_FFmpeg.Create();
   {$ELSEIF Defined(UseSRCResample)}
   Converter := TAudioConverter_SRC.Create();
-//  {$ELSEIF Defined(UseSWResample)}
-//  Converter := TAudioConverter_SWResample.Create();
+  {$ELSEIF Defined(UseSWResample)}
+  Converter := TAudioConverter_SWResample.Create();
   {$ELSE}
   Converter := TAudioConverter_SDL.Create();
   {$IFEND}


### PR DESCRIPTION
In #656 the code for using libswresample was fixed. This commit enables it and prefers it over the SDL resampler.