### PR TITLE
CI: implement build for MacOS 14 (ARM build)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,11 @@ jobs:
           if-no-files-found: error
 
   build_mac:
-    name: Build for MacOS
-    runs-on: macos-13
+    name: Build for MacOS (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-13, macos-14]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -54,6 +57,13 @@ jobs:
         run: |
           VNAME=$(cat VERSION | sed "s/+dev$/+dev-$(git rev-parse --short HEAD)/")
           echo "versionName=$VNAME" >> $GITHUB_ENV
+      - name: Determine Arch
+        run: |
+          if [ "${{ matrix.os }}" = "macos-13" ]; then
+            echo "arch=x86" >> $GITHUB_ENV
+          else
+            echo "arch=ARM" >> $GITHUB_ENV
+          fi
       - name: Install Dependencies
         run: |
           brew install fpc sdl2 sdl2_image automake portaudio lua ffmpeg
@@ -62,12 +72,12 @@ jobs:
           ./autogen.sh
           ./configure
           make macosx-dmg
-          mv UltraStarDeluxe.dmg UltraStarDeluxe-${{ env.versionName }}.dmg
+          mv UltraStarDeluxe.dmg UltraStarDeluxe-${{ env.arch }}-${{ env.versionName }}.dmg
       - name: Upload Image Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MAC-UltraStarDeluxe-image-${{ env.versionName }}
-          path: UltraStarDeluxe-${{ env.versionName }}.dmg
+          name: MAC-${{ env.arch }}-UltraStarDeluxe-image-${{ env.versionName }}
+          path: UltraStarDeluxe-${{ env.arch }}-${{ env.versionName }}.dmg
           if-no-files-found: error
 
   build_linux:

--- a/Makefile.in
+++ b/Makefile.in
@@ -478,6 +478,7 @@ macosx-dmg: macosx-standalone-app
 	find $(USDX_GAME_DIR) -name 'LICENSE.*' -maxdepth 1 -exec cp {} /Volumes/UltraStarDeluxe/Licenses \;
 #	/bin/cp ultrastardx/icons/UltraStarDeluxeVolumeIcon.icns /Volumes/UltraStarDeluxe/.VolumeIcon.icns
 #	/Developer/Tools/SetFile -a C /Volumes/UltraStarDeluxe/.VolumeIcon.icns /Volumes/UltraStarDeluxe
+	codesign --force --deep --sign - /Volumes/UltraStarDeluxe/UltraStarDeluxe.app
 	$(HDIUTIL) detach /Volumes/UltraStarDeluxe
 	$(HDIUTIL) convert UltraStarDeluxe.sparseimage -format UDBZ -o UltraStarDeluxe.dmg
 	$(RM) UltraStarDeluxe.sparseimage


### PR DESCRIPTION
This adds a build for MacOS on ARM. The `codesign` call is necessary for the ARM build, as that version requires apps to be signed, and prevents execution otherwise.
I don't have a Mac, but had people confirm that both the MacOS 13 and MacOS 14 build run fine.