### PR TITLE
newer SDLs appear to need this to get the windowsize

### DIFF
--- a/src/base/UGraphic.pas
+++ b/src/base/UGraphic.pas
@@ -597,6 +597,7 @@ var
   W, H:   integer;
   X, Y:   integer; // offset for re-positioning
   Depth:  Integer;
+  ActualW, ActualH: integer;
   Borderless, Fullscreen: boolean;
   Split: boolean;
   Disp: TSDL_DisplayMode;
@@ -704,8 +705,9 @@ NoDoubledResolution:
         Ini.SetResolution(Disp.w, Disp.h, false, true);
       end;
 
-      X := Disp.w - Screen.w;
-      Y := Disp.h - Screen.h;
+      SDL_GetWindowSize(Screen, @ActualW, @ActualH);
+      X := Disp.w - ActualW;
+      Y := Disp.h - ActualH;
     end;
 
     // if screen is out of the visisble desktop area, move it back
@@ -750,8 +752,8 @@ NoDoubledResolution:
   // define virtual (Render) and real (Screen) screen size
   RenderW := 800;
   RenderH := 600;
-  ScreenW := Screen.w;
-  ScreenH := Screen.h;
+  ScreenW := ActualW;
+  ScreenH := ActualH;
   // Ausganswerte für die State-Machine setzen
   SDL_GL_SetSwapInterval(1); // VSYNC (currently Windows only)
 


### PR DESCRIPTION
without this patch my display looks like:

https://github.com/user-attachments/assets/57673b0d-023a-4b6b-9542-51be948a8af0

and it never updates. it might become completely black at some point (starting a song, usually) after which it stays black. the game is fully functional behind whatever it is doing, but navigating it completely blind is... challenging.

I've been using this patch for my local builds for a very long time already, but somehow I never needed it on a fresh git master until when I recently updated some things on my computer.

* I tested Windowed, Borderless and Fullscreen and they all work on _my_ machine
* I'll grab a CI artifact and test if Windows still works
* @DeinAlptraum can you test if this makes it also still work on _your_ machine?