### PR TITLE
Do not repeat songs when randomizing

### DIFF
--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -80,6 +80,7 @@ type
 
       RandomSongOrder: CardinalArray;
       NextRandomSongIdx: cardinal;
+      RandomSearchOrder: CardinalArray;
 
       procedure StartMusicPreview();
       procedure StartVideoPreview();
@@ -223,6 +224,8 @@ type
       ListMinLine: integer;
 
       SongIndex:    integer; //Index of Song that is playing since UScreenScore...
+
+      NextRandomSearchIdx: cardinal;
 
       constructor Create; override;
       procedure SetScroll;
@@ -1008,13 +1011,26 @@ begin
             end
             else // random in one category
             begin
-              if NextRandomSongIdx >= CatSongs.VisibleSongs then
+              if CatSongs.CatNumShow = -2 then
               begin
-                NextRandomSongIdx := 0;
-                RandomSongOrder := RandomPermute(CatSongs.VisibleSongs);
-              end;
-              SkipTo(RandomSongOrder[NextRandomSongIdx]);
-              Inc(NextRandomSongIdx);
+                if NextRandomSearchIdx >= CatSongs.VisibleSongs then
+                begin
+                  NextRandomSearchIdx := 0;
+                  RandomSearchOrder := RandomPermute(CatSongs.VisibleSongs);
+                end;
+                SkipTo(RandomSearchOrder[NextRandomSearchIdx]);
+                Inc(NextRandomSearchIdx);
+              end
+              else
+              begin
+                if NextRandomSongIdx >= CatSongs.VisibleSongs then
+                begin
+                  NextRandomSongIdx := 0;
+                  RandomSongOrder := RandomPermute(CatSongs.VisibleSongs);
+                end;
+                SkipTo(RandomSongOrder[NextRandomSongIdx]);
+                Inc(NextRandomSongIdx);
+              end
             end;
             AudioPlayback.PlaySound(SoundLib.Change);
 
@@ -1122,6 +1138,7 @@ begin
               begin
                 //Atm: Set Empty Filter
                 CatSongs.SetFilter('', fltAll);
+                NextRandomSearchIdx := CatSongs.VisibleSongs;
 
                 //Show Cat in Top Left Mod
                 HideCatTL;
@@ -1842,7 +1859,8 @@ begin
   LastSelectMouse := 0;
   LastSelectTime := 0;
 
-  NextRandomSongIdx := CatSongs.VisibleSongs
+  NextRandomSongIdx := CatSongs.VisibleSongs;
+  NextRandomSearchIdx := CatSongs.VisibleSongs;
 
 end;
 

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -57,6 +57,7 @@ uses
 
 type
   TVisArr = array of integer;
+  CardinalArray = array of cardinal;
 
   TScreenSong = class(TMenu)
     private
@@ -76,6 +77,9 @@ type
 
       LastSelectMouse: integer;
       LastSelectTime: integer;
+
+      RandomSongOrder: CardinalArray;
+      NextRandomSongIdx: cardinal;
 
       procedure StartMusicPreview();
       procedure StartVideoPreview();
@@ -645,6 +649,24 @@ var
   VerifySong, WebList: string;
   Fix: boolean;
   VS: integer;
+
+  function RandomPermute(Num: integer): CardinalArray;
+  var
+    Ordered: array of cardinal;
+    Idx, i: cardinal;
+  begin
+    SetLength(Ordered, Num);
+    SetLength(Result, Num);
+    for i := 0 to Num-1 do Ordered[i] := i;
+    for i := 0 to Num-1 do
+    begin
+      Idx := Random(Num);
+      Result[i] := Ordered[Idx];
+      Delete(Ordered, Idx, 1);
+      Dec(Num);
+    end;
+  end;
+
 begin
   Result := true;
 
@@ -919,7 +941,6 @@ begin
 
       SDLK_R:
         begin
-          Randomize;
           if (Songs.SongList.Count > 0) and
              (FreeListMode) then
           begin
@@ -987,7 +1008,13 @@ begin
             end
             else // random in one category
             begin
-              SkipTo(Random(CatSongs.VisibleSongs));
+              if NextRandomSongIdx >= CatSongs.VisibleSongs then
+              begin
+                NextRandomSongIdx := 0;
+                RandomSongOrder := RandomPermute(CatSongs.VisibleSongs);
+              end;
+              SkipTo(RandomSongOrder[NextRandomSongIdx]);
+              Inc(NextRandomSongIdx);
             end;
             AudioPlayback.PlaySound(SoundLib.Change);
 
@@ -1814,6 +1841,8 @@ begin
 
   LastSelectMouse := 0;
   LastSelectTime := 0;
+
+  NextRandomSongIdx := CatSongs.VisibleSongs
 
 end;
 

--- a/src/screens/UScreenSongJumpto.pas
+++ b/src/screens/UScreenSongJumpto.pas
@@ -101,6 +101,7 @@ begin
 
         Button[0].Text[0].Text := Button[0].Text[0].Text + UCS4ToUTF8String(CharCode);
         SetTextFound(CatSongs.SetFilter(Button[0].Text[0].Text, fSelectType));
+        ScreenSong.NextRandomSearchIdx := CatSongs.VisibleSongs;
       end;
     end;
 
@@ -112,6 +113,7 @@ begin
           begin
             Button[0].Text[0].DeleteLastLetter();
             SetTextFound(CatSongs.SetFilter(Button[0].Text[0].Text, fSelectType));
+            ScreenSong.NextRandomSearchIdx := CatSongs.VisibleSongs;
           end;
         end;
 
@@ -130,6 +132,7 @@ begin
             //ScreenSong.UnLoadDetailedCover;
             Button[0].Text[0].Text := '';
             CatSongs.SetFilter('', fltAll);
+            ScreenSong.NextRandomSearchIdx := CatSongs.VisibleSongs;
             SetTextFound(0);
           end;
         end;
@@ -151,7 +154,10 @@ begin
           Interaction := 1;
           InteractInc;
           if (Length(Button[0].Text[0].Text) > 0) then
+          begin
             SetTextFound(CatSongs.SetFilter(Button[0].Text[0].Text, fSelectType));
+            ScreenSong.NextRandomSearchIdx := CatSongs.VisibleSongs;
+          end;
           Interaction := 0;
         end;
       SDLK_LEFT:
@@ -159,7 +165,10 @@ begin
           Interaction := 1;
           InteractDec;
           if (Length(Button[0].Text[0].Text) > 0) then
+          begin
             SetTextFound(CatSongs.SetFilter(Button[0].Text[0].Text, fSelectType));
+            ScreenSong.NextRandomSearchIdx := CatSongs.VisibleSongs;
+          end;
           Interaction := 0;
         end;
     end;


### PR DESCRIPTION
Instead of picking a random song whenever R is pressed, this generates a random permutation of all songs, goes to the next one in that order every time R is pressed, and finally generates a new permutation once all songs have come up once.
While in a search, this creates a random queue based on the filtered subset of songs. This queue is reset whenever the search filter is changed.

Depending on what your expectations are, I would say this resolves #186

I have only implemented this for the regular randomization (the "in one category" case) since I have no idea what the category feature does or how I can access it...