### PR TITLE
Implement UltraStar File Format 1.0.0

### DIFF
--- a/src/base/UFiles.pas
+++ b/src/base/UFiles.pas
@@ -126,12 +126,6 @@ begin
   try
     SongFile := TMemTextFileStream.Create(Name, fmCreate);
     try
-      // to-do: should we really write the BOM?
-      //        it causes problems w/ older versions
-      //        e.g. usdx 1.0.1a or ultrastar < 0.7.0
-      if (Song.Encoding = encUTF8) then
-        SongFile.WriteString(UTF8_BOM);
-
       if Song.FormatVersion.MinVersion(1,0,0,true) then
       begin
         // Only save version if it is at least 1.0.0

--- a/src/base/UFiles.pas
+++ b/src/base/UFiles.pas
@@ -132,9 +132,20 @@ begin
       if (Song.Encoding = encUTF8) then
         SongFile.WriteString(UTF8_BOM);
 
-      // do not save "auto" encoding tag
-      if (Song.Encoding <> encAuto) then
-        SongFile.WriteLine('#ENCODING:' + EncodingName(Song.Encoding));
+      if Song.FormatVersion.MinVersion(1,0,0,true) then
+      begin
+        // Only save version if it is at least 1.0.0
+        SongFile.WriteLine('#VERSION:' + EncodeToken(Song.FormatVersion.VersionString));
+        // RELATIVE was removed in format 1.0.0
+        Relative := False;
+      end
+      else
+      begin
+        // Only save Encoding if Version is below 1.0.0
+        // do not save "auto" encoding tag
+        if (Song.Encoding <> encAuto) then
+          SongFile.WriteLine('#ENCODING:' + EncodingName(Song.Encoding));
+      end;
       SongFile.WriteLine('#TITLE:'    + EncodeToken(Song.Title));
       SongFile.WriteLine('#ARTIST:'   + EncodeToken(Song.Artist));
 

--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -998,6 +998,7 @@ begin
     //First: Read the format version
     if (TagMap.TryGetData('VERSION', Value)) then
     begin
+      RemoveTagsFromTagMap('VERSION');
       try
         self.FormatVersion := TVersion.Create(Value);
       except


### PR DESCRIPTION
This PR implements support for the UltraStar File Format 1.0.0.
Most notably, `TSong` was extended by the public field `FormatVersion`, which represents the version of the songs txt file file as indicated by the VERSION header. (The absence of the VERSION header is evaluated as a legacy version 0.3.0.)

The file format 1.0.0 removed a few headers, which USDX will now ignore if they are found in a file with VERSION >= 1.0.0. These headers are:

- DUETSINGERP1 / DUETSINGERP2
- RESOLUTION
- NOTESGAP
- ENCODING (For VERSION >= 1.0.0 the UTF-8 encoding is enforced)
- RELATIVE (Songs with VERSION >= 1.0.0 and RELATIVE header are rejected)

I also updated the Song saving code, to handle songs with VERSION >= 1.0.0 slightly differently:

- The VERSION header is written as first header of the file
- The ENCODING header will not be written
- Relative saving is disabled -> saving using shift + s will result in a normal (non-relative) file

## Open question regarding UTF-8 BOM

The [format specification](https://github.com/UltraStar-Deluxe/format/blob/main/spec.md) says:

> The UTF-8 encoding MUST be used. Implementations MUST NOT add a byte order mark to the beginning of a file.

Currently USDX saves UTF-8 files with BOM, which does not adhere to the specification.
The code already contains a comment questioning this behavior.
I would like to address our handling of UTF-8 BOM in the context of this PR, as I see it as a further aspect of being format specification compliant.

I see three different ways to handle the UTF-8 BOM:

1. Keep it as is and always write the BOM if encoding is UTF-8. This would be in violation of the format specification.
2. Never write BOM. This adheres to the specification.
3. Only write BOM for legacy songs with format version < 1.0.0 (i.e. no VERSION tag) and don't write BOM for songs with format version >= 1.0.0. This would adhere to the specification at least for "recent" format versions.

Out of the three options I would prefer 2 the most, as I don't see the need for UTF-8 BOM regardless of format version.
If you believe BOM to be important for legacy support I would also be fine with option 3.

If in your opinion the BOM discussion is out of scope for this PR, we can naturally move it to a new issue / PR, while this PR only focuses on the new header handling for reading and writing songs.

I'm interested in your thoughts on the BOM topic and my changes in general. :smile: 