### PR TITLE
hardcode lua array size

### DIFF
--- a/src/lua/ULuaScreenSing.pas
+++ b/src/lua/ULuaScreenSing.pas
@@ -99,7 +99,7 @@ function ULuaScreenSing_SetSettings(L: Plua_State): Integer; cdecl;
 function ULuaScreenSing_GetSongLines(L: Plua_State): Integer; cdecl;
 
 const
-  ULuaScreenSing_Lib_f: array [0..UIni.IMaxPlayerCount-1] of lual_reg = (
+  ULuaScreenSing_Lib_f: array [0..11] of lual_reg = (
     (name:'GetScores';func:ULuaScreenSing_GetScores),
     (name:'GetRating';func:ULuaScreenSing_GetRating),
     (name:'GetBPM';func:ULuaScreenSing_GetBPM),


### PR DESCRIPTION
the array size for the lua functions has no relation whatsoever with IMaxPlayerCount, they currently just happen to be the same value

this is a similar change to what was done in #554, specifically https://github.com/UltraStar-Deluxe/USDX/pull/554#discussion_r571429805
I don't think it's wrong to use a hardcoded number here: it's a static array, it seems to be how Pascal works, it's done _hundreds_ of other times throughout the code -- see for example UIni.pas.

And maybe there is an even better way, but at the very least, I think this PR objectively improves the code.