### PR TITLE
Fix Record Options Crash After Changing Theme

### DIFF
--- a/src/screens/UScreenOptionsThemes.pas
+++ b/src/screens/UScreenOptionsThemes.pas
@@ -74,6 +74,7 @@ uses
   ULog,
   UMain,
   UPathUtils,
+  URecord,
   USkins,
   UUnicodeUtils,
   SysUtils;
@@ -267,6 +268,7 @@ begin
     UGraphic.UnLoadScreens();
     UGraphic.LoadScreens(USDXVersionStr);
     Ini.Load;
+    AudioInputProcessor.UpdateInputDeviceConfig();
   end;
 end;
 


### PR DESCRIPTION
Steps to reproduce the crash:
1. Go to Options->Record
2. Set the 'Assigned Player' for the current device to 'None'
3. Go to Options->Themes
4. Change to a different theme
5. Go Options->Record

Stacktrace:
```
Exception class: EAccessViolation
Message: Access violation
  $0000000000542901  DRAW,  line 813 of screens/UScreenOptionsRecord.pas
  $000000000045FABA  DRAW,  line 379 of menu/UDisplay.pas
  $000000000047A432  MAINLOOP,  line 344 of base/UMain.pas
  $000000000047A1C6  MAIN,  line 269 of base/UMain.pas
  $00000000004074A7  main,  line 386 of ultrastardx.dpr
```

The crash occurs [here](https://github.com/UltraStar-Deluxe/USDX/blob/2603abcc3aa70b57ede2348761bf641449b3e307/src/screens/UScreenOptionsRecord.pas#L813) because `DeviceCfg.ChannelToPlayerMap` is nil.

The reason is that changing the theme triggers a reloading of the `config.ini` file. In `TIni.LoadInputDeviceCfg`, the channel to player map is set to length zero by default, unless defined in the `config.ini`. Later, `TAudioInputProcessor.UpdateInputDeviceConfig` sets its length to the max number of channels supported by the audio device, which is at least 1. This ensures that the array will not be nil.

In summary, initializing the device config used in the record options is a two step process:
1. `TIni.LoadInputDeviceCfg`: Read settings from `config.ini` into device config
2. `TAudioInputProcessor.UpdateInputDeviceConfig`: Fill in the device config with information from actual device

After changing the theme, the current code is only doing 1 above. So, now a call is added to `TAudioInputProcessor.UpdateInputDeviceConfig` which fully initializes the device config and fixes the crash.