### PR TITLE
AppImage: avoid build failure due to TERM variable

### DIFF
--- a/dists/linux/build.sh
+++ b/dists/linux/build.sh
@@ -2,6 +2,10 @@
 
 set -eo pipefail
 
+if ! tput setaf 1 || ! tput bold || ! tput sgr0 ; then
+	tput() { return 0 ; }
+fi >/dev/null 2>/dev/null
+
 root=$(pwd)
 
 

--- a/dists/linux/scan_libs.sh
+++ b/dists/linux/scan_libs.sh
@@ -2,6 +2,10 @@
 
 set -eo pipefail
 
+if ! tput setaf 1 || ! tput bold || ! tput sgr0 ; then
+	tput() { return 0 ; }
+fi >/dev/null 2>/dev/null
+
 # TODO: Use list from
 # https://raw.githubusercontent.com/probonopd/AppImages/master/excludelist
 

--- a/dists/linux/tasks.sh
+++ b/dists/linux/tasks.sh
@@ -2,6 +2,10 @@
 
 set -eo pipefail
 
+if ! tput setaf 1 || ! tput bold || ! tput sgr0 ; then
+	tput() { return 0 ; }
+fi >/dev/null 2>/dev/null
+
 root=$(pwd)
 
 SRC="$root/deps"


### PR DESCRIPTION
This redefines tput to an empty function if it would fail when called with the parameters later used in the script.