### PR TITLE
CI: upgrade to NSIS 3.05

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
           choco install wget --no-progress
           wget -q https://github.com/newpascal/newpascal/releases/download/np-v1.0.50/newpascal.zip
           7z x -y "newpascal.zip" -o"C:\" > nul
-          wget "https://netcologne.dl.sourceforge.net/project/nsis/NSIS%203/3.04/nsis-3.04-setup.exe"
-          ./nsis-3.04-setup.exe /S
+          wget "https://netcologne.dl.sourceforge.net/project/nsis/NSIS%203/3.05/nsis-3.05-setup.exe"
+          ./nsis-3.05-setup.exe /S
       - name: Build
         run: |
           c:\newpascal\configure.bat


### PR DESCRIPTION
Another day, another CI fix...
This hopefully fixes the super-flaky Windows builds. I've tested that the Windows installer built in the CI with NSIS 3.05 works 

Background:
As part of the Windows CI, we so far downgraded the installed NSIS version on the runner from 3.10 to 3.04, which is the version used by AppVeyor. Version 3.06 introduced a bug that made the installer crash after language selection, and a later version seemingly introduced another bug that made the installer crash even before that.
It seems like there's something going wrong with the down-grading process _some of the time_, as the random build failures complain about a missing function (`LoadAndSetImage`) that was only added in NSIS 3.05.

For now, I've tried repeating CI runs for both 3.04 and 3.05. The former led to a build failure with the aforementioned bug [in 3 out of 10 runs](https://github.com/DeinAlptraum/USDX/actions/runs/9103594960), the latter never produced this bug at all [in 17 runs](https://github.com/DeinAlptraum/USDX/actions/runs/9103678217) so far. 
In the long-term, we should probably look into finding out what goes wrong with the downgrade, or find the issue and contribute an upstream patch.