### PR TITLE
refactor NotesVisible to be an array of booleans

### DIFF
--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -604,7 +604,7 @@ var
 
   GoldenStarPos: real;
 begin
-  if (ScreenSing.settings.NotesVisible and (1 shl Track) <> 0) then
+  if (ScreenSing.settings.NotesVisible[Track]) then
   begin
     // the textures start counting at 1, but everything else just starts at 0
     PlayerNumber := PlayerIndex + 1;
@@ -864,7 +864,7 @@ var
   TempR:          real;
   W, H:           real;
 begin
-  if (ScreenSing.settings.NotesVisible and (1 shl PlayerIndex) <> 0) then
+  if (ScreenSing.settings.NotesVisible[PlayerIndex]) then
   begin
     //glColor4f(1, 1, 1, sqrt((1+sin( AudioPlayback.Position * 3))/4)/ 2 + 0.5 );
     glColor4f(1, 1, 1, sqrt((1 + sin(AudioPlayback.Position * 3)))/2 + 0.05);
@@ -1237,20 +1237,20 @@ begin
   // draw note-lines
 
   // to-do : needs fix when party mode works w/ 2 screens
-  if (PlayersPlay = 1) and (Ini.NoteLines = 1) and (ScreenSing.settings.NotesVisible and (1) <> 0) then
+  if (PlayersPlay = 1) and (Ini.NoteLines = 1) and (ScreenSing.settings.NotesVisible[0]) then
     SingDrawNoteLines(NR.Left + 10*ScreenX, Skin_P2_NotesB - 105, NR.Right + 10*ScreenX, 15);
 
   if (PlayersPlay = 2) and (Ini.NoteLines = 1) then
   begin
-    if (ScreenSing.settings.NotesVisible and (1 shl 0) <> 0) then
+    if (ScreenSing.settings.NotesVisible[0]) then
       SingDrawNoteLines(Nr.Left + 10*ScreenX, Skin_P1_NotesB - 105, Nr.Right + 10*ScreenX, 15);
-    if (ScreenSing.settings.NotesVisible and (1 shl 1) <> 0) then
+    if (ScreenSing.settings.NotesVisible[1]) then
       SingDrawNoteLines(Nr.Left + 10*ScreenX, Skin_P2_NotesB - 105, Nr.Right + 10*ScreenX, 15);
   end;
 
   if (PlayersPlay = 4) and (Ini.NoteLines = 1) then
   begin
-    if (ScreenSing.settings.NotesVisible and (1 shl 0) <> 0) then
+    if (ScreenSing.settings.NotesVisible[0]) then
     begin
       if (Ini.Screens = 1) then
         SingDrawNoteLines(Nr.Left + 10*ScreenX, Skin_P1_NotesB - 105, Nr.Right + 10*ScreenX, 15)
@@ -1261,7 +1261,7 @@ begin
       end;
     end;
 
-    if (ScreenSing.settings.NotesVisible and (1 shl 1) <> 0) then
+    if (ScreenSing.settings.NotesVisible[1]) then
     begin
       if (Ini.Screens = 1) then
         SingDrawNoteLines(Nr.Left + 10*ScreenX, Skin_P2_NotesB - 105, Nr.Right + 10*ScreenX, 15)
@@ -1274,16 +1274,16 @@ begin
   end;
 
   if (PlayersPlay = 3) and (Ini.NoteLines = 1) then begin
-    if (ScreenSing.settings.NotesVisible and (1 shl 0) <> 0) then
+    if (ScreenSing.settings.NotesVisible[0]) then
       SingDrawNoteLines(Nr.Left + 10*ScreenX, 120, Nr.Right + 10*ScreenX, 12);
-    if (ScreenSing.settings.NotesVisible and (1 shl 1) <> 0) then
+    if (ScreenSing.settings.NotesVisible[1]) then
       SingDrawNoteLines(Nr.Left + 10*ScreenX, 245, Nr.Right + 10*ScreenX, 12);
-    if (ScreenSing.settings.NotesVisible and (1 shl 2) <> 0) then
+    if (ScreenSing.settings.NotesVisible[2]) then
       SingDrawNoteLines(Nr.Left + 10*ScreenX, 370, Nr.Right + 10*ScreenX, 12);
   end;
 
   if (PlayersPlay = 6) and (Ini.NoteLines = 1) then begin
-    if (ScreenSing.settings.NotesVisible and (1 shl 0) <> 0) then
+    if (ScreenSing.settings.NotesVisible[0]) then
     begin
       if (Ini.Screens = 1) then
         SingDrawNoteLines(Nr.Left + 10*ScreenX, 120, Nr.Right + 10*ScreenX, 12)
@@ -1294,7 +1294,7 @@ begin
       end;
     end;
 
-    if (ScreenSing.settings.NotesVisible and (1 shl 1) <> 0) then
+    if (ScreenSing.settings.NotesVisible[1]) then
     begin
       if (Ini.Screens = 1) then
         SingDrawNoteLines(Nr.Left + 10*ScreenX, 245, Nr.Right + 10*ScreenX, 12)
@@ -1305,7 +1305,7 @@ begin
       end;
     end;
 
