### PR TITLE
remove unused TScreenScore.FillPlayer

### DIFF
--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -181,7 +181,6 @@ type
 
       procedure MapPlayersToPosition;
 
-      procedure FillPlayer(Item, P: integer);
       procedure FillPlayerItems(PlayerNumber: integer);
 
       procedure UpdateAnimation;
@@ -1756,40 +1755,6 @@ begin
     if (ScoreType = sbtGolden) then
       TextGolden_ActualValue[PlayerNumber]   := ScoreReached;
   end;
-end;
-
-procedure TScreenScore.FillPlayer(Item, P: integer);
-var
-  S:    string;
-begin
-  Text[TextName[Item]].Text := Ini.Name[P];
-
-  S := IntToStr((Round(Player[P].Score) div 10) * 10);
-  while (Length(S)<4) do
-    S := '0' + S;
-  Text[TextNotesScore[Item]].Text := S;
-
-  //  while (Length(S)<5) do S := '0' + S;
-  //  Text[TextTotalScore[Item]].Text := S;
-
-  //fixed: line bonus and golden notes don't show up,
-  //       another bug: total score was shown without added golden-, linebonus
-  S := IntToStr(Player[P].ScoreTotalInt);
-  while (Length(S)<5) do
-    S := '0' + S;
-  Text[TextTotalScore[Item]].Text := S;
-
-  S := IntToStr(Player[P].ScoreLineInt);
-  while (Length(S)<4) do
-    S := '0' + S;
-  Text[TextLineBonusScore[Item]].Text := S;
-
-  S := IntToStr(Player[P].ScoreGoldenInt);
-  while (Length(S)<4) do
-    S := '0' + S;
-  Text[TextGoldenNotesScore[Item]].Text := S;
-  //end of fix
-
 end;
 
 //Procedure Change current played Preview

--- a/src/screens/UScreenTop5.pas
+++ b/src/screens/UScreenTop5.pas
@@ -284,51 +284,7 @@ begin
 end;
 
 function TScreenTop5.Draw: boolean;
-//var
-{
-  Min:     real;
-  Max:     real;
-  Factor:  real;
-  Factor2: real;
-
-  Item:    integer;
-  P:       integer;
-  C:       integer;
-}
 begin
-  // Singstar - let it be...... with 6 statics
-(*
-  if PlayersPlay = 6 then
-  begin
-    for Item := 4 to 6 do
-    begin
-      if ScreenAct = 1 then P := Item-4;
-      if ScreenAct = 2 then P := Item-1;
-
-      FillPlayer(Item, P);
-{
-      if ScreenAct = 1 then
-      begin
-        LoadColor(
-          Statics[StaticBoxLightest[Item]].Texture.ColR,
-          Statics[StaticBoxLightest[Item]].Texture.ColG,
-          Statics[StaticBoxLightest[Item]].Texture.ColB,
-          'P1Dark');
-      end;
-
-      if ScreenAct = 2 then
-      begin
-        LoadColor(
-          Statics[StaticBoxLightest[Item]].Texture.ColR,
-          Statics[StaticBoxLightest[Item]].Texture.ColG,
-          Statics[StaticBoxLightest[Item]].Texture.ColB,
-          'P4Dark');
-      end;
-}
-    end;
-  end;
-*)
-
   Result := inherited Draw;
 end;
 


### PR DESCRIPTION
Was making some local modifications when I noticed an unused function. Well, there was technically some commented-out place using it, and I think that's the first time I've seen three different ways of doing comments in that close proximity.

I did check that the screens still work in 2-screen mode. They're still as ugly as ever and some of the colors aren't quite right, but that's also happening on master.