### PR TITLE
remove P3=P1+P2 duet hack. fixes #746

### DIFF
--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -613,9 +613,6 @@ begin
                 CurrentTrack := 0;
             end
             else
-              if (Param1 = 3) then
-                CurrentTrack := 2
-            else
             begin
               Log.LogError('Wrong P-Number in file: "' + FileName.ToNative + '"; Line '+IntToStr(FileLineNo)+' (LoadSong)');
               Result := False;
@@ -653,24 +650,14 @@ begin
           end;
 
           // add notes
-          if (CurrentTrack <> 2) then
+          if (Tracks[CurrentTrack].High < 0) or (Tracks[CurrentTrack].High > 5000) then
           begin
-            // P1
-            if (Tracks[CurrentTrack].High < 0) or (Tracks[CurrentTrack].High > 5000) then
-            begin
-              Log.LogError('Found faulty song. Did you forget a P1 or P2 tag? "'+Param0+' '+IntToStr(Param1)+
-              ' '+IntToStr(Param2)+' '+IntToStr(Param3)+ParamLyric+'" -> '+
-              FileNamePath.ToNative+' Line:'+IntToStr(FileLineNo));
-              Break;
-            end;
-            ParseNote(CurrentTrack, Param0, (Param1+Rel[CurrentTrack]) * Mult, Param2 * Mult, Param3, ParamLyric);
-          end
-          else
-          begin
-            // P1 + P2
-            ParseNote(0, Param0, (Param1+Rel[0]) * Mult, Param2 * Mult, Param3, ParamLyric);
-            ParseNote(1, Param0, (Param1+Rel[1]) * Mult, Param2 * Mult, Param3, ParamLyric);
+            Log.LogError('Found faulty song. Did you forget a P1 or P2 tag? "'+Param0+' '+IntToStr(Param1)+
+            ' '+IntToStr(Param2)+' '+IntToStr(Param3)+ParamLyric+'" -> '+
+            FileNamePath.ToNative+' Line:'+IntToStr(FileLineNo));
+            Break;
           end;
+          ParseNote(CurrentTrack, Param0, (Param1+Rel[CurrentTrack]) * Mult, Param2 * Mult, Param3, ParamLyric);
         end // if
 
         else
@@ -680,17 +667,7 @@ begin
           Param1 := ParseLyricIntParam(CurLine, LinePos);
           if self.Relative then
             Param2 := ParseLyricIntParam(CurLine, LinePos); // read one more data for relative system
-
-          // new sentence
-          if not CurrentSong.isDuet then
-            // one singer
-            NewSentence(CurrentTrack, (Param1 + Rel[CurrentTrack]) * Mult, Param2)
-          else
-          begin
-            // P1 + P2
-            NewSentence(0, (Param1 + Rel[0]) * Mult, Param2);
-            NewSentence(1, (Param1 + Rel[1]) * Mult, Param2);
-          end;
+          NewSentence(CurrentTrack, (Param1 + Rel[CurrentTrack]) * Mult, Param2);
         end // if
         else if Param0 = 'B' then
         begin


### PR DESCRIPTION
fixes #746

this makes it so that USDX will outright refuse to load songs that rely on the current behaviour for duets where if you have sentences for P3, they'll end up in both P1 and P2. instead it will now log an error for that txt in Error.log:

```
ERROR:  Wrong P-Number in file: "duetp3hack.txt"; Line 396 (LoadSong)
ERROR:  AnalyseFile failed for "/home/bbq/gits/Ultrastar/USDX/game/songs/songs_extra_some_pony/The Count of Monte Cristo - I know those eyes/duetp3hack.txt".
```

this has been announced as a future breaking change in the release notes of 2024.3.0, but I don't think it'll affect that many people anyway. refusing to load it makes it so that you also can't accidentally delete the shared parts from the editor. a workaround for people that still rely on it will be provided in the next release notes, in the form of "identify duets that use P3. use 2024.3.0. open each of the identified duets in the Editor and Save. they will appear again in the newest version"

side note: P3 was actually always destructive if you saved from the editor: it would just get saved in both the P1 and P2 section.