### PR TITLE
Refactorings in USingScores and UScreenSong

### DIFF
--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -1226,6 +1226,13 @@ var
   R, G, B:    real;
   Size, Diff: real;
   Drawing: boolean;
+  procedure updatePosition(themeElements: TThemeSingPlayer);
+  begin
+    Position.RBX := themeElements.SingBar.X;
+    Position.RBY := themeElements.SingBar.Y;
+    Position.RBW := themeElements.SingBar.W;
+    Position.RBH := themeElements.SingBar.H;
+  end;
 begin
   { if screens = 2 and playerplay <= 3 the 2nd screen shows the
    textures of screen 1 }
@@ -1246,61 +1253,19 @@ begin
       if (CurrentSong.isDuet) then
       begin
         case Index of
-          0:
-             begin
-               Position.RBX := Theme.Sing.Duet4PP1.SingBar.X;
-               Position.RBY := Theme.Sing.Duet4PP1.SingBar.Y;
-               Position.RBW := Theme.Sing.Duet4PP1.SingBar.W;
-               Position.RBH := Theme.Sing.Duet4PP1.SingBar.H;
-             end;
-          1: begin
-               Position.RBX := Theme.Sing.Duet4PP2.SingBar.X;
-               Position.RBY := Theme.Sing.Duet4PP2.SingBar.Y;
-               Position.RBW := Theme.Sing.Duet4PP2.SingBar.W;
-               Position.RBH := Theme.Sing.Duet4PP2.SingBar.H;
-             end;
-          2: begin
-               Position.RBX := Theme.Sing.Duet4PP3.SingBar.X;
-               Position.RBY := Theme.Sing.Duet4PP3.SingBar.Y;
-               Position.RBW := Theme.Sing.Duet4PP3.SingBar.W;
-               Position.RBH := Theme.Sing.Duet4PP3.SingBar.H;
-             end;
-          3: begin
-               Position.RBX := Theme.Sing.Duet4PP4.SingBar.X;
-               Position.RBY := Theme.Sing.Duet4PP4.SingBar.Y;
-               Position.RBW := Theme.Sing.Duet4PP4.SingBar.W;
-               Position.RBH := Theme.Sing.Duet4PP4.SingBar.H;
-             end;
+          0: updatePosition(Theme.Sing.Duet4PP1);
+          1: updatePosition(Theme.Sing.Duet4PP2);
+          2: updatePosition(Theme.Sing.Duet4PP3);
+          3: updatePosition(Theme.Sing.Duet4PP4);
         end;
       end
       else
       begin
         case Index of
-          0:
-             begin
-               Position.RBX := Theme.Sing.Solo4PP1.SingBar.X;
-               Position.RBY := Theme.Sing.Solo4PP1.SingBar.Y;
-               Position.RBW := Theme.Sing.Solo4PP1.SingBar.W;
-               Position.RBH := Theme.Sing.Solo4PP1.SingBar.H;
-             end;
-          1: begin
-               Position.RBX := Theme.Sing.Solo4PP2.SingBar.X;
-               Position.RBY := Theme.Sing.Solo4PP2.SingBar.Y;
-               Position.RBW := Theme.Sing.Solo4PP2.SingBar.W;
-               Position.RBH := Theme.Sing.Solo4PP2.SingBar.H;
-             end;
-          2: begin
-               Position.RBX := Theme.Sing.Solo4PP3.SingBar.X;
-               Position.RBY := Theme.Sing.Solo4PP3.SingBar.Y;
-               Position.RBW := Theme.Sing.Solo4PP3.SingBar.W;
-               Position.RBH := Theme.Sing.Solo4PP3.SingBar.H;
-             end;
-          3: begin
-               Position.RBX := Theme.Sing.Solo4PP4.SingBar.X;
-               Position.RBY := Theme.Sing.Solo4PP4.SingBar.Y;
-               Position.RBW := Theme.Sing.Solo4PP4.SingBar.W;
-               Position.RBH := Theme.Sing.Solo4PP4.SingBar.H;
-             end;
+          0: updatePosition(Theme.Sing.Solo4PP1);
+          1: updatePosition(Theme.Sing.Solo4PP2);
+          2: updatePosition(Theme.Sing.Solo4PP3);
+          3: updatePosition(Theme.Sing.Solo4PP4);
         end;
       end;
     end
