### PR TITLE
Use P1 inverted color to mark selected bar in editor

### DIFF
--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -1661,11 +1661,17 @@ begin
         Rec.Bottom := Rec.Top + 2 * NotesH[0];
         If (NoteType = ntRap) or (NoteType = ntRapGolden) then
         begin
-          glBindTexture(GL_TEXTURE_2D, Tex_Left_Rap[Color].TexNum);
+          If Color = 99 then
+            glBindTexture(GL_TEXTURE_2D, Tex_Left_Rap_Inv.TexNum)
+          else
+            glBindTexture(GL_TEXTURE_2D, Tex_Left_Rap[Color].TexNum)
         end
         else
         begin
-          glBindTexture(GL_TEXTURE_2D, Tex_Left[Color].TexNum);
+          If Color = 99 then
+            glBindTexture(GL_TEXTURE_2D, Tex_Left_Inv.TexNum)
+          else
+            glBindTexture(GL_TEXTURE_2D, Tex_Left[Color].TexNum)
         end;
         glBegin(GL_QUADS);
           glTexCoord2f(0, 0); glVertex2f(Rec.Left,  Rec.Top);
@@ -1681,11 +1687,17 @@ begin
 
         If (NoteType = ntRap) or (NoteType = ntRapGolden) then
         begin
-          glBindTexture(GL_TEXTURE_2D, Tex_Mid_Rap[Color].TexNum);
+          If Color = 99 then
+            glBindTexture(GL_TEXTURE_2D, Tex_Mid_Rap_Inv.TexNum)
+          else
+            glBindTexture(GL_TEXTURE_2D, Tex_Mid_Rap[Color].TexNum)
         end
         else
         begin
-          glBindTexture(GL_TEXTURE_2D, Tex_Mid[Color].TexNum);
+          If Color = 99 then
+            glBindTexture(GL_TEXTURE_2D, Tex_Mid_Inv.TexNum)
+          else
+            glBindTexture(GL_TEXTURE_2D, Tex_Mid[Color].TexNum)
         end;
         glBegin(GL_QUADS);
           glTexCoord2f(0, 0); glVertex2f(Rec.Left,  Rec.Top);
@@ -1700,11 +1712,19 @@ begin
 
         If (NoteType = ntRap) or (NoteType = ntRapGolden) then
         begin
-          glBindTexture(GL_TEXTURE_2D, Tex_Right_Rap[Color].TexNum);
+          If Color = 99 then
+            glBindTexture(GL_TEXTURE_2D, Tex_Right_Rap_Inv.TexNum)
+          else
+            glBindTexture(GL_TEXTURE_2D, Tex_Right_Rap[Color].TexNum)
         end
         else
         begin
-          glBindTexture(GL_TEXTURE_2D, Tex_Right[Color].TexNum);
+          If Color = 99 then
+          begin
+            glBindTexture(GL_TEXTURE_2D, Tex_Right_Inv.TexNum);
+          end
+          else
+            glBindTexture(GL_TEXTURE_2D, Tex_Right[Color].TexNum)
         end;
         glBegin(GL_QUADS);
           glTexCoord2f(0, 0); glVertex2f(Rec.Left,  Rec.Top);

--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -80,6 +80,9 @@ type
     Mid:    real;
   end;
 
+const
+P1_INVERTED = 99;
+
 var
   NotesW:   array [0..UIni.IMaxPlayerCount-1] of real;
   NotesH:   array [0..UIni.IMaxPlayerCount-1] of real;
@@ -1661,14 +1664,14 @@ begin
         Rec.Bottom := Rec.Top + 2 * NotesH[0];
         If (NoteType = ntRap) or (NoteType = ntRapGolden) then
         begin
-          If Color = 99 then
+          If Color = P1_INVERTED then
             glBindTexture(GL_TEXTURE_2D, Tex_Left_Rap_Inv.TexNum)
           else
             glBindTexture(GL_TEXTURE_2D, Tex_Left_Rap[Color].TexNum)
         end
         else
         begin
-          If Color = 99 then
+          If Color = P1_INVERTED then
             glBindTexture(GL_TEXTURE_2D, Tex_Left_Inv.TexNum)
           else
             glBindTexture(GL_TEXTURE_2D, Tex_Left[Color].TexNum)
@@ -1687,14 +1690,14 @@ begin
 
         If (NoteType = ntRap) or (NoteType = ntRapGolden) then
         begin
