### PR TITLE
document the --enable-debug flag for configure

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -56,6 +56,7 @@ Optional libraries:
 - `./game/ultrastardx[.exe]` (on MacOS: `open UltraStarDeluxe.app`)
 
 #### configure flags
+* `--enable-debug`: Outputs warnings and errors from Error.log also to the console, and prints stacktraces when an EAccessViolation occurs.
 * `--with-portaudio`: This is the default.
 * `--without-portaudio`: Use SDL audio input instead.
   This should support newer platforms like PulseAudio and PipeWire.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The [wiki](https://github.com/UltraStar-Deluxe/USDX/wiki) contains more informat
 There are two main ways to compile the game:
 
 1. Lazarus IDE
-2. `./autogen.sh && ./configure && make`
+2. `./autogen.sh && ./configure [--enable-debug] && make`
 
 The executable will be `game/ultrastardx[.exe]`.
 


### PR DESCRIPTION
document the --enable-debug flag for configure because it makes debugging EAccessViolation on at least Linux platforms possible