@@ -1310,85 +1275,23 @@ begin
       if (CurrentSong.isDuet) then
       begin
         case Index of
-          0:
-             begin
-               Position.RBX := Theme.Sing.Duet6PP1.SingBar.X;
-               Position.RBY := Theme.Sing.Duet6PP1.SingBar.Y;
-               Position.RBW := Theme.Sing.Duet6PP1.SingBar.W;
-               Position.RBH := Theme.Sing.Duet6PP1.SingBar.H;
-             end;
-          1: begin
-               Position.RBX := Theme.Sing.Duet6PP2.SingBar.X;
-               Position.RBY := Theme.Sing.Duet6PP2.SingBar.Y;
-               Position.RBW := Theme.Sing.Duet6PP2.SingBar.W;
-               Position.RBH := Theme.Sing.Duet6PP2.SingBar.H;
-             end;
-          2: begin
-               Position.RBX := Theme.Sing.Duet6PP3.SingBar.X;
-               Position.RBY := Theme.Sing.Duet6PP3.SingBar.Y;
-               Position.RBW := Theme.Sing.Duet6PP3.SingBar.W;
-               Position.RBH := Theme.Sing.Duet6PP3.SingBar.H;
-             end;
-          3: begin
-               Position.RBX := Theme.Sing.Duet6PP4.SingBar.X;
-               Position.RBY := Theme.Sing.Duet6PP4.SingBar.Y;
-               Position.RBW := Theme.Sing.Duet6PP4.SingBar.W;
-               Position.RBH := Theme.Sing.Duet6PP4.SingBar.H;
-             end;
-          4: begin
-               Position.RBX := Theme.Sing.Duet6PP5.SingBar.X;
-               Position.RBY := Theme.Sing.Duet6PP5.SingBar.Y;
-               Position.RBW := Theme.Sing.Duet6PP5.SingBar.W;
-               Position.RBH := Theme.Sing.Duet6PP5.SingBar.H;
-             end;
-          5: begin
-               Position.RBX := Theme.Sing.Duet6PP6.SingBar.X;
-               Position.RBY := Theme.Sing.Duet6PP6.SingBar.Y;
-               Position.RBW := Theme.Sing.Duet6PP6.SingBar.W;
-               Position.RBH := Theme.Sing.Duet6PP6.SingBar.H;
-             end;
+          0: updatePosition(Theme.Sing.Duet6PP1);
+          1: updatePosition(Theme.Sing.Duet6PP2);
+          2: updatePosition(Theme.Sing.Duet6PP3);
+          3: updatePosition(Theme.Sing.Duet6PP4);
+          4: updatePosition(Theme.Sing.Duet6PP5);
+          5: updatePosition(Theme.Sing.Duet6PP6);
         end;
       end
       else
       begin
         case Index of
