### PR TITLE
Switch to new FFmpeg AVPacket API

### DIFF
--- a/src/lib/ffmpeg-4.0/avcodec.pas
+++ b/src/lib/ffmpeg-4.0/avcodec.pas
@@ -59,6 +59,7 @@ type
     do_not_instantiate_this_record: incomplete_record;
   end;
   PAVPacket = ^TAVPacket;
+  PPAVPacket = ^PAVPacket;
   TAVPacket = record
     we_do_not_use_buf: pointer;
     pts: cint64;
@@ -306,7 +307,6 @@ type
     do_not_instantiate_this_record: incomplete_record;
   end;
 function av_dup_packet(pkt: PAVPacket): cint; cdecl; external av__codec; deprecated;
-procedure av_init_packet(var pkt: TAVPacket); cdecl; external av__codec; deprecated;
 procedure av_free_packet(pkt: PAVPacket); cdecl; external av__codec; deprecated;
 function avcodec_version(): cuint; cdecl; external av__codec;
 function av_codec_is_decoder(codec: PAVCodec): cint; cdecl; external av__codec;
@@ -325,5 +325,8 @@ function avcodec_send_packet(avctx: PAVCodecContext; avpkt: PAVPacket): cint; cd
 function avcodec_alloc_context3(codec: PAVCodec): PAVCodecContext; cdecl; external av__codec;
 procedure avcodec_free_context(avctx: PPAVCodecContext); cdecl; external av__codec;
 function avcodec_parameters_to_context(codec: PAVCodecContext; par: PAVCodecParameters): cint; cdecl; external av__codec;
+function av_packet_alloc(): PAVPacket; cdecl; external av__codec;
+procedure av_packet_free(pkt: PPAVPacket); cdecl; external av__codec;
+procedure av_packet_unref(pkt: PAVPacket); cdecl; external av__codec;
 implementation
 end.

--- a/src/lib/ffmpeg-4.0/avformat.pas
+++ b/src/lib/ffmpeg-4.0/avformat.pas
@@ -54,11 +54,6 @@ const
   AVSEEK_FLAG_ANY = 4;
   AVSEEK_FLAG_BACKWARD = 1;
 type
-  PAVPacketList = ^TAVPacketList;
-  TAVPacketList = record
-    pkt: TAVPacket;
-    next: ^TAVPacketList;
-  end;
   PAVInputFormat = ^TAVInputFormat;
   PAVStream = ^TAVStream;
   PPAVStream = ^PAVStream;
@@ -117,7 +112,7 @@ function avformat_version(): cuint; cdecl; external av__format;
 procedure av_register_all(); cdecl; external av__format; deprecated;
 function avformat_find_stream_info(ic: PAVFormatContext; options: PPAVDictionary): cint; cdecl; external av__format;
 function av_stream_get_r_frame_rate(s: PAVStream): TAVRational; cdecl; external av__format; deprecated;
-function av_read_frame(s: PAVFormatContext; var pkt: TAVPacket): cint; cdecl; external av__format;
+function av_read_frame(s: PAVFormatContext; pkt: PAVPacket): cint; cdecl; external av__format;
 function av_seek_frame(s: PAVFormatContext; stream_index: cint; timestamp: cint64; flags: cint): cint; cdecl; external av__format;
 implementation
 end.

--- a/src/lib/ffmpeg-5.0/avcodec.pas
+++ b/src/lib/ffmpeg-5.0/avcodec.pas
@@ -55,6 +55,7 @@ type
     AV_CODEC_ID_NONE
   );
   PAVPacket = ^TAVPacket;
+  PPAVPacket = ^PAVPacket;
   TAVPacket = record
     we_do_not_use_buf: pointer;
     pts: cint64;
@@ -271,7 +272,6 @@ type
   end;
 function av_packet_ref(dst: PAVPacket; src: PAVPacket): cint; cdecl; external av__codec;
 procedure av_packet_unref(pkt: PAVPacket); cdecl; external av__codec;
-procedure av_init_packet(var pkt: TAVPacket); cdecl; external av__codec; deprecated;
 function avcodec_version(): cuint; cdecl; external av__codec;
 function av_codec_is_decoder(codec: PAVCodec): cint; cdecl; external av__codec;
 function av_codec_iterate(opaque: ppointer): PAVCodec; cdecl; external av__codec;
@@ -286,5 +286,7 @@ function avcodec_send_packet(avctx: PAVCodecContext; avpkt: PAVPacket): cint; cd
 function avcodec_alloc_context3(codec: PAVCodec): PAVCodecContext; cdecl; external av__codec;
 procedure avcodec_free_context(avctx: PPAVCodecContext); cdecl; external av__codec;
 function avcodec_parameters_to_context(codec: PAVCodecContext; par: PAVCodecParameters): cint; cdecl; external av__codec;
+function av_packet_alloc(): PAVPacket; cdecl; external av__codec;
+procedure av_packet_free(pkt: PPAVPacket); cdecl; external av__codec;
 implementation
 end.

