### PR TITLE
add .gitattributes to have more descriptive git diff hunk headers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pas diff=pascal


### PR DESCRIPTION
When looking at the raw diff, most hunk headers in Pascal source files are currently literally `begin`, which doesn't really say anything useful.

Adding this .gitattributes changes that to print the function the change is in. This won't affect any actual `git apply` of diffs (it's just a comment for humans) but it makes it a lot easier to understand where we're changing things.