-          0:
-             begin
-               Position.RBX := Theme.Sing.Solo6PP1.SingBar.X;
-               Position.RBY := Theme.Sing.Solo6PP1.SingBar.Y;
-               Position.RBW := Theme.Sing.Solo6PP1.SingBar.W;
-               Position.RBH := Theme.Sing.Solo6PP1.SingBar.H;
-             end;
-          1: begin
-               Position.RBX := Theme.Sing.Solo6PP2.SingBar.X;
-               Position.RBY := Theme.Sing.Solo6PP2.SingBar.Y;
-               Position.RBW := Theme.Sing.Solo6PP2.SingBar.W;
-               Position.RBH := Theme.Sing.Solo6PP2.SingBar.H;
-             end;
-          2: begin
-               Position.RBX := Theme.Sing.Solo6PP3.SingBar.X;
-               Position.RBY := Theme.Sing.Solo6PP3.SingBar.Y;
-               Position.RBW := Theme.Sing.Solo6PP3.SingBar.W;
-               Position.RBH := Theme.Sing.Solo6PP3.SingBar.H;
-             end;
-          3: begin
-               Position.RBX := Theme.Sing.Solo6PP4.SingBar.X;
-               Position.RBY := Theme.Sing.Solo6PP4.SingBar.Y;
-               Position.RBW := Theme.Sing.Solo6PP4.SingBar.W;
-               Position.RBH := Theme.Sing.Solo6PP4.SingBar.H;
-             end;
-          4: begin
-               Position.RBX := Theme.Sing.Solo6PP5.SingBar.X;
-               Position.RBY := Theme.Sing.Solo6PP5.SingBar.Y;
-               Position.RBW := Theme.Sing.Solo6PP5.SingBar.W;
-               Position.RBH := Theme.Sing.Solo6PP5.SingBar.H;
-             end;
-          5: begin
-               Position.RBX := Theme.Sing.Solo6PP6.SingBar.X;
-               Position.RBY := Theme.Sing.Solo6PP6.SingBar.Y;
-               Position.RBW := Theme.Sing.Solo6PP6.SingBar.W;
-               Position.RBH := Theme.Sing.Solo6PP6.SingBar.H;
-             end;
+          0: updatePosition(Theme.Sing.Solo6PP1);
+          1: updatePosition(Theme.Sing.Solo6PP2);
+          2: updatePosition(Theme.Sing.Solo6PP3);
+          3: updatePosition(Theme.Sing.Solo6PP4);
+          4: updatePosition(Theme.Sing.Solo6PP5);
+          5: updatePosition(Theme.Sing.Solo6PP6);
         end;
       end;
     end;
@@ -1412,25 +1315,9 @@ begin
         if (CurrentSong.isDuet) and ((PlayersPlay = 3) or (PlayersPlay = 6)) then
         begin
           case Index of
-            0, 3, 6:
-               begin
-                 Position.RBX := Theme.Sing.Duet3PP1.SingBar.X;
-                 Position.RBY := Theme.Sing.Duet3PP1.SingBar.Y;
-                 Position.RBW := Theme.Sing.Duet3PP1.SingBar.W;
-                 Position.RBH := Theme.Sing.Duet3PP1.SingBar.H;
-               end;
-            1, 4, 7: begin
-                 Position.RBX := Theme.Sing.Duet3PP2.SingBar.X;
-                 Position.RBY := Theme.Sing.Duet3PP2.SingBar.Y;
-                 Position.RBW := Theme.Sing.Duet3PP2.SingBar.W;
-                 Position.RBH := Theme.Sing.Duet3PP2.SingBar.H;
-               end;
-            2, 5, 8: begin
-                 Position.RBX := Theme.Sing.Duet3PP3.SingBar.X;
-                 Position.RBY := Theme.Sing.Duet3PP3.SingBar.Y;
-                 Position.RBW := Theme.Sing.Duet3PP3.SingBar.W;
-                 Position.RBH := Theme.Sing.Duet3PP3.SingBar.H;
-               end;
+            0, 3, 6: updatePosition(Theme.Sing.Duet3PP1);
+            1, 4, 7: updatePosition(Theme.Sing.Duet3PP2);
+            2, 5, 8: updatePosition(Theme.Sing.Duet3PP3);
           end;
         end;
       end;

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -4501,59 +4501,59 @@ begin
 end;
 
 procedure TScreenSong.SongScore;
+  procedure setVisible(elements: array of integer; visible: boolean);
+  var
+    J: integer;
+  begin
+    for J := 0 to High(elements) do
+      Text[elements[J]].Visible := visible;
+  end;
+  procedure hide(elements: array of integer);
+  begin
+    setVisible(elements, false);
+  end;
+  procedure show(elements: array of integer);
+  begin
+    setVisible(elements, true);
+  end;
 begin
 
   if (CatSongs.Song[Interaction].isDuet) or (RapToFreestyle) or ((Mode <> smNormal) or (Ini.ShowScores = 0) or (CatSongs.Song[Interaction].Edition = '') or ((Ini.ShowScores = 1) and ((Text[TextMaxScore2].Text = '0') and (Text[TextMaxScoreLocal].Text = '0')))) then
   begin
