### PR TITLE
Make current file name known to the plugin.

### DIFF
--- a/src/lua/ULuaCore.pas
+++ b/src/lua/ULuaCore.pas
@@ -718,6 +718,10 @@ begin
       lua_setfield (State, LUA_REGISTRYINDEX, '_USDX_STATE_ID');
       lua_pop(State, Lua_GetTop(State));
 
+      // make current plugin filename (with absolute path) available to the plugin
+      lua_pushstring(State, PChar(Filename.ToNative));
+      lua_setglobal(State, PChar('current_filename'));
+
       // now run the plugin_init function
       // plugin_init() if false or nothing is returned plugin init is aborted
       if (CallFunctionByName('plugin_init', 0, 1)) then


### PR DESCRIPTION
Hi all

I just came up with this addition. This is useful if the plug-in wants to load additional resources relative to its location.

This is approach is quite daft. For a more intricate solution, we could also create a table with all the paths from `UPathUtils`. I am up for discussion. What do you think?

Kind Regards
Hermann