### PR TITLE
Fix compiling on Windows.

### DIFF
--- a/src/lib/bass/delphi/bass.pas
+++ b/src/lib/bass/delphi/bass.pas
@@ -15,6 +15,10 @@ unit BASS;
 
 interface
 
+{$IFDEF FPC}
+  {$MODE Delphi}
+{$ENDIF}
+
 {$IFDEF MSWINDOWS}
 uses
   Windows;


### PR DESCRIPTION
Compatibility flag for Delphi got removed during
the update to BASS 2.4.17, which caused compilation to fail on Windows when using MSYS2 and FPC.

This commit fixes that, so one can again build the game binary as instructed in the compilation guide.