-    Text[TextScore].Visible           := false;
-    Text[TextMaxScore].Visible        := false;
-    Text[TextMediaScore].Visible      := false;
-    Text[TextMaxScore2].Visible       := false;
-    Text[TextMediaScore2].Visible     := false;
-    Text[TextMaxScoreLocal].Visible   := false;
-    Text[TextMediaScoreLocal].Visible := false;
-    Text[TextScoreUserLocal].Visible  := false;
-    Text[TextScoreUser].Visible       := false;
+    hide([
+      TextScore, TextMaxScore, TextMediaScore,
+      TextScoreUser, TextMaxScore2, TextMediaScore2,
+      TextScoreUserLocal, TextMaxScoreLocal, TextMediaScoreLocal
+    ]);
   end
   else
   begin
+    // TODO: some of these if statements don't feel right? Like, unless ShowScores is inverted, most of these will still show them if there already is a score?
     if (Ini.ShowScores = 1) and (Text[TextMaxScoreLocal].Text = '0') and (High(DLLMan.Websites) < 0) then
     begin
-      Text[TextScore].Visible           := false;
-      Text[TextMaxScore].Visible        := false;
-      Text[TextMediaScore].Visible      := false;
+      hide([TextScore, TextMaxScore, TextMediaScore]);
     end
     else
     begin
-      Text[TextScore].Visible           := true;
-      Text[TextMaxScore].Visible        := true;
-      Text[TextMediaScore].Visible      := true;
+      show([TextScore, TextMaxScore, TextMediaScore]);
     end;
 
     if (Ini.ShowScores = 1) and (Text[TextMaxScore2].Text = '0') then
     begin
-      Text[TextScoreUser].Visible       := false;
-      Text[TextMaxScore2].Visible       := false;
-      Text[TextMediaScore2].Visible     := false;
+      hide([TextScoreUser, TextMaxScore2, TextMediaScore2]);
     end
     else
     begin
-      Text[TextScoreUser].Visible       := true;
-      Text[TextMaxScore2].Visible       := true;
-      Text[TextMediaScore2].Visible     := true;
+      show([TextScoreUser, TextMaxScore2, TextMediaScore2]);
     end;
 
     if (Ini.ShowScores = 1) and (Text[TextMaxScoreLocal].Text = '0') then
     begin
-      Text[TextScoreUserLocal].Visible  := false;
-      Text[TextMaxScoreLocal].Visible   := false;
-      Text[TextMediaScoreLocal].Visible := false;
+      hide([TextScoreUserLocal, TextMaxScoreLocal, TextMediaScoreLocal]);
     end
     else
     begin
-      Text[TextScoreUserLocal].Visible  := true;
-      Text[TextMaxScoreLocal].Visible   := true;
-      Text[TextMediaScoreLocal].Visible := true;
+      show([TextScoreUserLocal, TextMaxScoreLocal, TextMediaScoreLocal]);
     end;
 
   end;

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -4532,28 +4532,28 @@ begin
 
     if (Ini.ShowScores = 1) and (Text[TextMaxScore2].Text = '0') then
     begin
+      Text[TextScoreUser].Visible       := false;
       Text[TextMaxScore2].Visible       := false;
       Text[TextMediaScore2].Visible     := false;
-      Text[TextScoreUser].Visible       := false;
     end
     else
     begin
+      Text[TextScoreUser].Visible       := true;
       Text[TextMaxScore2].Visible       := true;
       Text[TextMediaScore2].Visible     := true;
-      Text[TextScoreUser].Visible       := true;
     end;
 
     if (Ini.ShowScores = 1) and (Text[TextMaxScoreLocal].Text = '0') then
     begin
+      Text[TextScoreUserLocal].Visible  := false;
       Text[TextMaxScoreLocal].Visible   := false;
       Text[TextMediaScoreLocal].Visible := false;
-      Text[TextScoreUserLocal].Visible  := false;
     end
     else
     begin
+      Text[TextScoreUserLocal].Visible  := true;
       Text[TextMaxScoreLocal].Visible   := true;
       Text[TextMediaScoreLocal].Visible := true;
