### PR TITLE
Fix Crash on Corrupt Audio Files

### DIFF
--- a/src/media/UMediaCore_FFmpeg.pas
+++ b/src/media/UMediaCore_FFmpeg.pas
@@ -223,10 +223,10 @@ end;
 
 function TMediaCore_FFmpeg.GetErrorString(ErrorNum: integer): string;
 var
-  ErrorBuf: array[0..255] of cchar;
+  ErrorBuf: array[0..255] of AnsiChar;
 begin
   av_strerror(ErrorNum, @ErrorBuf[0], SizeOf(ErrorBuf));
-  Result := string(@ErrorBuf[0]);
+  Result := ErrorBuf;
 end;
 
 {


### PR DESCRIPTION
This PR fixes the FFmpeg error number to string conversion function. It uses an invalid method to convert between a C-style string and a Pascal string, which causes a crash when UDSX encounters an FFmpeg error and tries to output it to the `Error.log` file. This may occur if the audio file is corrupted in some way.

This has been a regression since #944. Before #944, this function still did not work properly, but it didn't cause USDX to crash. It just did nothing.