### PR TITLE
Update AppStream file to meet FlatHub requirements

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,3 +19,5 @@
 6. Attach the artifacts to the release page and publish it.
     Don't forget to also create a PR for this release in
     https://github.com/UltraStar-Deluxe/ultrastar-deluxe.github.io
+7. Create a PR in [the FlatHub repository](https://github.com/flathub/eu.usdx.UltraStarDeluxe) that updates the tag and commit values
+    See this PR for an example: https://github.com/flathub/eu.usdx.UltraStarDeluxe/pull/7/files

--- a/dists/ultrastardx.appdata.xml
+++ b/dists/ultrastardx.appdata.xml
@@ -3,20 +3,25 @@
   <id>eu.usdx.UltraStarDeluxe</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>UltraStar Deluxe</name>
-  <summary>Karaoke program that evaluates your performance</summary>
+  <summary>Karaoke for your PC</summary>
   <description>
     <p>UltraStar Deluxe is a free open source karaoke game for your PC. It records the voice of the players and gives points if they hit the notes. Unlike the commercial alternatives, UltraStar Deluxe allows users to add their own songs.</p>
   </description>
   <project_license>GPL-2.0</project_license>
+  <developer id="eu.usdx">
+    <name>UltraStar Karaoke</name>
+  </developer>
   <url type="homepage">https://usdx.eu/</url>
   <url type="bugtracker">https://github.com/UltraStar-Deluxe/USDX/issues</url>
   <url type="translate">https://www.transifex.com/usdx/usdx</url>
   <screenshots>
     <screenshot type="default">
       <image>https://usdx.eu/images/screenshots/song_6_player_projectm.jpg</image>
+      <caption>A karaoke session with six players</caption>
     </screenshot>
     <screenshot>
       <image>https://usdx.eu/images/screenshots/main_menu.jpg</image>
+      <caption>The main menu</caption>
     </screenshot>
   </screenshots>
   <launchable type="desktop-id">ultrastardx.desktop</launchable>
@@ -24,14 +29,13 @@
   <requires>
     <control>voice</control>
   </requires>
-  <supports>
+  <recommends>
     <control>keyboard</control>
+  </recommends>
+  <supports>
     <control>pointing</control>
     <control>gamepad</control>
   </supports>
-  <recommended>
-    <control>keyboard</control>
-  </recommended>
   <releases>
     <release version="2024.5.1" date="2024-5-18" />
     <release version="2024.3.0" date="2024-3-2" />


### PR DESCRIPTION
The latest FlatHub build failed due to some lint errors on the AppStream file:
https://buildbot.flathub.org/#/builders/7/builds/15587/steps/11/logs/stdio

These were the required fixes:

- Add developer tag (https://docs.flathub.org/docs/for-app-authors/linter/#appstream-missing-developer-name)
- Shorten the summary to be less than 35 characters. Someone might want to suggest something more exciting than "Karaoke for your PC", but 35 characters isn't much to work with! (https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines/#summary)
- Add captions to screenshots (https://docs.flathub.org/docs/for-app-authors/linter/#appstream-screenshot-missing-caption)
- Rename `recommended` tag to `recommends` and remove "keyboard" from `supports`. Each value can only appear once across `recommends`, `supports`, and `required`. (https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-relations)

Also I noticed that there was an issue for documenting the FlatHub release process, so I added a little note in there to contribute to that. I don't know anything else about it though, as this was my first attempted FlatHub release.