### PR TITLE
fix special characters in file and folder names

### DIFF
--- a/src/base/UFilesystem.pas
+++ b/src/base/UFilesystem.pas
@@ -439,7 +439,7 @@ end;
 
 function TFileSystemImpl.FindFirst(const FilePattern: IPath; Attr: integer; var F: TSytemSearchRec): integer;
 begin
-  Result := SysUtils.FindFirst(FilePattern.ToNative(), Attr, F);
+  Result := SysUtils.FindFirst(FilePattern.ToWide(), Attr, F);
 end;
 
 function TFileSystemImpl.FindNext(var F: TSytemSearchRec): integer;

--- a/src/base/UFilesystem.pas
+++ b/src/base/UFilesystem.pas
@@ -42,7 +42,7 @@ uses
   UPath;
 
 type
-  TSytemSearchRec = TSearchRec;
+  TSytemSearchRec = TUnicodeSearchRec;
 
   TFileInfo = record
     Time: integer;  // timestamp


### PR DESCRIPTION
fix #837 

there are some other places where a `TSearchRec` is used, and we should probably also start getting rid of some of the `RawByteString` stuff because it's just asking for trouble, but _short-term_ this should at least allow people on Windows to load all their songs again.
does not appear to have any effect on Linux, hence no ifdef guards.