### PR TITLE
document DLL updates

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,4 +1,9 @@
 # Making a release
+## Check for DLL updates
+The draft release notes probably already mention them, but check the [mxe releases](https://github.com/UltraStar-Deluxe/mxe/releases) for any pre-release versions.
+If there are any pre-releases present, you probably need to check [UPDATING-DLLS.md](UPDATING-DLLS.md).
+
+## Releasing USDX
 1. Find the contents of `VERSION` (strip the `+dev`) throughout the code.
     This should result in six places:
     * [VERSION](VERSION)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,4 @@
 # Making a release
-## Check for DLL updates
-The draft release notes probably already mention them, but check the [mxe releases](https://github.com/UltraStar-Deluxe/mxe/releases) for any pre-release versions.
-If there are any pre-releases present, you probably need to check [UPDATING-DLLS.md](UPDATING-DLLS.md).
-
-## Releasing USDX
 1. Find the contents of `VERSION` (strip the `+dev`) throughout the code.
     This should result in six places:
     * [VERSION](VERSION)
@@ -16,13 +11,14 @@ If there are any pre-releases present, you probably need to check [UPDATING-DLLS
     * in `variables.nsh` update both blocks immediately and swap the comments
     * in `ultrastardx.appdata.xml` add a new entry
     * in `Info.plist` update the version number
-3. Commit, `git tag v<the-new-version>` and then `git push origin master v<the-new-version> master:release`
-4. Wait and get the artifacts from the CI.
+3. If there are pre-releases in [mxe releases](https://github.com/UltraStar-Deluxe/mxe/releases), see [UPDATING-DLLS.md](UPDATING-DLLS.md).
+4. Commit, `git tag v<the-new-version>` and then `git push origin master v<the-new-version> master:release`
+5. Wait and get the artifacts from the CI.
     If any of them fail, just add an extra `;` on one of the already commented lines in `variables.nsh`, commit, and then push only `master`.
-5. Add `+dev` to the version in the first two files and swap the comments in `variables.nsh` again, commit, push.
+6. Add `+dev` to the version in the first two files and swap the comments in `variables.nsh` again, commit, push.
     This is just to set the dev version again.
-6. Attach the artifacts to the release page and publish it.
+7. Attach the artifacts to the release page and publish it.
     Don't forget to also create a PR for this release in
     https://github.com/UltraStar-Deluxe/ultrastar-deluxe.github.io
-7. Create a PR in [the FlatHub repository](https://github.com/flathub/eu.usdx.UltraStarDeluxe) that updates the tag and commit values
+8. Create a PR in [the FlatHub repository](https://github.com/flathub/eu.usdx.UltraStarDeluxe) that updates the tag and commit values.
     See this PR for an example: https://github.com/flathub/eu.usdx.UltraStarDeluxe/pull/7/files

--- a/UPDATING-DLLS.md
+++ b/UPDATING-DLLS.md
@@ -1,0 +1,16 @@
+# Updating DLLs
+The Windows DLLs are stored as releases in the [mxe](https://github.com/UltraStar-Deluxe/mxe) repository.
+
+If you need to update them:
+1. Open a PR in the [mxe](https://github.com/UltraStar-Deluxe/mxe) repository
+2. Open a PR in the USDX repository that updates the commit id in [dldlls.py](dldlls.py)
+3. Once everything works, merge the PR in the mxe repository
+4. Update the PR in the USDX repository to point to the commit id of the merge commit from step 3
+5. Merge the PR in the USDX repository and make a pre-release in the mxe repository. Pre-releases have `-rc1` added to the name of both the release and the zip asset!
+
+## Release updated DLLs
+When releasing a new version of USDX that uses new DLLs for the first time, edit the pre-release:
+* change the name (name it the same the USDX version you're about to release)
+* rename the zip asset
+* unmark it as pre-release
+* set as latest release


### PR DESCRIPTION
this PR tries to capture what was written in this comment: https://github.com/UltraStar-Deluxe/USDX/pull/889#issuecomment-2326626847
in a way that I (or anyone) can find this back a year from now

most notably
* I merged steps 5 and 6 into a single step, because from how I understand it, we should make the pre-release pretty much _as_ we merge the USDX PR? all the previous steps _can_ have some time between them and it won't break anything
* I made step 7 into its own little section as that is something that isn't really connected to the original updates anymore. You're also doing it as part of releasing USDX itself, so it is a little bit more verbose. I'm not sure if it's 100% correct because we've never done that, but it's better than nothing.

@s09bQ5 the thing I'm most unsure of is _when exactly_ to "Release updated DLLs". Currently it's before you touch anything USDX-related, but should it be between step 5 and 6 of RELEASING.md instead?