### PR TITLE
CI: Deactivate fail-fast for Mac builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,7 @@ jobs:
     name: Build for MacOS (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-13, macos-14]
     steps:


### PR DESCRIPTION
This prevents one failing build from cancelling the other.