-          If Color = 99 then
+          If Color = P1_INVERTED then
             glBindTexture(GL_TEXTURE_2D, Tex_Mid_Rap_Inv.TexNum)
           else
             glBindTexture(GL_TEXTURE_2D, Tex_Mid_Rap[Color].TexNum)
         end
         else
         begin
-          If Color = 99 then
+          If Color = P1_INVERTED then
             glBindTexture(GL_TEXTURE_2D, Tex_Mid_Inv.TexNum)
           else
             glBindTexture(GL_TEXTURE_2D, Tex_Mid[Color].TexNum)
@@ -1712,14 +1715,14 @@ begin
 
         If (NoteType = ntRap) or (NoteType = ntRapGolden) then
         begin
-          If Color = 99 then
+          If Color = P1_INVERTED then
             glBindTexture(GL_TEXTURE_2D, Tex_Right_Rap_Inv.TexNum)
           else
             glBindTexture(GL_TEXTURE_2D, Tex_Right_Rap[Color].TexNum)
         end
         else
         begin
-          If Color = 99 then
+          If Color = P1_INVERTED then
           begin
             glBindTexture(GL_TEXTURE_2D, Tex_Right_Inv.TexNum);
           end

--- a/src/base/UGraphic.pas
+++ b/src/base/UGraphic.pas
@@ -229,6 +229,14 @@ var
   Tex_BG_Mid_Rap:      array[1..UIni.IMaxPlayerCount] of TTexture;   //rename to tex_noteglow_mid
   Tex_BG_Right_Rap:    array[1..UIni.IMaxPlayerCount] of TTexture;   //rename to tex_noteglow_right
 
+  // Inversions of first player colors used to mark selected note in editor
+  Tex_Left_Inv: TTexture;
+  Tex_Mid_Inv: TTexture;
+  Tex_Right_Inv: TTexture;
+  Tex_Left_Rap_Inv: TTexture;
+  Tex_Mid_Rap_Inv: TTexture;
+  Tex_Right_Rap_Inv: TTexture;
+
   Tex_Note_Star:  TTexture;
   Tex_Note_Perfect_Star: TTexture;
 

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -687,7 +687,7 @@ begin
                 while (CurrentNote[CurrentTrack] <= Tracks[CurrentTrack].Lines[LineIndex].HighNote) and (CurrentBeat > Tracks[CurrentTrack].Lines[LineIndex].Notes[CurrentNote[CurrentTrack]].EndBeat) do
                   Inc(CurrentNote[CurrentTrack]);
 
-                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
                 EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
                 EditorLyrics[CurrentTrack].Selected := 0;
 
@@ -826,7 +826,7 @@ begin
               begin
                 Tracks[CurrentTrack].CurrentLine := MedleyNotes.end_.line;
                 CurrentNote[CurrentTrack] := MedleyNotes.end_.note;
-                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
 
                 EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
                 EditorLyrics[CurrentTrack].Selected := 0;
@@ -849,7 +849,7 @@ begin
               begin
                 Tracks[CurrentTrack].CurrentLine := MedleyNotes.start.line;
                 CurrentNote[CurrentTrack] := MedleyNotes.start.note;
-                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
 
                 EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
                 EditorLyrics[CurrentTrack].Selected := 0;
@@ -1793,7 +1793,7 @@ begin
                 Tracks[CurrentTrack].CurrentLine := LineIndex;
                 ShowInteractiveBackground;
                 CurrentNote[CurrentTrack] := 0;
-                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
                 EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
                 EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
               end;
@@ -1817,7 +1817,7 @@ begin
 
                 Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 1;
                 CurrentNote[CurrentTrack] := NoteIndex;
-                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
                 EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
                 //play current note playonewithmidi
                 PlaySentenceMidi := false;
@@ -1898,7 +1898,7 @@ begin
             Inc(CurrentNote[CurrentTrack]);
             if CurrentNote[CurrentTrack] > Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].HighNote then
               CurrentNote[CurrentTrack] := 0;
-            Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+            Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
             EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
           end;
 
@@ -1976,7 +1976,7 @@ begin
             Dec(CurrentNote[CurrentTrack]);
             if CurrentNote[CurrentTrack] = -1 then
               CurrentNote[CurrentTrack] := Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].HighNote;
-            Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+            Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
             EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
           end;
 
@@ -3115,7 +3115,7 @@ begin
   end;
 
   Refresh;
-  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
   EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
   EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
 end;
