### PR TITLE
less untracked files on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ ppaslink.sh
 /game/*.db
 /game/*.log
 /game/ultrastardx
+
+# created by dldlls.py on Windows
+/usdx-dlls-i686.zip
+/game/*.dll
+/game/*.debug


### PR DESCRIPTION
Since #889, running dldlls.py creates a bunch of untracked files on Windows. these hinder development, so gitignore the resulting files.