### PR TITLE
reset the active lyric line's progress when restart command is invoked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ __history
 aclocal.m4
 /autom4te.cache/
 /CMakeFiles/
-link.res
+link*.res
 ppaslink.sh
 /UltraStarDeluxe.app/*
 /dists/autogen/config.guess

--- a/src/base/ULyrics.pas
+++ b/src/base/ULyrics.pas
@@ -248,6 +248,7 @@ end;
  *}
 procedure TLyricEngine.Clear(cBPM: real; cResolution: integer);
 begin
+  UpperLine.CurWord := -1;
   BPM := cBPM;
   Resolution := cResolution;
   LCounter := 0;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -78,6 +78,8 @@ type
 
     procedure LoadNextSong();
     procedure SongError();
+    procedure ResetLinesAndLyrics();
+    procedure ClearLyricEngines();
   public
     CheckPlayerConfigOnNextSong: boolean;
     eSongLoaded: THookableEvent; //< event is called after lyrics of a song are loaded on OnShow
@@ -283,10 +285,9 @@ begin
         end;
 
         LyricsState.SetCurrentTime(CurrentSong.Start);
-        Lyrics.Clear(CurrentSong.BPM[0].BPM, CurrentSong.Resolution);
         LyricsState.UpdateBeats();
-        OnSentenceChange(0, 0);
-        Tracks[0].CurrentLine := 0;
+        ClearLyricEngines;
+        ResetLinesAndLyrics;
 
         Scores.Init;
         Exit;
@@ -578,9 +579,9 @@ begin
         Scores.Init;
 
         AudioPlayback.SetPosition(AudioPlayback.Position - 5.0);
-	LyricsState.SetCurrentTime(AudioPlayback.Position - 5.0);
-	Lyrics.Clear(CurrentSong.BPM[0].BPM, CurrentSong.Resolution);
-	LyricsState.UpdateBeats();
+        LyricsState.SetCurrentTime(AudioPlayback.Position - 5.0);
+        ClearLyricEngines;
+        LyricsState.UpdateBeats();
         if (Assigned(fCurrentVideo)) then
           fCurrentVideo.Position := AudioPlayback.Position - 5.0;
         end;
@@ -1183,9 +1184,7 @@ begin
   AudioInput.CaptureStart;
 
   // main text
-  Lyrics.Clear(CurrentSong.BPM[0].BPM, CurrentSong.Resolution);
-  LyricsDuetP1.Clear(CurrentSong.BPM[0].BPM, CurrentSong.Resolution);
-  LyricsDuetP2.Clear(CurrentSong.BPM[0].BPM, CurrentSong.Resolution);
+  ClearLyricEngines;
 
   if (CurrentSong.isDuet) and (PlayersPlay <> 1) then
   begin
@@ -1244,6 +1243,26 @@ begin
 
   if (ScreenSong.Mode = smMedley) and (PlaylistMedley.CurrentMedleySong>1) then
     onShowFinish;
+end;
+
+// Forces the notes (lines) and lyrics to reset to the start of the song
+procedure TScreenSingController.ResetLinesAndLyrics();
+var
+  i1: integer;
+
+begin
+  for i1 := 0 to PlayersPlay - 1 do
+  begin
+    Tracks[i1].CurrentLine := 0;
+    OnSentenceChange(i1, 0);
+  end;
+end;
+
+procedure TScreenSingController.ClearLyricEngines();
+begin
+    Lyrics.Clear(CurrentSong.BPM[0].BPM, CurrentSong.Resolution);
+    LyricsDuetP1.Clear(CurrentSong.BPM[0].BPM, CurrentSong.Resolution);
+    LyricsDuetP2.Clear(CurrentSong.BPM[0].BPM, CurrentSong.Resolution);
 end;
 
 procedure TScreenSingController.ClearSettings;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -284,6 +284,8 @@ begin
           Scores.AddPlayer(Tex_ScoreBG[i1], Color);
         end;
         LyricsState.SetCurrentTime(CurrentSong.Start);
+        Lyrics.Clear(CurrentSong.BPM[0].BPM, CurrentSong.Resolution);
+        LyricsState.UpdateBeats;
         Scores.Init;
         Exit;
       end;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -248,7 +248,7 @@ begin
         Exit;
       end;
 
-      //Restart and pause song
+      // restart song
       SDLK_R:
       begin
         if ScreenSong.Mode = smMedley then Exit;
@@ -283,9 +283,13 @@ begin
         begin
           Scores.AddPlayer(Tex_ScoreBG[i1], Color);
         end;
+
         LyricsState.SetCurrentTime(CurrentSong.Start);
         Lyrics.Clear(CurrentSong.BPM[0].BPM, CurrentSong.Resolution);
-        LyricsState.UpdateBeats;
+        LyricsState.UpdateBeats();
+        OnSentenceChange(0, 0);
+        Tracks[0].CurrentLine := 0;
+
         Scores.Init;
         Exit;
       end;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -74,11 +74,9 @@ type
 type
   TScreenSingController = class(TMenu)
   private
-
     StartNote, EndNote:     TPos;
 
     procedure LoadNextSong();
-
     procedure SongError();
   public
     CheckPlayerConfigOnNextSong: boolean;
@@ -542,7 +540,7 @@ begin
       SDLK_RIGHT:
       begin
         if (SDL_ModState = KMOD_LCTRL) then // seek 5 seconds forward
-        AudioPlayback.SetPosition(AudioPlayback.Position + 5.0);
+          AudioPlayback.SetPosition(AudioPlayback.Position + 5.0);
         if (Assigned(fCurrentVideo)) then
           fCurrentVideo.Position := AudioPlayback.Position + 5.0;
       end;
@@ -550,9 +548,9 @@ begin
       SDLK_LEFT:
       begin
         if (SDL_ModState = KMOD_LCTRL) then // seek 5 seconds backward and reset scores to avoid cheating
-	begin
-	if (AudioPlayback.Position < 20.0) then
-	  exit;
+        begin
+          if (AudioPlayback.Position < 20.0) then
+          exit;
         for i1 := 0 to High(Player) do
         with Player[i1] do
         begin
@@ -577,7 +575,7 @@ begin
         begin
           Scores.AddPlayer(Tex_ScoreBG[i1], Color);
         end;
-	Scores.Init;
+        Scores.Init;
 
         AudioPlayback.SetPosition(AudioPlayback.Position - 5.0);
 	LyricsState.SetCurrentTime(AudioPlayback.Position - 5.0);


### PR DESCRIPTION
There's a bug where when you restart a song that's being played (using the 'r' key by default) the lyrics will no longer show correctly until the song catches up to the point at which it was restarted.  This PR fixes that.  