-      Text[TextScoreUserLocal].Visible  := true;
     end;
 
   end;

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -1866,87 +1866,54 @@ end;
 procedure TScreenSong.ColorDuetNameSingers();
 var
   Col: TRGB;
+  procedure setColor(static: integer; color: TRGB);
+  begin
+    Statics[static].Texture.ColR := color.R;
+    Statics[static].Texture.ColG := color.G;
+    Statics[static].Texture.ColB := color.B;
+  end;
 begin
   if (PlayersPlay = 1) then
   begin
-    Statics[Static2PlayersDuetSingerP1].Texture.ColR := ColPlayer[0].R;
-    Statics[Static2PlayersDuetSingerP1].Texture.ColG := ColPlayer[0].G;
-    Statics[Static2PlayersDuetSingerP1].Texture.ColB := ColPlayer[0].B;
-
-    Col := GetPlayerLightColor(Ini.SingColor[0]);
-    Statics[Static2PlayersDuetSingerP2].Texture.ColR := Col.R;
-    Statics[Static2PlayersDuetSingerP2].Texture.ColG := Col.G;
-    Statics[Static2PlayersDuetSingerP2].Texture.ColB := Col.B;
+    setColor(Static2PlayersDuetSingerP1, ColPlayer[0]);
+    // this one is different from all the others
+    setColor(Static2PlayersDuetSingerP2, GetPlayerLightColor(Ini.SingColor[0]));
   end;
 
   if (PlayersPlay = 2) then
   begin
-    Statics[Static2PlayersDuetSingerP1].Texture.ColR := ColPlayer[0].R;
-    Statics[Static2PlayersDuetSingerP1].Texture.ColG := ColPlayer[0].G;
-    Statics[Static2PlayersDuetSingerP1].Texture.ColB := ColPlayer[0].B;
-
-    Statics[Static2PlayersDuetSingerP2].Texture.ColR := ColPlayer[1].R;
-    Statics[Static2PlayersDuetSingerP2].Texture.ColG := ColPlayer[1].G;
-    Statics[Static2PlayersDuetSingerP2].Texture.ColB := ColPlayer[1].B;
+    setColor(Static2PlayersDuetSingerP1, ColPlayer[0]);
+    setColor(Static2PlayersDuetSingerP2, ColPlayer[1]);
   end;
 
   if (PlayersPlay = 3) then
   begin
-    Statics[Static3PlayersDuetSingerP1].Texture.ColR := ColPlayer[0].R;
-    Statics[Static3PlayersDuetSingerP1].Texture.ColG := ColPlayer[0].G;
-    Statics[Static3PlayersDuetSingerP1].Texture.ColB := ColPlayer[0].B;
-
-    Statics[Static3PlayersDuetSingerP2].Texture.ColR := ColPlayer[1].R;
-    Statics[Static3PlayersDuetSingerP2].Texture.ColG := ColPlayer[1].G;
-    Statics[Static3PlayersDuetSingerP2].Texture.ColB := ColPlayer[1].B;
-
-    Statics[Static3PlayersDuetSingerP3].Texture.ColR := ColPlayer[2].R;
-    Statics[Static3PlayersDuetSingerP3].Texture.ColG := ColPlayer[2].G;
-    Statics[Static3PlayersDuetSingerP3].Texture.ColB := ColPlayer[2].B;
+    setColor(Static3PlayersDuetSingerP1, ColPlayer[0]);
+    setColor(Static3PlayersDuetSingerP2, ColPlayer[1]);
+    setColor(Static3PlayersDuetSingerP3, ColPlayer[2]);
   end;
 
   if (PlayersPlay = 4) then
   begin
     if (Screens = 1) then
     begin
