### PR TITLE
Ignore invalid #RESOLUTION

### DIFF
--- a/src/base/UFiles.pas
+++ b/src/base/UFiles.pas
@@ -150,8 +150,7 @@ begin
       if Song.Video.IsSet              then    SongFile.WriteLine('#VIDEO:'       + EncodeToken(Song.Video.ToUTF8));
 
       if Song.VideoGAP    <> 0.0       then    SongFile.WriteLine('#VIDEOGAP:'    + FloatToStr(Song.VideoGAP));
-      // TODO: this default also appears in USong.ReadTXTHeader and USong.Clear
-      if Song.Resolution  <> 4         then    SongFile.WriteLine('#RESOLUTION:'  + IntToStr(Song.Resolution));
+      if Song.Resolution  <> USong.DEFAULT_RESOLUTION then    SongFile.WriteLine('#RESOLUTION:'  + IntToStr(Song.Resolution));
       if Song.NotesGAP    <> 0         then    SongFile.WriteLine('#NOTESGAP:'    + IntToStr(Song.NotesGAP));
       if Song.Start       <> 0.0       then    SongFile.WriteLine('#START:'       + FloatToStr(Song.Start));
       if Song.Finish      <> 0         then    SongFile.WriteLine('#END:'         + IntToStr(Song.Finish));

--- a/src/base/UFiles.pas
+++ b/src/base/UFiles.pas
@@ -150,6 +150,7 @@ begin
       if Song.Video.IsSet              then    SongFile.WriteLine('#VIDEO:'       + EncodeToken(Song.Video.ToUTF8));
 
       if Song.VideoGAP    <> 0.0       then    SongFile.WriteLine('#VIDEOGAP:'    + FloatToStr(Song.VideoGAP));
+      // TODO: this default also appears in USong.ReadTXTHeader and USong.Clear
       if Song.Resolution  <> 4         then    SongFile.WriteLine('#RESOLUTION:'  + IntToStr(Song.Resolution));
       if Song.NotesGAP    <> 0         then    SongFile.WriteLine('#NOTESGAP:'    + IntToStr(Song.NotesGAP));
       if Song.Start       <> 0.0       then    SongFile.WriteLine('#START:'       + FloatToStr(Song.Start));

--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -61,6 +61,9 @@ uses
   UUnicodeStringHelper,
   UUnicodeUtils;
 
+const
+  DEFAULT_RESOLUTION = 4; // default #RESOLUTION
+
 type
 
   TSingMode = ( smNormal, smPartyClassic, smPartyFree, smPartyChallenge, smPartyTournament, smJukebox, smPlaylistRandom , smMedley );
@@ -973,9 +976,8 @@ begin
       begin
         TryStrtoInt(Value, self.Resolution);
         if (self.Resolution < 1) then begin
-          // TODO: this hardcoded default also appears in Clear and UFiles.SaveSong
           Log.LogError('Ignoring invalid resolution in song: ' + FullFileName);
-          self.Resolution := 4;
+          self.Resolution := DEFAULT_RESOLUTION;
         end
       end
 
@@ -1477,8 +1479,7 @@ begin
   Video      := PATH_NONE;
   VideoGAP   := 0;
   NotesGAP   := 0;
-  // TODO: this default also appears in ReadTXTHeader and UFiles.SaveSong
-  Resolution := 4;
+  Resolution := DEFAULT_RESOLUTION;
   Creator    := '';
   PreviewStart := 0;
   CalcMedley := true;

--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -971,7 +971,12 @@ begin
       // Resolution
       else if (Identifier = 'RESOLUTION') then
       begin
-        TryStrtoInt(Value, self.Resolution)
+        TryStrtoInt(Value, self.Resolution);
+        if (self.Resolution < 1) then begin
+          // TODO: this hardcoded default also appears in Clear and UFiles.SaveSong
+          Log.LogError('Ignoring invalid resolution in song: ' + FullFileName);
+          self.Resolution := 4;
+        end
       end
 
       // Notes Gap
@@ -1472,6 +1477,7 @@ begin
   Video      := PATH_NONE;
   VideoGAP   := 0;
   NotesGAP   := 0;
+  // TODO: this default also appears in ReadTXTHeader and UFiles.SaveSong
   Resolution := 4;
   Creator    := '';
   PreviewStart := 0;


### PR DESCRIPTION
fixes #859 

only `#RESOLUTION` 1 or higher is now considered valid. if an invalid resolution is encountered, it will log the following line in Error.log at startup:
```
ERROR:  Ignoring invalid resolution in song: /path/to/notes.txt
```
and internally just use the default. It will not modify the file directly, but when saving from the Editor, the illegal line will be permanently removed.

First commit fixes the problem, second commit is some housekeeping to reduce duplicated hardcoding.
