### PR TITLE
More Accurate FFmpeg Audio Seeking

### DIFF
--- a/src/lib/ffmpeg-4.0/avcodec.pas
+++ b/src/lib/ffmpeg-4.0/avcodec.pas
@@ -50,6 +50,7 @@ const
 
 const
   FF_BUG_AUTODETECT = 1;
+  AV_PKT_DATA_SKIP_SAMPLES = 11;
 type
   TAVCodecID = (
     AV_CODEC_ID_NONE
@@ -58,6 +59,7 @@ type
   TAVPicture = record
     do_not_instantiate_this_record: incomplete_record;
   end;
+  TAVPacketSideDataType = cenum;
   PAVPacket = ^TAVPacket;
   PPAVPacket = ^PAVPacket;
   TAVPacket = record
@@ -69,7 +71,7 @@ type
     stream_index: cint;
     flags: cint;
     side_data: pointer;
-    we_do_not_use_side_data_elems: cint;
+    side_data_elems: cint;
     we_do_not_use_duration: cint64;
     we_do_not_use_pos: cint64;
     we_do_not_use_convergence_duration: cint64;
@@ -328,5 +330,7 @@ function avcodec_parameters_to_context(codec: PAVCodecContext; par: PAVCodecPara
 function av_packet_alloc(): PAVPacket; cdecl; external av__codec;
 procedure av_packet_free(pkt: PPAVPacket); cdecl; external av__codec;
 procedure av_packet_unref(pkt: PAVPacket); cdecl; external av__codec;
+function av_packet_new_side_data(pkt: PAVPacket; type_data: TAVPacketSideDataType; size: csize_t): pcuint8; cdecl; external av__codec;
+function av_packet_get_side_data(const pkt: PAVPacket; type_data: TAVPacketSideDataType; size: pcsize_t): pcuint8; cdecl; external av__codec;
 implementation
 end.

--- a/src/lib/ffmpeg-5.0/avcodec.pas
+++ b/src/lib/ffmpeg-5.0/avcodec.pas
@@ -50,10 +50,12 @@ const
 
 const
   FF_BUG_AUTODETECT = 1;
+  AV_PKT_DATA_SKIP_SAMPLES = 11;
 type
   TAVCodecID = (
     AV_CODEC_ID_NONE
   );
+  TAVPacketSideDataType = cenum;
   PAVPacket = ^TAVPacket;
   PPAVPacket = ^PAVPacket;
   TAVPacket = record
@@ -65,7 +67,7 @@ type
     stream_index: cint;
     flags: cint;
     we_do_not_use_side_data: pointer;
-    we_do_not_use_side_data_elems: cint;
+    side_data_elems: cint;
     we_do_not_use_duration: cint64;
     we_do_not_use_pos: cint64;
     opaque: pointer;
@@ -288,5 +290,7 @@ procedure avcodec_free_context(avctx: PPAVCodecContext); cdecl; external av__cod
 function avcodec_parameters_to_context(codec: PAVCodecContext; par: PAVCodecParameters): cint; cdecl; external av__codec;
 function av_packet_alloc(): PAVPacket; cdecl; external av__codec;
 procedure av_packet_free(pkt: PPAVPacket); cdecl; external av__codec;
+function av_packet_new_side_data(pkt: PAVPacket; type_data: TAVPacketSideDataType; size: csize_t): pcuint8; cdecl; external av__codec;
+function av_packet_get_side_data(const pkt: PAVPacket; type_data: TAVPacketSideDataType; size: pcsize_t): pcuint8; cdecl; external av__codec;
 implementation
 end.

--- a/src/lib/ffmpeg-6.0/avcodec.pas
+++ b/src/lib/ffmpeg-6.0/avcodec.pas
@@ -50,10 +50,12 @@ const
 
 const
   FF_BUG_AUTODETECT = 1;
+  AV_PKT_DATA_SKIP_SAMPLES = 11;
 type
   TAVCodecID = (
     AV_CODEC_ID_NONE
   );
+  TAVPacketSideDataType = cenum;
   PAVPacket = ^TAVPacket;
   PPAVPacket = ^PAVPacket;
   TAVPacket = record
@@ -65,7 +67,7 @@ type
     stream_index: cint;
     flags: cint;
     we_do_not_use_side_data: pointer;
-    we_do_not_use_side_data_elems: cint;
+    side_data_elems: cint;
     we_do_not_use_duration: cint64;
     we_do_not_use_pos: cint64;
     opaque: pointer;
@@ -250,5 +252,7 @@ procedure avcodec_free_context(avctx: PPAVCodecContext); cdecl; external av__cod
 function avcodec_parameters_to_context(codec: PAVCodecContext; par: PAVCodecParameters): cint; cdecl; external av__codec;
 function av_packet_alloc(): PAVPacket; cdecl; external av__codec;
 procedure av_packet_free(pkt: PPAVPacket); cdecl; external av__codec;
+function av_packet_new_side_data(pkt: PAVPacket; type_data: TAVPacketSideDataType; size: csize_t): pcuint8; cdecl; external av__codec;
+function av_packet_get_side_data(const pkt: PAVPacket; type_data: TAVPacketSideDataType; size: pcsize_t): pcuint8; cdecl; external av__codec;
 implementation
 end.

--- a/src/lib/ffmpeg-7.0/avcodec.pas
+++ b/src/lib/ffmpeg-7.0/avcodec.pas
@@ -50,10 +50,12 @@ const
 
 const
   FF_BUG_AUTODETECT = 1;
+  AV_PKT_DATA_SKIP_SAMPLES = 11;
 type
   TAVCodecID = (
     AV_CODEC_ID_NONE
   );
+  TAVPacketSideDataType = cenum;
   PAVPacket = ^TAVPacket;
   PPAVPacket = ^PAVPacket;
   TAVPacket = record
@@ -65,7 +67,7 @@ type
     stream_index: cint;
     flags: cint;
     we_do_not_use_side_data: pointer;
-    we_do_not_use_side_data_elems: cint;
+    side_data_elems: cint;
     we_do_not_use_duration: cint64;
     we_do_not_use_pos: cint64;
     opaque: pointer;
@@ -242,5 +244,7 @@ procedure avcodec_free_context(avctx: PPAVCodecContext); cdecl; external av__cod
 function avcodec_parameters_to_context(codec: PAVCodecContext; par: PAVCodecParameters): cint; cdecl; external av__codec;
 function av_packet_alloc(): PAVPacket; cdecl; external av__codec;
 procedure av_packet_free(pkt: PPAVPacket); cdecl; external av__codec;
+function av_packet_new_side_data(pkt: PAVPacket; type_data: TAVPacketSideDataType; size: csize_t): pcuint8; cdecl; external av__codec;
+function av_packet_get_side_data(const pkt: PAVPacket; type_data: TAVPacketSideDataType; size: pcsize_t): pcuint8; cdecl; external av__codec;
 implementation
 end.


### PR DESCRIPTION
This is the first of two PRs intended to resolve USDX's audio seeking accuracy issues (#673, #749, #884)

This PR significantly improves the seeking accuracy for the FFmpeg audio decoder. The existing seeking method can only seek to points *between* `AVPacket` structures returned by the demuxer. The new method can seek an exact audio sample *within* an `AVPacket`, using FFmpeg's `AVPacketSideData` API. Here is a summary of the changes:
1. Change the seek flag to `AVSEEK_FLAG_BACKWARD`. This ensures that if no `AVPacket` has the exact timestamp requested (which is typical), then the seeking function will select the closest `AVPacket` with a timestamp *less* than the seek target. This means that the seek target will be contained somewhere inside of the `AVPacket`'s compressed audio data
2. When retrieving the first packet from the demuxer after a seek operation, compare the timestamp of the packet with the seek target. Calculate the number of samples to skip in the output if the packet timestamp is less than the seek target.
3. Encode the number of samples to skip in the output with FFmpeg's `AVPacketSideData` API. This instructs the decoder to skip the number of samples, so when `avcodec_receive_frame` is called, the uncompressed audio data output will be at the exact seek point that was requested.

I have successfully tested the new seeking method with the following file formats:
1. M4A/AAC
2. MP3 (including VBR)
3. FLAC
4. Ogg Vorbis
5. Opus
6. WAV