### PR TITLE
Fix issues with PulseAudio in CI build

### DIFF
--- a/dists/linux/dl.sh
+++ b/dists/linux/dl.sh
@@ -44,7 +44,7 @@ if older 1.8 wayland-scanner --version ; then
 	deps+=('wayland,https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.21.91/downloads/wayland-1.21.91.tar.xz,d4f5b5e2453d45902016138dae0605cae096e00b')
 fi
 
-deps+=('pulseaudio,https://freedesktop.org/software/pulseaudio/releases/pulseaudio-16.1.tar.xz,7bf3845b522a1da263b6b84a0bc5aa761e49bc87')
+deps+=('pulseaudio,https://www.freedesktop.org/software/pulseaudio/releases/pulseaudio-16.1.tar.xz,7bf3845b522a1da263b6b84a0bc5aa761e49bc87')
 deps+=('pipewire,https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/0.3.66/pipewire-0.3.66.tar.bz2,20c58dd867c33a7d111df69d7ec8d31c45b92a0b')
 deps+=('wayland-protocols,https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.31/downloads/wayland-protocols-1.31.tar.xz,5a84628630598027fab1708f822fc399d9e70b02')
 deps+=('SDL2,https://www.libsdl.org/release/SDL2-2.26.5.tar.gz,ca5d89edc537fd819eddab1f1a86f61e45fcb68b')

--- a/dists/linux/tasks.sh
+++ b/dists/linux/tasks.sh
@@ -186,7 +186,7 @@ EOF
 	true | $CC -shared -o $PREFIX/lib/libpulse-simple.so.0 -Wl,-soname,libpulse-simple.so.0 -x c -
 	ln -s libpulse-simple.so.0 $PREFIX/lib/libpulse-simple.so
 	PA_VERSION=$(cat .tarball-version)
-	sed -e "s:@prefix@:$PREFIX:;s:@exec_prefix@:$PREFIX:;s:@libdir@:$PREFIX/lib:;s:@includedir@:$PREFIX/include:;s:@PACKAGE_VERSION@:$PA_VERSION:;s:@PTHREAD_LIBS@:-pthread:;/^Libs.private/d" < libpulse-simple.pc.in > $PREFIX/lib/pkgconfig/libpulse-simple.pc
+	sed -e "s:@prefix@:$PREFIX:;s:@exec_prefix@:$PREFIX:;s:@libdir@:$PREFIX/lib:;s:@includedir@:$PREFIX/include:;s:@PACKAGE_VERSION@:$PA_VERSION:;s:@PTHREAD_LIBS@:-pthread:;/^Libs.private/d;/^Requires:/d" < libpulse-simple.pc.in > $PREFIX/lib/pkgconfig/libpulse-simple.pc
 }
 
 task_pipewire() {


### PR DESCRIPTION
Previous builds of the AppImage didn't have native PulseAudio support in SDL because of an incorrect dependency.
Currently the AppImage doesn't build at all because of an issue with the HTTPS certificate of the server where we download PulseAudio.