### PR TITLE
cleanup GetPlayerLightColor vs GetPlayerLightColorV2

### DIFF
--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -1369,7 +1369,6 @@ function GetLyricBarColor(Color: integer): TRGB;
 
 function GetPlayerColor(Color: integer): TRGB;
 function GetPlayerLightColor(Color: integer): TRGB;
-function GetPlayerLightColorV2(Color: integer): TRGB;
 procedure LoadPlayersColors;
 procedure LoadTeamsColors;
 
@@ -3273,72 +3272,6 @@ begin
 end;
 
 function GetPlayerLightColor(Color: integer): TRGB;
-begin
-  case (Color) of
-    1://blue
-    begin
-      Result.R := 145/255;
-      Result.G := 215/255;
-      Result.B := 240/255;
-    end;
-    2: //red
-    begin
-      Result.R := 245/255;
-      Result.G := 162/255;
-      Result.B := 162/255;
-    end;
-    3: //green
-    begin
-      Result.R := 152/255;
-      Result.G := 250/255;
-      Result.B := 153/255;
-    end;
-    4: //yellow
-    begin
-      Result.R := 255/255;
-      Result.G := 246/255;
-      Result.B := 143/255;
-    end;
-    5: //orange
-    begin
-      Result.R := 255/255;
-      Result.G := 204/255;
-      Result.B := 156/255;
-    end;
-    6: //pink
-    begin
-      Result.R := 255/255;
-      Result.G := 192/255;
-      Result.B := 205/255;
-    end;
-    7: //purple
-    begin
-      Result.R := 240/255;
-      Result.G := 170/255;
-      Result.B := 255/255;
-    end;
-    8: //gold
-    begin
-      Result.R := 255/255;
-      Result.G := 214/255;
-      Result.B := 118/255;
-    end;
-    9: //gray
-    begin
-      Result.R := 220/255;
-      Result.G := 220/255;
-      Result.B := 220/255;
-    end;
-    else
-    begin
-      Result.R := 145/255;
-      Result.G := 215/255;
-      Result.B := 240/255;
-    end;
-  end;
-end;
-
-function GetPlayerLightColorV2(Color: integer): TRGB;
 begin
   case (Color) of
     1://blue

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -732,7 +732,7 @@ var
   Col, DesCol: TRGB;
 begin
 
-  Col := GetPlayerLightColorV2(K);
+  Col := GetPlayerLightColor(K);
 
   Button[PlayerName].SelectColR:= Col.R;
   Button[PlayerName].SelectColG:= Col.G;


### PR DESCRIPTION
some cleanup around GetPlayerLightColor vs GetPlayerLightColorV2.

also fixes a long-standing bug where if P1 or P2 in duets had picked one of the later colors (for example Flame), their lyrics would be colored blue instead of their own color. It now picks the correct color.