### PR TITLE
UMusic: Consider line duration 0 as no duration

### DIFF
--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -1280,8 +1280,8 @@ begin
   Result := false;
   if Length(Notes) >= 0 then
   begin
-    Result := true;
     Len := EndBeat - Notes[0].StartBeat;
+    Result := (Len > 0);
   end;
 end;
 


### PR DESCRIPTION
All users of HasLength use the return line duration as divisor. To avoid division by zero, set the result to false if the duration is 0.

Fixes #858 