### PR TITLE
Fix High Resolution Audio Support on Windows

### DIFF
--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -400,7 +400,10 @@ begin
 
   // now initialize the audio-format
   PackedSampleFormat := av_get_packed_sample_fmt(fCodecCtx^.sample_fmt);
-  if (PackedSampleFormat <> fCodecCtx^.sample_fmt) then
+  if ((PackedSampleFormat <> fCodecCtx^.sample_fmt)
+
+    // BASS expects the audio provided by the decoder to be in 16 bit signed integer or 32 bit float format
+    {$IFDEF UseBASSPlayback} or (not ((fCodecCtx^.sample_fmt = AV_SAMPLE_FMT_S16) or (fCodecCtx^.sample_fmt = AV_SAMPLE_FMT_FLT))){$ENDIF}) then
   begin
     // There is no point in leaving PackedSampleFormat as is.
     // av_audio_resample_init as used by TAudioConverter_FFmpeg will internally


### PR DESCRIPTION
As discussed in #968, the BASS playback stream expects the decoded audio stream to be in either 16 bit signed integer or 32 bit float format. Currently, the FFmpeg audio decoder has built-in resampling support, but it only does planar to packed conversions. It doesn't do any bit depth conversions.

This PR changes the behavior of the FFmpeg decoder in the Windows version so that it will only provide audio in 16 bit signed integer or 32 bit float format, which emulates the behavior of the former BASS audio decoder.

An alternative solution would be to change the behavior of `TBassPlaybackStream` so that it can accept audio in any format, like the Mac/Linux `TGenericPlaybackStream` can. However, that would require a significant rewrite of `TBassPlaybackStream`, which would increase the risk of introducing further regressions.

Fixes #968 