### PR TITLE
change top scores default to Player

### DIFF
--- a/src/base/UIni.pas
+++ b/src/base/UIni.pas
@@ -1584,7 +1584,7 @@ begin
   SingScores := ReadArrayIndex(ISingScores, IniFile, 'Advanced', 'SingScores', IGNORE_INDEX, 'On');
 
   // TopScores
-  TopScores := ReadArrayIndex(ITopScores, IniFile, 'Advanced', 'TopScores', IGNORE_INDEX, 'All');
+  TopScores := ReadArrayIndex(ITopScores, IniFile, 'Advanced', 'TopScores', IGNORE_INDEX, 'Player');
 
   // SyncTo
   SyncTo := ReadArrayIndex(ISyncTo, IniFile, 'Advanced', 'SyncTo', Ord(stMusic));


### PR DESCRIPTION
This has come up in the discord more than once. There really is no point in listing out that AReallyGoodPlayer has not only the highest score of 7550, but also 7530, 7480, 7440 and 7410. At least not in new installations.

For new installations, it will now only show the 7550 from AReallyGoodPlayer, so that AnAveragePlayer 6880, AnotherAveragePlayer 6700, PlayedForTheFirstTime 5500 and ICantSing 2300 can also be shown.

See also #725. The fact that I couldn't even figure out what the option was for while looking at the code should tell you a lot.