### PR TITLE
Fix downloading of DLL releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
           7z x -y usdx-dlls-i686.zip -ogame "*.dll"
         env:
           ARTIFACT_ACCESS_TOKEN: ${{ secrets.MxeActionsReadAccessToken }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create installer
         run: |
           del game\*.debug

--- a/dldlls.py
+++ b/dldlls.py
@@ -15,7 +15,9 @@ headers = {
     }
 
 token = os.environ.get('ARTIFACT_ACCESS_TOKEN')
-if token != None:
+if token == None or token.strip() == '':
+    token = os.environ.get('GITHUB_TOKEN')
+if token != None and token.strip() != '':
     headers['Authorization'] = 'Bearer ' + token
 
 print('Searching for binaries built from commit ' + sha)


### PR DESCRIPTION
As remarked in https://github.com/UltraStar-Deluxe/USDX/issues/889#issuecomment-2337573625 there is a problem when downloading DLLs.

Merge requests from other repositories will not have access to the secret used for the ARTIFACT_ACCESS_TOKEN environment variable. The variable will be set to an empty string. Using an empty token in the Authorization header makes Github reject requests which would be allowed without that header.

If the ARTIFACT_ACCESS_TOKEN is not available, try the GITHUB_TOKEN to avoid the throttling of requests without authorization. It won't work for downloading artifacts, though.