### PR TITLE
Add .editorconfig and CI check for trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.github/workflows/check-whitespace.yml
+++ b/.github/workflows/check-whitespace.yml
@@ -1,0 +1,18 @@
+# Credit: https://github.com/zlib-ng/zlib-ng/blob/develop/.github/workflows/lint.yml
+name: Lint
+on: [pull_request]
+
+jobs:
+  lint:
+    name: Check trailing whitespace
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Whitespace errors
+      run: |
+        git config core.whitespace blank-at-eol
+        git diff --color --check ${{ github.event.pull_request.base.sha }} -- './src' ':!./src/lib' ':!./src/webSDK'


### PR DESCRIPTION
The editorconfig should prevent trailing whitespaces and ensure a trailing newline in all files.
The CI adds another job that runs on PRs only, marking all spots in `src` (though ignoring `src/lib`, `src/webSDK`) changed in that revision that added trailing spaces. An example of the output in case of failure can be seen [here](https://github.com/UltraStar-Deluxe/USDX/actions/runs/10111040317/job/27962189639).

This encompasses stage 1 & 2 from #873 

Open question: Should the .editorconfig apply to all files, or should we limit this to the same folders as the CI check?