### PR TITLE
Update dependencies for Linux AppImage

### DIFF
--- a/dists/linux/dl.sh
+++ b/dists/linux/dl.sh
@@ -48,27 +48,27 @@ deps+=('pulseaudio,https://www.freedesktop.org/software/pulseaudio/releases/puls
 deps+=('pipewire,https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/0.3.66/pipewire-0.3.66.tar.bz2,20c58dd867c33a7d111df69d7ec8d31c45b92a0b')
 deps+=('wayland-protocols,https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.31/downloads/wayland-protocols-1.31.tar.xz,5a84628630598027fab1708f822fc399d9e70b02')
 deps+=('SDL2,https://www.libsdl.org/release/SDL2-2.26.5.tar.gz,ca5d89edc537fd819eddab1f1a86f61e45fcb68b')
-deps+=('SDL2_image,https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.6.3.tar.gz,f4f616ccbba2f3b41383edb47b449439aa51d443')
-deps+=('sqlite,https://www.sqlite.org/2023/sqlite-autoconf-3410200.tar.gz,f5a8a9ad5552b19fb5a41cf5536c8ab3b9bce82e')
+deps+=('SDL2_image,https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.8.2.tar.gz,5c8926619d7e3f7edea4eb6410f8b1e7be7978ff')
+deps+=('sqlite,https://www.sqlite.org/2024/sqlite-autoconf-3460100.tar.gz,1fdbada080f3285ac864c314bfbfc581b13e804b')
 
 if older 2.14 nasm --version ; then
 	deps+=('nasm,https://www.nasm.us/pub/nasm/releasebuilds/2.16.01/nasm-2.16.01.tar.xz,3ab515b4a7d50b7f8c63406a19070a93dcfdb820')
 fi
 
-deps+=('dav1d,https://downloads.videolan.org/pub/videolan/dav1d/1.1.0/dav1d-1.1.0.tar.xz,f042e5e84a55a60ea439e6afd3e18e1dfcdb6d7b')
-deps+=('ffmpeg,http://ffmpeg.org/releases/ffmpeg-6.0.tar.xz,e934c379c99fb02c3cb7bb89c041ea2c028fb66b')
+deps+=('dav1d,https://downloads.videolan.org/pub/videolan/dav1d/1.4.3/dav1d-1.4.3.tar.xz,daf40121d16d5f580c42b4e8374c91d34efd9835')
+deps+=('ffmpeg,http://ffmpeg.org/releases/ffmpeg-7.0.2.tar.xz,69e11a56def9ac7073aca9d6602fa9d51a6ed6b6')
 deps+=('portmidi,https://sourceforge.net/projects/portmedia/files/portmidi/217/portmidi-src-217.zip,f45bf4e247c0d7617deacd6a65d23d9fddae6117')
 deps+=('portmidi-debian,http://http.debian.net/debian/pool/main/p/portmidi/portmidi_217-6.debian.tar.xz,02e4c6dcfbd35a75913de2acd39be8f0cfd0b244')
-deps+=('lua,https://www.lua.org/ftp/lua-5.4.5.tar.gz,72e9cd7048f765384ab4c8770e84c5e559e4ec59')
+deps+=('lua,https://www.lua.org/ftp/lua-5.4.7.tar.gz,29b54f97dab8631f52ee21a44871622eaefbe235')
 deps+=('libjpeg-turbo,https://download.sourceforge.net/libjpeg-turbo/libjpeg-turbo-2.1.5.1.tar.gz,3ec9f6a19781a583285d93c2c4653f3dbe845fcc')
-deps+=('libpng,https://download.sourceforge.net/libpng/libpng-1.6.39.tar.xz,3f2386d61eccae211ec4f57899e4ac2ca60d390b')
+deps+=('libpng,https://download.sourceforge.net/libpng/libpng-1.6.43.tar.xz,ad9f087b73acf01e2c252920810b005ee69d3e0e')
 # deps+=('libcwrap.h,https://raw.githubusercontent.com/wheybags/glibc_version_header/master/version_headers/force_link_glibc_2.10.2.h,aff0c46cf3005fe15c49688e74df62a9988855a5')
 
 if ! patchelf 2>&1 | grep -q syntax ; then
 	deps+=('patchelf,https://github.com/NixOS/patchelf/releases/download/0.13.1/patchelf-0.13.1.tar.bz2,5d9c1690c0fbe70c312f43d597e04b6c1eeffc60')
 fi
 
-deps+=('opencv,https://github.com/opencv/opencv/archive/4.7.0.tar.gz,7865fc2ff7267c26b289cda8b479439694fcfb98')
+deps+=('opencv,https://github.com/opencv/opencv/archive/refs/tags/4.10.0.tar.gz,6bd566dc4297023914137677aa96fdebee89f5bd')
 deps+=('projectm,https://github.com/projectM-visualizer/projectm/releases/download/v2.2.1/projectM-2.2.1.tar.gz,bfd0cb09797384a814c3585b7b0369fc1c8b04fe')
 # if [ -f /.dockerenv ]; then
 # 	deps+=('fpc-x86_64,https://sourceforge.net/projects/freepascal/files/Linux/3.0.4/fpc-3.0.4.x86_64-linux.tar,0720e428eaea423423e1b76a7267d6749c3399f4')

--- a/dists/linux/tasks.sh
+++ b/dists/linux/tasks.sh
@@ -390,6 +390,7 @@ task_dav1d() {
 task_ffmpeg() {
 	start_build ffmpeg FFmpeg || return 0
 	# disable vaapi until it can be tested
+	# disable libdrm, currently only useful on devices that can use Rockchip MPP codecs
 	PKG_CONFIG_PATH="$PKG_CONFIG_PATH" \
 	./configure --prefix="$PREFIX" \
 		--cc="$CC" \
@@ -406,6 +407,7 @@ task_ffmpeg() {
 		--disable-libxcb-shm \
 		--disable-libx264 \
 		--disable-libx265 \
+		--disable-libdrm \
 		--disable-network \
 		--disable-debug \
 		--disable-indevs \


### PR DESCRIPTION
Updates
SDL2_image to 2.8.2
SQLite to 3.46.1
dav1d to 1.4.3
FFmpeg to 7.0.2
Lua to 5.4.7
libpng to 1.6.43
OpenCV to 4.10.0

i.e., apart from OpenCV, the same versions used by our Windows build.