### PR TITLE
Fix EPEL download URL in dockerfile

### DIFF
--- a/dists/linux/Dockerfile.in
+++ b/dists/linux/Dockerfile.in
@@ -3,7 +3,7 @@ FROM %%from%%
 RUN sed -i 's;^.*baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
 
 RUN [ -z "%%epelpkgs%%" ] || yum install -y --setopt=tsflags=nodocs \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm
 
 RUN yum upgrade -y --setopt=tsflags=nodocs
 


### PR DESCRIPTION
Seems like the EPEL URL has been quietly changed to archives *separately* from when they moved the entire repo over, see [here](https://dl.fedoraproject.org/pub/epel/7/README).
This PR changes the download URL used by the dockerfile to point to the last release (EPEL 7.14) in archives instead.