### PR TITLE
fix scoreline bonus only allowing values up to 990 instead of 1000

### DIFF
--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -1712,7 +1712,7 @@ begin
         // apply line-bonus
         CurrentPlayer.ScoreLine :=
           CurrentPlayer.ScoreLine + LineBonus * LinePerfection;
-        CurrentPlayer.ScoreLineInt := Floor(CurrentPlayer.ScoreLine / 10) * 10;
+        CurrentPlayer.ScoreLineInt := Floor(Round(CurrentPlayer.ScoreLine) / 10) * 10;
         // update total score
         CurrentPlayer.ScoreTotalInt :=
           CurrentPlayer.ScoreInt +


### PR DESCRIPTION
An alternate fix for #844 

This probably obsoletes #903 but I'll give @DeinAlptraum a chance to test it first

Some random Pascal that probably describes better what this PR does:

```
writeln ('OLD BEHAVIOUR');
writeln(Floor(989.499 / 10) * 10); // 980
writeln(Floor(989.500 / 10) * 10); // 980
writeln(Floor(999.499 / 10) * 10); // 990
writeln(Floor(999.500 / 10) * 10); // 990
writeln(Floor(999.999 / 10) * 10); // 990

writeln('NEW BEHAVIOUR');
writeln(Floor(Round(989.499) / 10) * 10); // 980
writeln(Floor(Round(989.500) / 10) * 10); // 990
writeln(Floor(Round(999.499) / 10) * 10); // 990
writeln(Floor(Round(999.500) / 10) * 10); // 1000
writeln(Floor(Round(999.999) / 10) * 10); // 1000
```

If it's supposed to go to a 1000 at 995 already, we can change that again in a future PR if needed. This PR focuses on making 1000 actually possible.