@@ -3187,7 +3187,7 @@ begin
   end;
 
   Refresh;
-  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
   EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
   EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
 end;
@@ -3205,7 +3205,7 @@ begin
   CurrentNote[CurrentTrack] := 0;
   if Tracks[CurrentTrack].CurrentLine > Tracks[CurrentTrack].High then
     Tracks[CurrentTrack].CurrentLine := 0;
-  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
 
   EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
   EditorLyrics[CurrentTrack].Selected := 0;
@@ -3232,7 +3232,7 @@ begin
   CurrentNote[CurrentTrack] := 0;
   if Tracks[CurrentTrack].CurrentLine = -1 then
     Tracks[CurrentTrack].CurrentLine := Tracks[CurrentTrack].High;
-  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
 
   EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
   EditorLyrics[CurrentTrack].Selected := 0;
@@ -3340,7 +3340,7 @@ begin
         EndBeat := Notes[HighNote].StartBeat + Notes[HighNote].Duration;
     end;
 
-    Tracks[CurrentTrack].Lines[CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+    Tracks[CurrentTrack].Lines[CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
   end
   // Last Note of current Sentence Deleted - > Delete Sentence
   // if there are more than two left
@@ -3362,7 +3362,7 @@ begin
     else
       Tracks[CurrentTrack].CurrentLine := 0;
 
-    Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+    Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
   end;
 
   // update lyric display
@@ -3396,7 +3396,7 @@ begin
   Refresh;
   //SelectPrevNote();
   //SelectNextNote();
-  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
   EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
 end;
 
@@ -3511,7 +3511,7 @@ begin
   Tracks[DstTrack].Lines[DstLine].EndBeat := Tracks[DstTrack].Lines[DstLine].Notes[NoteIndex].StartBeat + Tracks[DstTrack].Lines[DstLine].Notes[NoteIndex].Duration;
 
   Refresh;
-  Tracks[DstTrack].Lines[DstLine].Notes[CurrentNote[DstTrack]].Color := 99;
+  Tracks[DstTrack].Lines[DstLine].Notes[CurrentNote[DstTrack]].Color := P1_INVERTED;
   EditorLyrics[DstTrack].AddLine(DstTrack, Tracks[DstTrack].CurrentLine);
 end;
 
@@ -3563,7 +3563,7 @@ begin
   CurrentTrack := 0;
   Refresh;
   CurrentNote[CurrentTrack] := 0;
-  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
 
   EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
 end;
@@ -3710,7 +3710,7 @@ begin
   EditorLyrics[DstTrack].AddLine(DstTrack, Tracks[DstTrack].CurrentLine);
   EditorLyrics[DstTrack].Selected := 0;
   CurrentNote[DstTrack] := 0;
-  Tracks[SrcTrack].Lines[SrcLine].Notes[CurrentNote[SrcTrack]].Color := 99;
+  Tracks[SrcTrack].Lines[SrcLine].Notes[CurrentNote[SrcTrack]].Color := P1_INVERTED;
   Result := true;
 end;
 
@@ -4930,7 +4930,7 @@ begin
     begin
       Tracks[TrackIndex].CurrentLine := 0;
       CurrentNote[TrackIndex] := 0;
-      Tracks[TrackIndex].Lines[0].Notes[0].Color := 99;
+      Tracks[TrackIndex].Lines[0].Notes[0].Color := P1_INVERTED;
     end;
 
     AudioPlayBack.Open(CurrentSong.Path.Append(CurrentSong.Mp3));
@@ -5090,7 +5090,7 @@ begin
         Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 1;
         CurrentNote[CurrentTrack] := NoteIndex;
         EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
-        Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
+        Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
       end; //if
     end; //for NoteIndex}
   end; //end move cursor

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -2059,7 +2059,7 @@ begin
             begin
               Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 0;
               CurrentTrack := 1;
-              Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+              Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
               EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
               EditorLyrics[CurrentTrack].Selected := 0;
               Text[TextInfo].Text := Language.Translate('EDIT_INFO_SWITCHED_TO_TRACK') + ' 2 (' + CurrentSong.DuetNames[CurrentTrack] + ')';
@@ -2115,7 +2115,7 @@ begin
             begin
               Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 0;
               CurrentTrack := 0;
-              Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+              Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
               EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
               EditorLyrics[CurrentTrack].Selected := 0;
               Text[TextInfo].Text := Language.Translate('EDIT_INFO_SWITCHED_TO_TRACK') + ' 1 (' + CurrentSong.DuetNames[CurrentTrack] + ')';

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -687,7 +687,7 @@ begin
                 while (CurrentNote[CurrentTrack] <= Tracks[CurrentTrack].Lines[LineIndex].HighNote) and (CurrentBeat > Tracks[CurrentTrack].Lines[LineIndex].Notes[CurrentNote[CurrentTrack]].EndBeat) do
                   Inc(CurrentNote[CurrentTrack]);
 
-                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
                 EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
                 EditorLyrics[CurrentTrack].Selected := 0;
 
@@ -826,7 +826,7 @@ begin
               begin
                 Tracks[CurrentTrack].CurrentLine := MedleyNotes.end_.line;
                 CurrentNote[CurrentTrack] := MedleyNotes.end_.note;
-                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
 
                 EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
                 EditorLyrics[CurrentTrack].Selected := 0;
@@ -849,7 +849,7 @@ begin
               begin
                 Tracks[CurrentTrack].CurrentLine := MedleyNotes.start.line;
                 CurrentNote[CurrentTrack] := MedleyNotes.start.note;
-                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
 
                 EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
                 EditorLyrics[CurrentTrack].Selected := 0;
@@ -1793,7 +1793,7 @@ begin
                 Tracks[CurrentTrack].CurrentLine := LineIndex;
                 ShowInteractiveBackground;
                 CurrentNote[CurrentTrack] := 0;
-                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
                 EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
                 EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
               end;
@@ -1817,7 +1817,7 @@ begin
 
                 Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 1;
                 CurrentNote[CurrentTrack] := NoteIndex;
-                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+                Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
                 EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
                 //play current note playonewithmidi
                 PlaySentenceMidi := false;
@@ -1898,7 +1898,7 @@ begin
             Inc(CurrentNote[CurrentTrack]);
             if CurrentNote[CurrentTrack] > Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].HighNote then
               CurrentNote[CurrentTrack] := 0;
-            Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+            Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
             EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
           end;
 
@@ -1976,7 +1976,7 @@ begin
             Dec(CurrentNote[CurrentTrack]);
             if CurrentNote[CurrentTrack] = -1 then
               CurrentNote[CurrentTrack] := Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].HighNote;