-      Statics[Static2PlayersDuetSingerP1].Texture.ColR := ColPlayer[0].R;
-      Statics[Static2PlayersDuetSingerP1].Texture.ColG := ColPlayer[0].G;
-      Statics[Static2PlayersDuetSingerP1].Texture.ColB := ColPlayer[0].B;
-
-      Statics[Static2PlayersDuetSingerP2].Texture.ColR := ColPlayer[1].R;
-      Statics[Static2PlayersDuetSingerP2].Texture.ColG := ColPlayer[1].G;
-      Statics[Static2PlayersDuetSingerP2].Texture.ColB := ColPlayer[1].B;
-
-      Statics[Static4PlayersDuetSingerP3].Texture.ColR := ColPlayer[2].R;
-      Statics[Static4PlayersDuetSingerP3].Texture.ColG := ColPlayer[2].G;
-      Statics[Static4PlayersDuetSingerP3].Texture.ColB := ColPlayer[2].B;
-
-      Statics[Static4PlayersDuetSingerP4].Texture.ColR := ColPlayer[3].R;
-      Statics[Static4PlayersDuetSingerP4].Texture.ColG := ColPlayer[3].G;
-      Statics[Static4PlayersDuetSingerP4].Texture.ColB := ColPlayer[3].B;
+      setColor(Static2PlayersDuetSingerP1, ColPlayer[0]);
+      setColor(Static2PlayersDuetSingerP2, ColPlayer[1]);
+      setColor(Static4PlayersDuetSingerP3, ColPlayer[2]);
+      setColor(Static4PlayersDuetSingerP4, ColPlayer[3]);
     end
     else
     begin
       if (ScreenAct = 1) then
       begin
-        Statics[Static2PlayersDuetSingerP1].Texture.ColR := ColPlayer[0].R;
-        Statics[Static2PlayersDuetSingerP1].Texture.ColG := ColPlayer[0].G;
-        Statics[Static2PlayersDuetSingerP1].Texture.ColB := ColPlayer[0].B;
-
-        Statics[Static2PlayersDuetSingerP2].Texture.ColR := ColPlayer[1].R;
-        Statics[Static2PlayersDuetSingerP2].Texture.ColG := ColPlayer[1].G;
-        Statics[Static2PlayersDuetSingerP2].Texture.ColB := ColPlayer[1].B;
+        setColor(Static2PlayersDuetSingerP1, ColPlayer[0]);
+        setColor(Static2PlayersDuetSingerP2, ColPlayer[1]);
       end;
 
       if (ScreenAct = 2) then
       begin
-        Statics[Static2PlayersDuetSingerP1].Texture.ColR := ColPlayer[2].R;
-        Statics[Static2PlayersDuetSingerP1].Texture.ColG := ColPlayer[2].G;
-        Statics[Static2PlayersDuetSingerP1].Texture.ColB := ColPlayer[2].B;
-
-        Statics[Static2PlayersDuetSingerP2].Texture.ColR := ColPlayer[3].R;
-        Statics[Static2PlayersDuetSingerP2].Texture.ColG := ColPlayer[3].G;
-        Statics[Static2PlayersDuetSingerP2].Texture.ColB := ColPlayer[3].B;
+        setColor(Static2PlayersDuetSingerP1, ColPlayer[2]);
+        setColor(Static2PlayersDuetSingerP2, ColPlayer[3]);
       end;
     end;
   end;
@@ -1955,60 +1922,27 @@ begin
   begin
     if (Screens = 1) then
     begin