-    if (ScreenSing.settings.NotesVisible and (1 shl 2) <> 0) then
+    if (ScreenSing.settings.NotesVisible[2]) then
     begin
       if (Ini.Screens = 1) then
         SingDrawNoteLines(Nr.Left + 10*ScreenX, 370, Nr.Right + 10*ScreenX, 12)

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -124,7 +124,7 @@ type
 
       OscilloscopeVisible: Boolean; //< shows or hides oscilloscope
       LyricsVisible:       Boolean; //< shows or hides lyrics
-      NotesVisible:        Integer; //< if bit[playernum] is set the notes for the specified player are visible. By default all players notes are visible
+      NotesVisible:        array [0..IMaxPlayerCount-1] of Boolean; //< if NotesVisible[playerIndex] is set the notes for the specified player are visible. By default all players notes are visible
       ScoresVisible:       Boolean; //< shows or hides scores
       AvatarsVisible:      Boolean; //< shows or hides avatars
       TimeBarVisible:      Boolean; //< shows or hides timebar
@@ -161,6 +161,7 @@ type
     FadeOut: boolean;
 
     procedure ClearSettings;
+    procedure AllNotesVisible(visible: boolean);
     procedure ApplySettings; //< applies changes of settings record
     procedure EndSong;
 
@@ -445,7 +446,13 @@ begin
           if (ScreenSong.Mode <> smNormal) and (ScreenSong.Mode <> smMedley) then
             Exit;
 
-          ScreenSing.Settings.NotesVisible := ifthen(ScreenSing.Settings.NotesVisible = 0, High(Integer), 0);
+          if (ScreenSing.Settings.NotesVisible[0]) then begin
+            // if first player is currently visible, set all players to not visible
+            AllNotesVisible(false);
+          end else begin
+            // else set all players to visible
+            AllNotesVisible(true);
+          end;
           Exit;
         end;
       end;
@@ -505,14 +512,20 @@ begin
           if (ScreenSong.Mode <> smNormal) and (ScreenSong.Mode <> smMedley) then
             Exit;
 
-          ScreenSing.Settings.NotesVisible        := ifthen(ScreenSing.Settings.NotesVisible = 0, High(Integer), 0);
+          if (ScreenSing.Settings.NotesVisible[0]) then begin
+            // if first player is currently visible, set all players to not visible
+            AllNotesVisible(false);
+          end else begin
+            // else set all players to visible
+            AllNotesVisible(true);
+          end;
           // synchronize show/hide of all other elements with NotesVisible
-          ScreenSing.Settings.LyricsVisible       := (ScreenSing.Settings.NotesVisible <> 0);
-          ScreenSing.Settings.ScoresVisible       := (ScreenSing.Settings.NotesVisible <> 0);
-          ScreenSing.Settings.AvatarsVisible      := (ScreenSing.Settings.NotesVisible <> 0);
-          ScreenSing.Settings.TimeBarVisible      := (ScreenSing.Settings.NotesVisible <> 0);
-          ScreenSing.Settings.InputVisible        := (ScreenSing.Settings.NotesVisible <> 0);
-          ScreenSing.Settings.OscilloscopeVisible := (ScreenSing.Settings.NotesVisible <> 0);
+          ScreenSing.Settings.LyricsVisible       := (ScreenSing.Settings.NotesVisible[0]);
+          ScreenSing.Settings.ScoresVisible       := (ScreenSing.Settings.NotesVisible[0]);
+          ScreenSing.Settings.AvatarsVisible      := (ScreenSing.Settings.NotesVisible[0]);
+          ScreenSing.Settings.TimeBarVisible      := (ScreenSing.Settings.NotesVisible[0]);
+          ScreenSing.Settings.InputVisible        := (ScreenSing.Settings.NotesVisible[0]);
+          ScreenSing.Settings.OscilloscopeVisible := (ScreenSing.Settings.NotesVisible[0]);
           Exit;
         end;
       end;
@@ -1265,13 +1278,22 @@ begin
   Settings.Finish := False;
   Settings.OscilloscopeVisible := Boolean(Ini.Oscilloscope);
   Settings.LyricsVisible := True;
-  Settings.NotesVisible := high(Integer);
+  AllNotesVisible(true);
   Settings.ScoresVisible := True;
   Settings.AvatarsVisible := True;
   Settings.TimeBarVisible := True;
   Settings.InputVisible := True;
   Settings.PlayerEnabled := high(Integer);
   Settings.SoundEnabled := True;
+end;
+
+procedure TScreenSingController.AllNotesVisible(visible: boolean);
+var
+  I: integer;
+begin
+  for I := 0 to High(ScreenSing.Settings.NotesVisible) do begin
+    ScreenSing.Settings.NotesVisible[I] := visible;
+  end;
 end;
 
 { applies changes of settings record }

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -949,7 +949,7 @@ begin
   end;
 
   // draw notes lines
-  if (ScreenSing.Settings.NotesVisible <> 0) or (ScreenSing.Settings.InputVisible) then
+  if (ScreenSing.Settings.InputVisible) then
     SingDrawLines;
 
   // draw static menu (FG)


### PR DESCRIPTION
Why: I was trying to refactor SingDrawLines and all the bitshifting stuff does not make this very readable. The performance impact should be negligible in the grand scheme of things.

It should all be 1:1 with the exception of UScreenSingView, part of that `if` statement just didn't make much sense.

I tested some modes with this and everything _appears_ to still be working, but it's probably a good idea if someone that uses party mode extensively tests+reviews this, because that's where the changes most prone to errors are.