### PR TITLE
Update release documentation

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,10 @@
 6. Add `+dev` to the version in the first two files and swap the comments in `variables.nsh` again, commit, push.
     This is just to set the dev version again.
 7. Attach the artifacts to the release page and publish it.
-    Don't forget to also create a PR for this release in
-    https://github.com/UltraStar-Deluxe/ultrastar-deluxe.github.io
 8. Create a PR in [the FlatHub repository](https://github.com/flathub/eu.usdx.UltraStarDeluxe) that updates the tag and commit values.
     See this PR for an example: https://github.com/flathub/eu.usdx.UltraStarDeluxe/pull/7/files
+9. Create a PR in [the github.io repository](https://github.com/UltraStar-Deluxe/ultrastar-deluxe.github.io)
+10. By now the FlatHub build will probably have completed.
+    If it builds successfully, merge it using the _Rebase and Merge_ option.
+11. Merge the github.io PR.
+12. Close the USDX Draft Release Notes issue and make an announcement in Discord.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,7 +14,7 @@
 3. If there are pre-releases in [mxe releases](https://github.com/UltraStar-Deluxe/mxe/releases), see [UPDATING-DLLS.md](UPDATING-DLLS.md).
 4. Commit, `git tag v<the-new-version>` and then `git push origin master v<the-new-version> master:release`
 5. Wait and get the artifacts from the CI.
-    If any of them fail, just add an extra `;` on one of the already commented lines in `variables.nsh`, commit, and then push only `master`.
+    If any of them fail, retry the job.
 6. Add `+dev` to the version in the first two files and swap the comments in `variables.nsh` again, commit, push.
     This is just to set the dev version again.
 7. Attach the artifacts to the release page and publish it.


### PR DESCRIPTION
In #935 it was found that some release steps were incomplete/slightly off. This PR corrects that.

Also updated the section on failed jobs, as that was for AppVeyor (where we couldn't retry jobs) but on Github we can just retry until It Works.