### PR TITLE
Allow songs that only have a single sentence

### DIFF
--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -822,7 +822,7 @@ begin
   begin
     if ((Both) or (TrackIndex = 0)) then
     begin
-      if (Length(Tracks[TrackIndex].Lines) < 2) then
+      if (Length(Tracks[TrackIndex].Lines) < 1) then
       begin
         LastError := 'ERROR_CORRUPT_SONG_NO_BREAKS';
         Log.LogError('Error loading file: Can''t find any linebreaks in "' + FileNamePath.ToNative + '"');

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -4091,7 +4091,7 @@ begin
   else
     EditDrawBorderedBox(X, Y, W, H, ColR, ColG, ColB, Alpha);
 
-  if(numLines = 1) then
+  if(numLines < 1) then
     Exit;
 
   SongStart := FindStartBeat;

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -1281,8 +1281,6 @@ begin
   for CurrentTrack := 0 to High(Tracks) do //for P1 of duet or solo lyrics, P2 of duet,..
   begin
     numLines := Length(Tracks[CurrentTrack].Lines); //Lyric lines
-    if (numLines < 2) then //catch cases which could cause endless loop
-      Exit;
     //set color to player.color
     if (CurrentTrack = 0) then
       glColor4f(GetLyricColor(Ini.SingColor[0]).R, GetLyricColor(Ini.SingColor[0]).G, GetLyricColor(Ini.SingColor[0]).B, 0.6)


### PR DESCRIPTION
this PR allows songs that only have a single sentence to be played and edited. Previously, these would not be loaded and have a `Can't find any linebreaks` error in the logs.

I'm pretty sure the singview can do without the check altogether (the "endless loop" comment has always been there since the beginning of the repo, but even if you manage to get a song with 0 sentences in, it should still be fine?). Not sure about the editor as it's doing divisions, hence I made it `if < 1` there. Besides, not sure what's the point of editing a song that has no sentences.

fixes #895 