### PR TITLE
don't log ERROR: STOP the whole time in the editor

### DIFF
--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -5089,7 +5089,6 @@ begin
     // stop the music
     if (AudioPlayback.Position > PlayStopTime) then
     begin
-      Log.LogError('STOP');
       AudioPlayback.Stop;
       PlaySentence := false;
       PlayOne := false;


### PR DESCRIPTION
I don't need to see `ERROR: STOP` logged every single time a note (or sentence) ends when I'm working in the editor. I considered downgrading it to Debug but then it still doesn't really tell you much of value. Considering the all caps it reads like some kind of forgotten development comment.

(the git blame for this is misleading, bohning only changed the indentation but it was always there)