### PR TITLE
CI: build on Ubuntu 20 instead of 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
 
   build_linux:
     name: Build for Linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
As pointed out by @s09bQ5 [here](https://github.com/UltraStar-Deluxe/USDX/pull/840#discussion_r1601412150), we should build on the oldest available runner for maximum Glibc compatibilty