### PR TITLE
when releasing, all zips except the portable need to be extracted

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,7 +17,8 @@
     If any of them fail, retry the job.
 6. Add `+dev` to the version in the first two files and swap the comments in `variables.nsh` again, commit, push.
     This is just to set the dev version again.
-7. Attach the artifacts to the release page and publish it.
+7. Attach the artifacts to the release page and publish it.\
+    You need to extract all the zips _except_ the portable: `for i in UltraStarDeluxe-*{linux,mac,installer}*; do unzip $i; rm $i; done`
 8. Create a PR in [the FlatHub repository](https://github.com/flathub/eu.usdx.UltraStarDeluxe) that updates the tag and commit values.
     See this PR for an example: https://github.com/flathub/eu.usdx.UltraStarDeluxe/pull/7/files
 9. Create a PR in [the github.io repository](https://github.com/UltraStar-Deluxe/ultrastar-deluxe.github.io)


### PR DESCRIPTION
if the artifact is not a zip, github will always zip it for you. but we don't want those pointless zips on the release pages, so document that they need to be extracted.
also add a copy-paste oneliner that will work most of the time

(I used to be able to just "Extract Here" but that gives like three popups nowadays. the oneliner is trivial but at the same time enough effort that I don't want to have to retype it every release)