--- a/src/lib/ffmpeg-5.0/avformat.pas
+++ b/src/lib/ffmpeg-5.0/avformat.pas
@@ -54,11 +54,6 @@ const
   AVSEEK_FLAG_ANY = 4;
   AVSEEK_FLAG_BACKWARD = 1;
 type
-  PAVPacketList = ^TAVPacketList;
-  TAVPacketList = record
-    pkt: TAVPacket;
-    next: ^TAVPacketList;
-  end;
   PAVInputFormat = ^TAVInputFormat;
   PAVStream = ^TAVStream;
   PPAVStream = ^PAVStream;
@@ -112,7 +107,7 @@ function avformat_open_input(ps: PPAVFormatContext; url: PAnsiChar; fmt: PAVInpu
 procedure avformat_close_input(s: PPAVFormatContext); cdecl; external av__format;
 function avformat_version(): cuint; cdecl; external av__format;
 function avformat_find_stream_info(ic: PAVFormatContext; options: PPAVDictionary): cint; cdecl; external av__format;
-function av_read_frame(s: PAVFormatContext; var pkt: TAVPacket): cint; cdecl; external av__format;
+function av_read_frame(s: PAVFormatContext; pkt: PAVPacket): cint; cdecl; external av__format;
 function av_seek_frame(s: PAVFormatContext; stream_index: cint; timestamp: cint64; flags: cint): cint; cdecl; external av__format;
 implementation
 end.

--- a/src/lib/ffmpeg-6.0/avcodec.pas
+++ b/src/lib/ffmpeg-6.0/avcodec.pas
@@ -55,6 +55,7 @@ type
     AV_CODEC_ID_NONE
   );
   PAVPacket = ^TAVPacket;
+  PPAVPacket = ^PAVPacket;
   TAVPacket = record
     we_do_not_use_buf: pointer;
     pts: cint64;
@@ -70,11 +71,6 @@ type
     opaque: pointer;
     we_do_not_use_opaque_ref: pointer;
     we_do_not_use_time_base: TAVRational;
-  end;
-  PAVPacketList = ^TAVPacketList;
-  TAVPacketList = record
-    pkt: TAVPacket;
-    next: ^TAVPacketList;
   end;
   PAVCodecDescriptor = ^TAVCodecDescriptor;
   TAVCodecDescriptor = record
@@ -238,7 +234,6 @@ type
   end;
 function av_packet_ref(dst: PAVPacket; src: PAVPacket): cint; cdecl; external av__codec;
 procedure av_packet_unref(pkt: PAVPacket); cdecl; external av__codec;
-procedure av_init_packet(var pkt: TAVPacket); cdecl; external av__codec; deprecated;
 function avcodec_version(): cuint; cdecl; external av__codec;
 function av_codec_is_decoder(codec: PAVCodec): cint; cdecl; external av__codec;
 function av_codec_iterate(opaque: ppointer): PAVCodec; cdecl; external av__codec;
@@ -253,5 +248,7 @@ function avcodec_send_packet(avctx: PAVCodecContext; avpkt: PAVPacket): cint; cd
 function avcodec_alloc_context3(codec: PAVCodec): PAVCodecContext; cdecl; external av__codec;
 procedure avcodec_free_context(avctx: PPAVCodecContext); cdecl; external av__codec;
 function avcodec_parameters_to_context(codec: PAVCodecContext; par: PAVCodecParameters): cint; cdecl; external av__codec;
+function av_packet_alloc(): PAVPacket; cdecl; external av__codec;
+procedure av_packet_free(pkt: PPAVPacket); cdecl; external av__codec;
 implementation
 end.

--- a/src/lib/ffmpeg-6.0/avformat.pas
+++ b/src/lib/ffmpeg-6.0/avformat.pas
@@ -108,7 +108,7 @@ function avformat_open_input(ps: PPAVFormatContext; url: PAnsiChar; fmt: PAVInpu
 procedure avformat_close_input(s: PPAVFormatContext); cdecl; external av__format;
 function avformat_version(): cuint; cdecl; external av__format;
 function avformat_find_stream_info(ic: PAVFormatContext; options: PPAVDictionary): cint; cdecl; external av__format;
-function av_read_frame(s: PAVFormatContext; var pkt: TAVPacket): cint; cdecl; external av__format;
+function av_read_frame(s: PAVFormatContext; pkt: PAVPacket): cint; cdecl; external av__format;
 function av_seek_frame(s: PAVFormatContext; stream_index: cint; timestamp: cint64; flags: cint): cint; cdecl; external av__format;
 implementation
 end.

--- a/src/lib/ffmpeg-7.0/avcodec.pas
+++ b/src/lib/ffmpeg-7.0/avcodec.pas
@@ -55,6 +55,7 @@ type
     AV_CODEC_ID_NONE
   );
   PAVPacket = ^TAVPacket;
+  PPAVPacket = ^PAVPacket;
   TAVPacket = record
     we_do_not_use_buf: pointer;
     pts: cint64;