-            Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+            Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
             EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
           end;
 
@@ -3115,7 +3115,7 @@ begin
   end;
 
   Refresh;
-  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
   EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
   EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
 end;
@@ -3187,7 +3187,7 @@ begin
   end;
 
   Refresh;
-  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
   EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
   EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
 end;
@@ -3205,7 +3205,7 @@ begin
   CurrentNote[CurrentTrack] := 0;
   if Tracks[CurrentTrack].CurrentLine > Tracks[CurrentTrack].High then
     Tracks[CurrentTrack].CurrentLine := 0;
-  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
 
   EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
   EditorLyrics[CurrentTrack].Selected := 0;
@@ -3232,7 +3232,7 @@ begin
   CurrentNote[CurrentTrack] := 0;
   if Tracks[CurrentTrack].CurrentLine = -1 then
     Tracks[CurrentTrack].CurrentLine := Tracks[CurrentTrack].High;
-  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
 
   EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
   EditorLyrics[CurrentTrack].Selected := 0;
@@ -3340,7 +3340,7 @@ begin
         EndBeat := Notes[HighNote].StartBeat + Notes[HighNote].Duration;
     end;
 
-    Tracks[CurrentTrack].Lines[CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+    Tracks[CurrentTrack].Lines[CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
   end
   // Last Note of current Sentence Deleted - > Delete Sentence
   // if there are more than two left
@@ -3362,7 +3362,7 @@ begin
     else
       Tracks[CurrentTrack].CurrentLine := 0;
 
-    Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+    Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
   end;
 
   // update lyric display
@@ -3396,7 +3396,7 @@ begin
   Refresh;
   //SelectPrevNote();
   //SelectNextNote();
-  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
   EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
 end;
 
@@ -3511,7 +3511,7 @@ begin
   Tracks[DstTrack].Lines[DstLine].EndBeat := Tracks[DstTrack].Lines[DstLine].Notes[NoteIndex].StartBeat + Tracks[DstTrack].Lines[DstLine].Notes[NoteIndex].Duration;
 
   Refresh;
-  Tracks[DstTrack].Lines[DstLine].Notes[CurrentNote[DstTrack]].Color := 2;
+  Tracks[DstTrack].Lines[DstLine].Notes[CurrentNote[DstTrack]].Color := 99;
   EditorLyrics[DstTrack].AddLine(DstTrack, Tracks[DstTrack].CurrentLine);
 end;
 
@@ -3563,7 +3563,7 @@ begin
   CurrentTrack := 0;
   Refresh;
   CurrentNote[CurrentTrack] := 0;
-  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+  Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
 
   EditorLyrics[CurrentTrack].AddLine(CurrentTrack, Tracks[CurrentTrack].CurrentLine);
 end;
@@ -3710,7 +3710,7 @@ begin
   EditorLyrics[DstTrack].AddLine(DstTrack, Tracks[DstTrack].CurrentLine);
   EditorLyrics[DstTrack].Selected := 0;
   CurrentNote[DstTrack] := 0;
-  Tracks[SrcTrack].Lines[SrcLine].Notes[CurrentNote[SrcTrack]].Color := 2;
+  Tracks[SrcTrack].Lines[SrcLine].Notes[CurrentNote[SrcTrack]].Color := 99;
   Result := true;
 end;
 
@@ -4930,7 +4930,7 @@ begin
     begin
       Tracks[TrackIndex].CurrentLine := 0;
       CurrentNote[TrackIndex] := 0;
-      Tracks[TrackIndex].Lines[0].Notes[0].Color := 2;
+      Tracks[TrackIndex].Lines[0].Notes[0].Color := 99;
     end;
 
     AudioPlayBack.Open(CurrentSong.Path.Append(CurrentSong.Mp3));
@@ -5090,7 +5090,7 @@ begin
         Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 1;
         CurrentNote[CurrentTrack] := NoteIndex;
         EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
-        Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 2;
+        Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 99;
       end; //if
     end; //for NoteIndex}
   end; //end move cursor

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -625,7 +625,7 @@ begin
   Tex_Left_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayLeft'), TEXTURE_TYPE_COLORIZED, Color);
   Tex_Mid_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayMid'), TEXTURE_TYPE_COLORIZED, Color);
   Tex_Right_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayRight'), TEXTURE_TYPE_COLORIZED, Color);
-  Tex_Left_Rap_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayLeftRap'), TEXTURE_TYPE_COLORIZED, Color); 
+  Tex_Left_Rap_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayLeftRap'), TEXTURE_TYPE_COLORIZED, Color);
   Tex_Mid_Rap_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayMidRap'), TEXTURE_TYPE_COLORIZED, Color);
   Tex_Right_Rap_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayRightRap'), TEXTURE_TYPE_COLORIZED, Color);
 

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -620,6 +620,15 @@ begin
     Tex_ScoreBG[I - 1] := Texture.LoadTexture(Skin.GetTextureFileName('ScoreBG'), TEXTURE_TYPE_COLORIZED, Color);
   end;
 
+  // Inversions of first player colors used to mark selected note in editor
+  Color := RGBFloatToInt(1 - Col[1].R, 1 - Col[1].G, 1 - Col[1].B);
+  Tex_Left_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayLeft'), TEXTURE_TYPE_COLORIZED, Color);
+  Tex_Mid_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayMid'), TEXTURE_TYPE_COLORIZED, Color);
+  Tex_Right_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayRight'), TEXTURE_TYPE_COLORIZED, Color);
+  Tex_Left_Rap_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayLeftRap'), TEXTURE_TYPE_COLORIZED, Color); 
+  Tex_Mid_Rap_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayMidRap'), TEXTURE_TYPE_COLORIZED, Color);
+  Tex_Right_Rap_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayRightRap'), TEXTURE_TYPE_COLORIZED, Color);
+
   StaticPausePopup := ScreenSing.AddStatic(Theme.Sing.PausePopUp);
 
   // <note> pausepopup is not visible at the beginning </note>


### PR DESCRIPTION
Before, the selected bar would use P2's color to mark the selected bar. This leads to no marking at all when no color has been selected for P2.

The color attribute for each bar currently holds only a single integer for the player number, since this reuses the coloring-mechanism of the actual sing mode. I chose to mark the selected syllable as belonging to player 99 (instead of player 2) and then making a distinction for that number. The choice is arbitrary, I just didn't want to use 0 since it seems to be already used for something else.

Currently, the color used for marking is the inversion of P1's color. We could also change this to not be based on the player colors at all, and instead use two fixed colors for selected/not selecte or similar.