### PR TITLE
More Reliable EOF Detection

### DIFF
--- a/src/media/UAudioPlayback_SoftMixer.pas
+++ b/src/media/UAudioPlayback_SoftMixer.pas
@@ -663,6 +663,16 @@ begin
 
       SourceSize := SourceStream.ReadData(
           @SourceBuffer[SourceBufferCount], SourceBufferSize-SourceBufferCount);
+
+      // end-of-file reached -> stop playback
+      if (SourceStream.EOF) then
+      begin
+        if (Loop) then
+          SourceStream.Position := 0
+        else
+          Stop();
+      end;
+
       // break on error (-1) or if no data is available (0), e.g. while seeking
       if (SourceSize <= 0) then
       begin
@@ -678,15 +688,6 @@ begin
       end;
 
       SourceBufferCount := SourceBufferCount + SourceSize;
-
-      // end-of-file reached -> stop playback
-      if (SourceStream.EOF) then
-      begin
-        if (Loop) then
-          SourceStream.Position := 0
-        else
-          Stop();
-      end;
 
       if (SkipSourceCount > 0) then
       begin


### PR DESCRIPTION
I added some new songs to my library recently, and encountered #600 for the first time. After some debugging, I have discovered the root cause. I have found that there are actually two different issues causing this, the first in `TFFmpegDecodeStream`, and the second in `TGenericPlaybackStream`. This is why this problem only impacts the Linux/Mac versions (the Windows version uses BASS for both audio decoding and playback).

The first issue is relatively straightforward. For some files, the FFmpeg parser thread is not sending the EOF status packet, and is sending an error status packet instead. The [current FFmpeg code](https://github.com/UltraStar-Deluxe/USDX/blob/fc15e33ee3d847cb38e77e8789b18627738ba44e/src/media/UAudioDecoder_FFmpeg.pas#L861-L907) uses a hack method to detect EOF. This may have been the best way to do it at the time that code was written. But modern FFmpeg provides a return value from `av_read_frame` (`AVERROR_EOF`) which tells you when EOF is reached. This is the standard way to detect EOF in FFmpeg (all of FFmpeg's official code examples use it).

The second issue is only triggered by a very particular set of circumstances. The relevant code is [here](https://github.com/UltraStar-Deluxe/USDX/blob/fc15e33ee3d847cb38e77e8789b18627738ba44e/src/media/UAudioPlayback_SoftMixer.pas#L664-L689). It happens when a call is made to `TFFmpegDecodeStream.ReadData` while the packet queue contains only a single packet, and it's a status packet with the EOF flag set (i.e., not a "real" packet returned by FFmpeg containing actual audio data).

Here is an overview of the program execution in this case:
1. `TGenericPlaybackStream.ReadData` calls `TFFmpegDecodeStream.ReadData` while the packet queue contains only an EOF status packet
2. `TFFmpegDecodeStream.ReadData` takes the EOF status packet out of the queue, sets its EOF property, then returns 0, because no audio data was copied into the buffer.
3. Because the return value was 0, `TGenericPlaybackStream.ReadData` executes [here](https://github.com/UltraStar-Deluxe/USDX/blob/fc15e33ee3d847cb38e77e8789b18627738ba44e/src/media/UAudioPlayback_SoftMixer.pas#L667-L678), then exits
4. Every subsequent call to `TFFmpegDecodeStream.ReadData` returns -1, because [EOF property has already been set](https://github.com/UltraStar-Deluxe/USDX/blob/fc15e33ee3d847cb38e77e8789b18627738ba44e/src/media/UAudioDecoder_FFmpeg.pas#L1196-L1198). As a result, the same code block as above executes indefinitely, exiting/breaking out of the loop.
5. The program execution never gets to [this point](https://github.com/UltraStar-Deluxe/USDX/blob/fc15e33ee3d847cb38e77e8789b18627738ba44e/src/media/UAudioPlayback_SoftMixer.pas#L682-L689) where the playback stream is stopped.

In summary, `TGenericPlaybackStream.ReadData` does not check for EOF on the source stream if the source stream copied no data into the audio buffer.

The current process is:
1. Call `ReadData` on the source stream
2. Handle the case where no data was copied into the buffer (break/exit)
3. Check for EOF on the source stream.

My proposed solution for this issue is to flip the order of 2 and 3 above. So, now it's:

1. Call `ReadData` on the source stream
2. Check for EOF on the source stream
3. Handle the case where no data was copied into the buffer (break/exit)

This ensures the the playback stream will always check for EOF on the source stream regardless of how much data was copied into the audio buffer.

This fixes the problem and has not introduced any regressions in my testing.

Fixes #600