@@ -70,11 +71,10 @@ type
     opaque: pointer;
     we_do_not_use_opaque_ref: pointer;
     we_do_not_use_time_base: TAVRational;
-  end;
-  PAVPacketList = ^TAVPacketList;
-  TAVPacketList = record
-    pkt: TAVPacket;
-    next: ^TAVPacketList;
+  (* According to the FFmpeg documentation, sizeof(AVPacket) is
+   * deprecated for the public ABI. However, TAVPacket is still a member of
+   * TAVStream. So we can't put the incomplete record member because that will
+   * change the memory layout of TAVStream *)
   end;
   PAVCodecDescriptor = ^TAVCodecDescriptor;
   TAVCodecDescriptor = record
@@ -227,7 +227,6 @@ type
   end;
 function av_packet_ref(dst: PAVPacket; src: PAVPacket): cint; cdecl; external av__codec;
 procedure av_packet_unref(pkt: PAVPacket); cdecl; external av__codec;
-procedure av_init_packet(var pkt: TAVPacket); cdecl; external av__codec; deprecated;
 function avcodec_version(): cuint; cdecl; external av__codec;
 function av_codec_is_decoder(codec: PAVCodec): cint; cdecl; external av__codec;
 function av_codec_iterate(opaque: ppointer): PAVCodec; cdecl; external av__codec;
@@ -241,5 +240,7 @@ function avcodec_send_packet(avctx: PAVCodecContext; avpkt: PAVPacket): cint; cd
 function avcodec_alloc_context3(codec: PAVCodec): PAVCodecContext; cdecl; external av__codec;
 procedure avcodec_free_context(avctx: PPAVCodecContext); cdecl; external av__codec;
 function avcodec_parameters_to_context(codec: PAVCodecContext; par: PAVCodecParameters): cint; cdecl; external av__codec;
+function av_packet_alloc(): PAVPacket; cdecl; external av__codec;
+procedure av_packet_free(pkt: PPAVPacket); cdecl; external av__codec;
 implementation
 end.

--- a/src/lib/ffmpeg-7.0/avformat.pas
+++ b/src/lib/ffmpeg-7.0/avformat.pas
@@ -112,7 +112,7 @@ function avformat_open_input(ps: PPAVFormatContext; url: PAnsiChar; fmt: PAVInpu
 procedure avformat_close_input(s: PPAVFormatContext); cdecl; external av__format;
 function avformat_version(): cuint; cdecl; external av__format;
 function avformat_find_stream_info(ic: PAVFormatContext; options: PPAVDictionary): cint; cdecl; external av__format;
-function av_read_frame(s: PAVFormatContext; var pkt: TAVPacket): cint; cdecl; external av__format;
+function av_read_frame(s: PAVFormatContext; pkt: PAVPacket): cint; cdecl; external av__format;
 function av_seek_frame(s: PAVFormatContext; stream_index: cint; timestamp: cint64; flags: cint): cint; cdecl; external av__format;
 implementation
 end.

--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -902,6 +902,7 @@ begin
       UnlockParser();
     end;
   end;
+  av_packet_free(@Packet);
   if (IsQuit()) then
   begin
     Result := false;

--- a/src/media/UMediaCore_FFmpeg.pas
+++ b/src/media/UMediaCore_FFmpeg.pas
@@ -597,12 +597,8 @@ end;
 procedure TPacketQueue.FreeStatusInfo(Packet: PAVPacket);
 begin
   {$IF LIBAVCODEC_VERSION_MAJOR >= 59}
-  if (Packet^.opaque <> nil) then
-  begin
     FreeMemAndNil(Packet^.opaque);
-  end;
   {$ELSE}
-  if (Packet^.side_data <> nil) then
     FreeMemAndNil(Packet^.side_data);
   {$ENDIF}
 


### PR DESCRIPTION
A significant breaking change is coming to the FFmpeg API in the [next major version bump of libavcodec](https://github.com/FFmpeg/FFmpeg/blob/539cea31830e71f1ce290c56ff2d639b209c2ac2/libavcodec/version_major.h#L40), which is expected to occur with the release of FFmpeg 8 sometime in the next few months. See #778 for more details.
- sizeof(`AVPacket`) is being removed from the public ABI. The FFmpeg developers want to add fields to the end of the struct without bumping the major version. This means that calling applications should not allocate the `AVPacket` structure, but instead use `av_packet_alloc` to let FFmpeg allocate it. Otherwise, there is a risk of a segfault.
- `av_init_packet` is being removed (`av_packet_alloc` takes over this functionality).
- `AVPacketList` is being removed

New code is added to use the FFmpeg allocator for `TAVPacket`, and operate on `PAVPacket` instead of `TAVPacket`. A custom record type `TPacketList` was introduced to replace `TAVPacketList`, which fulfills the same purpose.

I've done some testing locally on both Linux and Windows. Everything is working on my end and I haven't detected any memory leaks.

Fixes #778