### PR TITLE
 CI/Windows: fix sourceforge download timeout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Install Dependencies
         run: |
           choco install wget --no-progress
-          wget -q https://github.com/newpascal/newpascal/releases/download/np-v1.0.50/newpascal.zip
-          7z x -y "newpascal.zip" -o"C:\" > nul
-          wget "https://netcologne.dl.sourceforge.net/project/nsis/NSIS%203/3.05/nsis-3.05-setup.exe"
+          wget https://github.com/newpascal/newpascal/releases/download/np-v1.0.50/newpascal.zip --timeout 60 --progress=dot:giga
+          7z x -y "newpascal.zip" -o"C:\"
+          wget "https://sourceforge.net/projects/nsis/files/NSIS%203/3.05/nsis-3.05-setup.exe/download" -O nsis-3.05-setup.exe --timeout 60
           ./nsis-3.05-setup.exe /S
       - name: Build
         run: |


### PR DESCRIPTION
Un-silence newpascal download and extraction.
Use sourceforge's automatic mirror selection.

See #894 