### PR TITLE
Fix FFmpeg Start Silence Functionality

### DIFF
--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -1048,20 +1048,14 @@ begin
   if (EOF) then
     Exit;
 
+  if (fAudioPaketSilence > 0) then
+  begin
+    Result := 0;
+    Exit;
+  end;
+
   while(true) do
   begin
-
-    // for titles with start_time > 0 we have to generate silence
-    // until we reach the pts of the first data packet.
-    if (fAudioPaketSilence > 0) then
-    begin
-      DataSize := Min(fAudioPaketSilence, AUDIO_BUFFER_SIZE);
-      FillChar(fAudioBuffer[0], DataSize, 0);
-      Dec(fAudioPaketSilence, DataSize);
-      fAudioStreamPos := fAudioStreamPos + DataSize / fFormatInfo.BytesPerSec;
-      Result := DataSize;
-      Exit;
-    end;
 
     // read packet data
     while (fAudioPaketSize > 0) do
@@ -1149,6 +1143,9 @@ begin
           SilenceDuration := PDouble(fPacketQueue.GetStatusInfo(Packet))^;
           fAudioPaketSilence := Round(SilenceDuration * fFormatInfo.SampleRate) * fFormatInfo.FrameSize;
           fPacketQueue.FreeStatusInfo(Packet);
+          av_packet_free(@Packet);
+          Result := 0;
+          Exit;
         end
         else
         begin
@@ -1263,6 +1260,18 @@ begin
       end;
 
       RemainByteCount := BufferSize - BufferPos;
+
+      // for titles with start_time > 0 we have to generate silence
+      // until we reach the pts of the first data packet.
+      if (fAudioPaketSilence > 0) then
+      begin
+        CopyByteCount := Min(fAudioPaketSilence, RemainByteCount);
+        FillChar(Buffer[BufferPos], CopyByteCount, 0);
+        Dec(fAudioPaketSilence, CopyByteCount);
+        Inc(BufferPos, CopyByteCount);
+        fAudioStreamPos := fAudioStreamPos + CopyByteCount / fFormatInfo.BytesPerSec;
+        continue;
+      end;
 
       if (fSwrContext <> nil) then
       begin

--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -79,11 +79,6 @@ uses
 const
   MAX_AUDIOQ_SIZE = (5 * 16 * 1024);
 
-const
-  // TODO: The factor 3/2 might not be necessary as we do not need extra
-  // space for synchronizing as in the tutorial.
-  AUDIO_BUFFER_SIZE = (192000 * 3) div 2;
-
 type
   TFFmpegDecodeStream = class(TAudioDecodeStream)
     private
@@ -1060,8 +1055,6 @@ begin
     // read packet data
     while (fAudioPaketSize > 0) do
     begin
-      DataSize := AUDIO_BUFFER_SIZE;
-
       got_frame_ptr := avcodec_receive_frame(fCodecCtx, fAudioBufferFrame);
       if (got_frame_ptr = AVERROR(EAGAIN)) then
         PaketDecodedSize := fAudioPaketSize


### PR DESCRIPTION
The FFmpeg audio decoder has a function where it fills an audio stream with silence before the stream start time, if the first timestamp is greater than 0. An issue has been reported that this is causing crashes on such audio files since #944. The problematic statement is [here](https://github.com/UltraStar-Deluxe/USDX/blob/026cebb2996dbc6173873defdd60de9ffa602e01/src/media/UAudioDecoder_FFmpeg.pas#L1059). At that point in execution, `fAudioBuffer` is nil, which causes the crash.

#944 fixed the "StatusInfo" functionality of the packet queue, which had not been functional for many years (since FFmpeg 1.x was used). `fAudioBuffer` used to be an actual audio buffer, but since the codebase switched to use FFmpeg's `AVFrame` API, it's now implemented as a pointer to the `AVFrame` data buffer. So I believe this is a latent bug that has existed for a long time, but it never "activated" until #944 fixed the StatusInfo functionality.

My proposed solution is to move the silence filling code up a level, from `DecodeFrame` to `ReadData`. Instead of copying the silence into `fAudioBuffer`, it now copies silence directly into the `ReadData` buffer, which is guaranteed to exist.