### PR TITLE
Support Video Files That Contain Embedded Artwork

### DIFF
--- a/src/lib/ffmpeg-4.0/avformat.pas
+++ b/src/lib/ffmpeg-4.0/avformat.pas
@@ -53,6 +53,7 @@ const
   AVFMT_FLAG_GENPTS = 1;
   AVSEEK_FLAG_ANY = 4;
   AVSEEK_FLAG_BACKWARD = 1;
+  AV_DISPOSITION_ATTACHED_PIC = 1024;
 type
   PAVInputFormat = ^TAVInputFormat;
   PAVStream = ^TAVStream;
@@ -87,7 +88,7 @@ type
     start_time: cint64;
     we_do_not_use_duration: cint64;
     we_do_not_use_nb_frames: cint64;
-    we_do_not_use_disposition: cint;
+    disposition: cint;
     we_do_not_use_discard: cenum;
     we_do_not_use_sample_aspect_ratio: TAVRational;
     we_do_not_use_metadata: PAVDictionary;

--- a/src/lib/ffmpeg-5.0/avformat.pas
+++ b/src/lib/ffmpeg-5.0/avformat.pas
@@ -53,6 +53,7 @@ const
   AVFMT_FLAG_GENPTS = 1;
   AVSEEK_FLAG_ANY = 4;
   AVSEEK_FLAG_BACKWARD = 1;
+  AV_DISPOSITION_ATTACHED_PIC = 1024;
 type
   PAVInputFormat = ^TAVInputFormat;
   PAVStream = ^TAVStream;
@@ -85,7 +86,7 @@ type
     start_time: cint64;
     we_do_not_use_duration: cint64;
     we_do_not_use_nb_frames: cint64;
-    we_do_not_use_disposition: cint;
+    disposition: cint;
     we_do_not_use_discard: cenum;
     we_do_not_use_sample_aspect_ratio: TAVRational;
     we_do_not_use_metadata: PAVDictionary;

--- a/src/lib/ffmpeg-6.0/avformat.pas
+++ b/src/lib/ffmpeg-6.0/avformat.pas
@@ -53,6 +53,7 @@ const
   AVFMT_FLAG_GENPTS = 1;
   AVSEEK_FLAG_ANY = 4;
   AVSEEK_FLAG_BACKWARD = 1;
+  AV_DISPOSITION_ATTACHED_PIC = 1024;
 type
   PAVInputFormat = ^TAVInputFormat;
   PAVStream = ^TAVStream;
@@ -87,7 +88,7 @@ type
     start_time: cint64;
     we_do_not_use_duration: cint64;
     we_do_not_use_nb_frames: cint64;
-    we_do_not_use_disposition: cint;
+    disposition: cint;
     we_do_not_use_discard: cenum;
     we_do_not_use_sample_aspect_ratio: TAVRational;
     we_do_not_use_metadata: PAVDictionary;

--- a/src/lib/ffmpeg-7.0/avformat.pas
+++ b/src/lib/ffmpeg-7.0/avformat.pas
@@ -53,6 +53,7 @@ const
   AVFMT_FLAG_GENPTS = 1;
   AVSEEK_FLAG_ANY = 4;
   AVSEEK_FLAG_BACKWARD = 1;
+  AV_DISPOSITION_ATTACHED_PIC = 1024;
 type
   PAVInputFormat = ^TAVInputFormat;
   PAVStream = ^TAVStream;
@@ -91,7 +92,7 @@ type
     start_time: cint64;
     we_do_not_use_duration: cint64;
     we_do_not_use_nb_frames: cint64;
-    we_do_not_use_disposition: cint;
+    disposition: cint;
     we_do_not_use_discard: cenum;
     we_do_not_use_sample_aspect_ratio: TAVRational;
     we_do_not_use_metadata: PAVDictionary;

--- a/src/media/UMediaCore_FFmpeg.pas
+++ b/src/media/UMediaCore_FFmpeg.pas
@@ -250,7 +250,8 @@ begin
 
 {$IF LIBAVFORMAT_VERSION < 59000000}
     if (Stream.codec.codec_type = AVMEDIA_TYPE_VIDEO) and
-       (FirstVideoStream < 0) then
+       (FirstVideoStream < 0) and
+       ((Stream.disposition and AV_DISPOSITION_ATTACHED_PIC) <> AV_DISPOSITION_ATTACHED_PIC) then
     begin
       FirstVideoStream := i;
     end;
@@ -263,7 +264,8 @@ begin
   end;
 {$ELSE}
     if (Stream.codecpar.codec_type = AVMEDIA_TYPE_VIDEO) and
-       (FirstVideoStream < 0) then
+       (FirstVideoStream < 0) and
+       ((Stream.disposition and AV_DISPOSITION_ATTACHED_PIC) <> AV_DISPOSITION_ATTACHED_PIC) then
     begin
       FirstVideoStream := i;
     end;


### PR DESCRIPTION
For some file formats (notably MP4), FFmpeg uses an `AVStream` structure to logically represent embedded cover art. USDX's current video stream selection logic always selects the first video stream reported by FFmpeg. If the first video stream is cover art, USDX will fail to play the video. See #902.

FFmpeg sets a flag `AV_DISPOSITION_ATTACHED_PIC` to indicate that an `AVStream` object represents cover art. This PR updates the stream selection logic to reject video streams that have the flag set. This ensures that an actual video stream will be selected for files that contain embedded cover art.

Fixes #902