-        Statics[Static3PlayersDuetSingerP1].Texture.ColR := ColPlayer[0].R;
-        Statics[Static3PlayersDuetSingerP1].Texture.ColG := ColPlayer[0].G;
-        Statics[Static3PlayersDuetSingerP1].Texture.ColB := ColPlayer[0].B;
-
-        Statics[Static3PlayersDuetSingerP2].Texture.ColR := ColPlayer[1].R;
-        Statics[Static3PlayersDuetSingerP2].Texture.ColG := ColPlayer[1].G;
-        Statics[Static3PlayersDuetSingerP2].Texture.ColB := ColPlayer[1].B;
-
-        Statics[Static3PlayersDuetSingerP3].Texture.ColR := ColPlayer[2].R;
-        Statics[Static3PlayersDuetSingerP3].Texture.ColG := ColPlayer[2].G;
-        Statics[Static3PlayersDuetSingerP3].Texture.ColB := ColPlayer[2].B;
-
-        Statics[Static6PlayersDuetSingerP4].Texture.ColR := ColPlayer[3].R;
-        Statics[Static6PlayersDuetSingerP4].Texture.ColG := ColPlayer[3].G;
-        Statics[Static6PlayersDuetSingerP4].Texture.ColB := ColPlayer[3].B;
-
-        Statics[Static6PlayersDuetSingerP5].Texture.ColR := ColPlayer[4].R;
-        Statics[Static6PlayersDuetSingerP5].Texture.ColG := ColPlayer[4].G;
-        Statics[Static6PlayersDuetSingerP5].Texture.ColB := ColPlayer[4].B;
-
-        Statics[Static6PlayersDuetSingerP6].Texture.ColR := ColPlayer[5].R;
-        Statics[Static6PlayersDuetSingerP6].Texture.ColG := ColPlayer[5].G;
-        Statics[Static6PlayersDuetSingerP6].Texture.ColB := ColPlayer[5].B;
+      setColor(Static3PlayersDuetSingerP1, ColPlayer[0]);
+      setColor(Static3PlayersDuetSingerP2, ColPlayer[1]);
+      setColor(Static3PlayersDuetSingerP3, ColPlayer[2]);
+      setColor(Static6PlayersDuetSingerP4, ColPlayer[3]);
+      setColor(Static6PlayersDuetSingerP5, ColPlayer[4]);
+      setColor(Static6PlayersDuetSingerP6, ColPlayer[5]);
     end
     else
     begin
       if (ScreenAct = 1) then
       begin
-        Statics[Static3PlayersDuetSingerP1].Texture.ColR := ColPlayer[0].R;
-        Statics[Static3PlayersDuetSingerP1].Texture.ColG := ColPlayer[0].G;
-        Statics[Static3PlayersDuetSingerP1].Texture.ColB := ColPlayer[0].B;
-
-        Statics[Static3PlayersDuetSingerP2].Texture.ColR := ColPlayer[1].R;
-        Statics[Static3PlayersDuetSingerP2].Texture.ColG := ColPlayer[1].G;
-        Statics[Static3PlayersDuetSingerP2].Texture.ColB := ColPlayer[1].B;
-
-        Statics[Static3PlayersDuetSingerP3].Texture.ColR := ColPlayer[2].R;
-        Statics[Static3PlayersDuetSingerP3].Texture.ColG := ColPlayer[2].G;
-        Statics[Static3PlayersDuetSingerP3].Texture.ColB := ColPlayer[2].B;
+        setColor(Static3PlayersDuetSingerP1, ColPlayer[0]);
+        setColor(Static3PlayersDuetSingerP2, ColPlayer[1]);
+        setColor(Static3PlayersDuetSingerP3, ColPlayer[2]);
       end;
 
       if (ScreenAct = 2) then
       begin
-        Statics[Static3PlayersDuetSingerP1].Texture.ColR := ColPlayer[3].R;
-        Statics[Static3PlayersDuetSingerP1].Texture.ColG := ColPlayer[3].G;
-        Statics[Static3PlayersDuetSingerP1].Texture.ColB := ColPlayer[3].B;
-
-        Statics[Static3PlayersDuetSingerP2].Texture.ColR := ColPlayer[4].R;
-        Statics[Static3PlayersDuetSingerP2].Texture.ColG := ColPlayer[4].G;
-        Statics[Static3PlayersDuetSingerP2].Texture.ColB := ColPlayer[4].B;
-
-        Statics[Static3PlayersDuetSingerP3].Texture.ColR := ColPlayer[5].R;
-        Statics[Static3PlayersDuetSingerP3].Texture.ColG := ColPlayer[5].G;
-        Statics[Static3PlayersDuetSingerP3].Texture.ColB := ColPlayer[5].B;
+        setColor(Static3PlayersDuetSingerP1, ColPlayer[3]);
+        setColor(Static3PlayersDuetSingerP2, ColPlayer[4]);
+        setColor(Static3PlayersDuetSingerP3, ColPlayer[5]);
       end;
     end;
   end;


### PR DESCRIPTION
I was looking through my local diff and found some more areas where my 9-player modification is creating giant walls of duplication.

Also fixed a few other ones along the way. Most notably this PR adds a TODO in `TScreenSong.SongScore` because something feels off about those equations.

None of what this PR does should change any existing behaviour.