### PR TITLE
Refactor singdrawlines

### DIFF
--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -1109,6 +1109,7 @@ begin
         glTexCoord2f(1, 1); glVertex2f(Bounds.Right, Bounds.Bottom);
         glTexCoord2f(1, 0); glVertex2f(Bounds.Right, Bounds.Top);
       glEnd;
+      glDisable(GL_TEXTURE_2D);
       glDisable(GL_BLEND);
     end;
   end;

--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -1249,6 +1249,15 @@ begin
       SingDrawNoteLines(Nr.Left + 10*ScreenX, Skin_P2_NotesB - 105, Nr.Right + 10*ScreenX, 15);
   end;
 
+  if (PlayersPlay = 3) and (Ini.NoteLines = 1) then begin
+    if (ScreenSing.settings.NotesVisible[0]) then
+      SingDrawNoteLines(Nr.Left + 10*ScreenX, 120, Nr.Right + 10*ScreenX, 12);
+    if (ScreenSing.settings.NotesVisible[1]) then
+      SingDrawNoteLines(Nr.Left + 10*ScreenX, 245, Nr.Right + 10*ScreenX, 12);
+    if (ScreenSing.settings.NotesVisible[2]) then
+      SingDrawNoteLines(Nr.Left + 10*ScreenX, 370, Nr.Right + 10*ScreenX, 12);
+  end;
+
   if (PlayersPlay = 4) and (Ini.NoteLines = 1) then
   begin
     if (ScreenSing.settings.NotesVisible[0]) then
@@ -1272,15 +1281,6 @@ begin
         SingDrawNoteLines(Nr.Right/2 - 20 + 10*ScreenX + Nr.Left + 10*ScreenX, Skin_P2_NotesB - 105, Nr.Right + 10*ScreenX, 15)
       end;
     end;
-  end;
-
-  if (PlayersPlay = 3) and (Ini.NoteLines = 1) then begin
-    if (ScreenSing.settings.NotesVisible[0]) then
-      SingDrawNoteLines(Nr.Left + 10*ScreenX, 120, Nr.Right + 10*ScreenX, 12);
-    if (ScreenSing.settings.NotesVisible[1]) then
-      SingDrawNoteLines(Nr.Left + 10*ScreenX, 245, Nr.Right + 10*ScreenX, 12);
-    if (ScreenSing.settings.NotesVisible[2]) then
-      SingDrawNoteLines(Nr.Left + 10*ScreenX, 370, Nr.Right + 10*ScreenX, 12);
   end;
 
   if (PlayersPlay = 6) and (Ini.NoteLines = 1) then begin

--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -1332,6 +1332,7 @@ const
   LineSpacingOneRow = 15;
   LineSpacingTwoRows = 15;
   LineSpacingThreeRows = 12;
+  // TODO: it looks like all these TopXRowsY constants are actually referring to the bottom. But all the functions they call have historically called it Top.
   TopOneRow1 = Skin_P2_NotesB;
   TopTwoRows1 = Skin_P1_NotesB;
   TopTwoRows2 = Skin_P2_NotesB;

--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -638,7 +638,7 @@ begin
               glColor4f(1, 1, 1, 1);        // We set alpha to 1, cause we can control the transparency through the png itself
 
             // left part
-            Rec.Left  := (StartBeat - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left + 0.5 + 10*ScreenX;
+            Rec.Left  := (StartBeat - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left + 0.5;
             Rec.Right := Rec.Left + NotesW[PlayerIndex];
             Rec.Top := Top - (Tone-BaseNote)*LineSpacing/2 - NotesH[PlayerIndex];
             Rec.Bottom := Rec.Top + 2 * NotesH[PlayerIndex];
@@ -663,7 +663,7 @@ begin
 
             // middle part
             Rec.Left := Rec.Right;
-            Rec.Right := (StartBeat + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left - NotesW[PlayerIndex] - 0.5 + 10*ScreenX;
+            Rec.Right := (StartBeat + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left - NotesW[PlayerIndex] - 0.5;
 
             // the left note is more right than the right note itself, sounds weird - so we fix that xD
             if Rec.Right <= Rec.Left then
@@ -748,7 +748,7 @@ begin
         with Player[PlayerIndex].Note[N] do
         begin
           // Left part of note
-          Rec.Left  := Left + (Start - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + 0.5 + 10*ScreenX;
+          Rec.Left  := Left + (Start - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + 0.5;
           Rec.Right := Rec.Left + NotesW[PlayerIndex];
 
           // Draw it in half size, if not hit
@@ -783,7 +783,7 @@ begin
 
           // Middle part of the note
           Rec.Left  := Rec.Right;
-          Rec.Right := Left + (Start + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR - NotesW[PlayerIndex] - 0.5  + 10*ScreenX;
+          Rec.Right := Left + (Start + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR - NotesW[PlayerIndex] - 0.5;
 
           // new
           if (Start + Duration - 1 = LyricsState.CurrentBeatD) then
@@ -889,15 +889,15 @@ begin
             H := NotesH[PlayerIndex] * 1.5 + 3.5;
 
             {
-            X2 := (Start-Tracks[Track].Lines[Tracks[Track].Current].Notes[0].Start) * TempR + Left + 0.5 + 10*ScreenX + 4;
+            X2 := (Start-Tracks[Track].Lines[Tracks[Track].Current].Notes[0].Start) * TempR + Left + 0.5 + 4;
             X1 := X2-W;
 
-            X3 := (Start+Length-Tracks[Track].Lines[Tracks[Track].Current].Notes[0].Start) * TempR + Left - 0.5 + 10*ScreenX - 4;
+            X3 := (Start+Length-Tracks[Track].Lines[Tracks[Track].Current].Notes[0].Start) * TempR + Left - 0.5 - 4;
             X4 := X3+W;
             }
 
             // left
-            Rec.Right := (StartBeat - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left + 0.5 + 10*ScreenX + 4;
+            Rec.Right := (StartBeat - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left + 0.5 + 4;
             Rec.Left  := Rec.Right - W;
             Rec.Top := Top - (Tone-BaseNote)*LineSpacing/2 - H;
             Rec.Bottom := Rec.Top + 2 * H;
@@ -919,7 +919,7 @@ begin
 
             // middle part
             Rec.Left  := Rec.Right;
-            Rec.Right := (StartBeat + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left - 0.5 + 10*ScreenX - 4;
+            Rec.Right := (StartBeat + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left - 0.5 - 4;
 
             // the left note is more right than the right note itself, sounds weird - so we fix that xD
             if Rec.Right <= Rec.Left then
@@ -1239,23 +1239,23 @@ begin
 
   // to-do : needs fix when party mode works w/ 2 screens
   if (PlayersPlay = 1) and (Ini.NoteLines = 1) and (ScreenSing.settings.NotesVisible[0]) then
-    SingDrawNoteLines(NR.Left + 10*ScreenX, Skin_P2_NotesB - 105, NR.Right + 10*ScreenX, 15);
+    SingDrawNoteLines(NR.Left, Skin_P2_NotesB - 105, NR.Right, 15);
 
   if (PlayersPlay = 2) and (Ini.NoteLines = 1) then
   begin
     if (ScreenSing.settings.NotesVisible[0]) then
-      SingDrawNoteLines(Nr.Left + 10*ScreenX, Skin_P1_NotesB - 105, Nr.Right + 10*ScreenX, 15);
+      SingDrawNoteLines(Nr.Left, Skin_P1_NotesB - 105, Nr.Right, 15);
     if (ScreenSing.settings.NotesVisible[1]) then
-      SingDrawNoteLines(Nr.Left + 10*ScreenX, Skin_P2_NotesB - 105, Nr.Right + 10*ScreenX, 15);
+      SingDrawNoteLines(Nr.Left, Skin_P2_NotesB - 105, Nr.Right, 15);
   end;
 
   if (PlayersPlay = 3) and (Ini.NoteLines = 1) then begin
     if (ScreenSing.settings.NotesVisible[0]) then
-      SingDrawNoteLines(Nr.Left + 10*ScreenX, 120, Nr.Right + 10*ScreenX, 12);
+      SingDrawNoteLines(Nr.Left, 120, Nr.Right, 12);
     if (ScreenSing.settings.NotesVisible[1]) then
-      SingDrawNoteLines(Nr.Left + 10*ScreenX, 245, Nr.Right + 10*ScreenX, 12);
+      SingDrawNoteLines(Nr.Left, 245, Nr.Right, 12);
     if (ScreenSing.settings.NotesVisible[2]) then
-      SingDrawNoteLines(Nr.Left + 10*ScreenX, 370, Nr.Right + 10*ScreenX, 12);
+      SingDrawNoteLines(Nr.Left, 370, Nr.Right, 12);
   end;
 
   if (PlayersPlay = 4) and (Ini.NoteLines = 1) then
@@ -1263,22 +1263,22 @@ begin
     if (ScreenSing.settings.NotesVisible[0]) then
     begin
       if (Ini.Screens = 1) then
-        SingDrawNoteLines(Nr.Left + 10*ScreenX, Skin_P1_NotesB - 105, Nr.Right + 10*ScreenX, 15)
+        SingDrawNoteLines(Nr.Left, Skin_P1_NotesB - 105, Nr.Right, 15)
       else
       begin
-        SingDrawNoteLines(Nr.Left + 10*ScreenX, Skin_P1_NotesB - 105, Nr.Right/2 - 5 + 10*ScreenX, 15);
-        SingDrawNoteLines(Nr.Right/2 - 20 + 10*ScreenX + Nr.Left + 10*ScreenX, Skin_P1_NotesB - 105, Nr.Right + 10*ScreenX, 15)
+        SingDrawNoteLines(Nr.Left, Skin_P1_NotesB - 105, Nr.Right/2 - 5, 15);
+        SingDrawNoteLines(Nr.Right/2 - 20 + Nr.Left, Skin_P1_NotesB - 105, Nr.Right, 15)
       end;
     end;
 
     if (ScreenSing.settings.NotesVisible[1]) then
     begin
       if (Ini.Screens = 1) then
-        SingDrawNoteLines(Nr.Left + 10*ScreenX, Skin_P2_NotesB - 105, Nr.Right + 10*ScreenX, 15)
+        SingDrawNoteLines(Nr.Left, Skin_P2_NotesB - 105, Nr.Right, 15)
       else
       begin
-        SingDrawNoteLines(Nr.Left + 10*ScreenX, Skin_P2_NotesB - 105, Nr.Right/2 - 5 + 10*ScreenX, 15);
-        SingDrawNoteLines(Nr.Right/2 - 20 + 10*ScreenX + Nr.Left + 10*ScreenX, Skin_P2_NotesB - 105, Nr.Right + 10*ScreenX, 15)
+        SingDrawNoteLines(Nr.Left, Skin_P2_NotesB - 105, Nr.Right/2 - 5, 15);
+        SingDrawNoteLines(Nr.Right/2 - 20 + Nr.Left, Skin_P2_NotesB - 105, Nr.Right, 15)
       end;
     end;
   end;
@@ -1287,33 +1287,33 @@ begin
     if (ScreenSing.settings.NotesVisible[0]) then
     begin
       if (Ini.Screens = 1) then
-        SingDrawNoteLines(Nr.Left + 10*ScreenX, 120, Nr.Right + 10*ScreenX, 12)
+        SingDrawNoteLines(Nr.Left, 120, Nr.Right, 12)
       else
       begin
-        SingDrawNoteLines(Nr.Left + 10*ScreenX, 120, Nr.Right/2 - 5 + 10*ScreenX, 12);
-        SingDrawNoteLines(Nr.Right/2 - 20 + 10*ScreenX + Nr.Left + 10*ScreenX, 120, Nr.Right + 10*ScreenX, 12);
+        SingDrawNoteLines(Nr.Left, 120, Nr.Right/2 - 5, 12);
+        SingDrawNoteLines(Nr.Right/2 - 20 + Nr.Left, 120, Nr.Right, 12);
       end;
     end;
 
     if (ScreenSing.settings.NotesVisible[1]) then
     begin
       if (Ini.Screens = 1) then
-        SingDrawNoteLines(Nr.Left + 10*ScreenX, 245, Nr.Right + 10*ScreenX, 12)
+        SingDrawNoteLines(Nr.Left, 245, Nr.Right, 12)
       else
       begin
-        SingDrawNoteLines(Nr.Left + 10*ScreenX, 245, Nr.Right/2 - 5 + 10*ScreenX, 12);
-        SingDrawNoteLines(Nr.Right/2 - 20 + 10*ScreenX + Nr.Left + 10*ScreenX, 245, Nr.Right + 10*ScreenX, 12);
+        SingDrawNoteLines(Nr.Left, 245, Nr.Right/2 - 5, 12);
+        SingDrawNoteLines(Nr.Right/2 - 20 + Nr.Left, 245, Nr.Right, 12);
       end;
     end;
 
     if (ScreenSing.settings.NotesVisible[2]) then
     begin
       if (Ini.Screens = 1) then
-        SingDrawNoteLines(Nr.Left + 10*ScreenX, 370, Nr.Right + 10*ScreenX, 12)
+        SingDrawNoteLines(Nr.Left, 370, Nr.Right, 12)
       else
       begin
-        SingDrawNoteLines(Nr.Left + 10*ScreenX, 370, Nr.Right/2 - 5 + 10*ScreenX, 12);
-        SingDrawNoteLines(Nr.Right/2 - 20 + 10*ScreenX + Nr.Left + 10*ScreenX, 370, Nr.Right + 10*ScreenX, 12);
+        SingDrawNoteLines(Nr.Left, 370, Nr.Right/2 - 5, 12);
+        SingDrawNoteLines(Nr.Right/2 - 20 + Nr.Left, 370, Nr.Right, 12);
       end;
     end;
   end;
@@ -1662,7 +1662,7 @@ begin
         end; // case
 
         // left part
-        Rec.Left  := (StartBeat - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + X + 0.5 + 10*ScreenX;
+        Rec.Left  := (StartBeat - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + X + 0.5;
         Rec.Right := Rec.Left + NotesW[0];
         Rec.Top := YBaseNote - (Tone-BaseNote)*Space/2 - NotesH[0];
         Rec.Bottom := Rec.Top + 2 * NotesH[0];
@@ -1690,7 +1690,7 @@ begin
 
         // middle part
         Rec.Left  := Rec.Right;
-        Rec.Right := (StartBeat + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + X - NotesW[0] - 0.5 + 10*ScreenX;
+        Rec.Right := (StartBeat + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + X - NotesW[0] - 0.5;
 
         If (NoteType = ntRap) or (NoteType = ntRapGolden) then
         begin

--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -1436,6 +1436,9 @@ begin
 
   end;
 
+  // draw notes lines
+  if (ScreenSing.Settings.InputVisible) then
+    SingDrawLines;
   // Draw the Notes
   if PlayersPlay = 1 then
   begin

--- a/src/base/UEditorLyrics.pas
+++ b/src/base/UEditorLyrics.pas
@@ -266,7 +266,7 @@ begin
   begin
     SetFontFamily(Word[WordIndex].FontFamily);
     SetFontStyle(Word[WordIndex].FontStyle);
-    SetFontPos(Word[WordIndex].X + 10*ScreenX, Word[WordIndex].Y);
+    SetFontPos(Word[WordIndex].X, Word[WordIndex].Y);
     SetFontSize(Word[WordIndex].Size);
     SetFontItalic(Word[WordIndex].Italic);
     glColor3f(Word[WordIndex].ColR, Word[WordIndex].ColG, Word[WordIndex].ColB);

--- a/src/base/UGraphic.pas
+++ b/src/base/UGraphic.pas
@@ -131,7 +131,6 @@ var
   ScreenH:    integer;
   Screens:    integer;
   ScreenAct:  integer;
-  ScreenX:    integer;
   LastX, LastY:    integer;
   LastW, LastH:    integer;
   HasValidPosition:     boolean;

--- a/src/menu/UDisplay.pas
+++ b/src/menu/UDisplay.pas
@@ -265,12 +265,6 @@ begin
   for S := 1 to Screens do
   begin
     ScreenAct := S;
-
-    //if Screens = 1 then ScreenX := 0;
-    //if (Screens = 2) and (S = 1) then ScreenX := -1;
-    //if (Screens = 2) and (S = 2) then ScreenX := 1;
-    ScreenX := 0;
-
     glViewPort((S-1) * ScreenW div Screens, 0, ScreenW div Screens, ScreenH);
 
     // popup check was successful... move on

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -4005,7 +4005,7 @@ begin
   BarWidth := 16;
   BarHeight := 16;
   HalfToneHeight := 7.5;
-  Rec.Right := 40 + 0.5 + 10 * ScreenX + Count;
+  Rec.Right := 40 + 0.5 + Count;
   Rec.Left  := Rec.Right - BarWidth;
 
   scale := Round((CurrentTone - Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote].Tone) / 12);
@@ -4233,8 +4233,8 @@ begin
           Rec.Top := Y - (Tone-BaseNote)*Space/2 - NotesH[0];
           Rec.Bottom := Rec.Top + 2 * NotesH[0];
           // middle part
-          Rec.Left := (StartBeat - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + X + 0.5 + 10*ScreenX + NotesW[0];
-          Rec.Right := (StartBeat + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + X - NotesW[0] - 0.5 + 10*ScreenX;
+          Rec.Left := (StartBeat - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + X + 0.5 + NotesW[0];
+          Rec.Right := (StartBeat + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + X - NotesW[0] - 0.5;
           SetFontPos(Rec.Left, Rec.Top);
           glPrint(Text);
           // add info if current note is medley start
@@ -4307,9 +4307,9 @@ begin
   TempR := 720 / (Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].EndBeat - Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat);
   for NoteIndex := 0 to Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].HighNote do
   begin
-    Button[TransparentNoteButtonId[NoteIndex]].SetX(Theme.EditSub.NotesBackground.X + NotesSkipX + (Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[NoteIndex].StartBeat - Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat) * TempR + 0.5 + 10*ScreenX);
+    Button[TransparentNoteButtonId[NoteIndex]].SetX(Theme.EditSub.NotesBackground.X + NotesSkipX + (Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[NoteIndex].StartBeat - Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat) * TempR + 0.5);
     Button[TransparentNoteButtonId[NoteIndex]].SetY(Theme.EditSub.NotesBackground.Y + 7 * LineSpacing - (Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[NoteIndex].Tone - Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].BaseNote) * LineSpacing / 2 - NotesH[0]);
-    Button[TransparentNoteButtonId[NoteIndex]].SetW((Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[NoteIndex].Duration) * TempR - 0.5 + 10*(ScreenX));
+    Button[TransparentNoteButtonId[NoteIndex]].SetW((Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[NoteIndex].Duration) * TempR - 0.5);
     Button[TransparentNoteButtonId[NoteIndex]].SetH(2 * NotesH[0]);
   end;
 end;

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -948,10 +948,6 @@ begin
     ScreenSing.fCurrentVideo.Draw;
   end;
 
-  // draw notes lines
-  if (ScreenSing.Settings.InputVisible) then
-    SingDrawLines;
-
   // draw static menu (FG)
   ScreenSing.DrawFG;
 


### PR DESCRIPTION
Originally I wanted to use this PR to integrate SingDrawLines more into SingDraw and just call SingDrawNoteLines directly, since they're operating on the same "rectangles". Turns out it's not really a rectangle but only the left and right, and in _some_ cases, `Top` actually means `Bottom`.

In a future PR, I will probably just make a completely new function from scratch called `SingDrawNoteArea` (or something to that extent), which in turns calls another new function that draws everything note-area related that aren't golden notes for a specific player in a specific place. Would mean a few more `if` statements checking each frame whether to draw something or not, but be a lot better maintainable.
I will possibly also explore a `PlayersPerScreen` (or something) variable so everything becomes dependent on that + what screen it's currently drawing (and not `PlayersPlay`), which _should in theory_ get rid of a lot of the if/else branches.

This current PR should not affect anything at all, it just refactors existing things:
* add a missing `glDisable` somewhere, otherwise we can't move the call to SingDrawLines to just before it starts drawing all the other notearea stuff
* reorder things in increasing number of PlayersPlay
* complete delete everything about `ScreenX` since it has been 0 [since 2007](https://sourceforge.net/p/ultrastardx/svn/1/tree/trunk/Game/Code/Menu/UDisplay.pas) (even the initial svn commit has the few lines that could change it commented out)
* add a comment because Top = Bottom is really not intuitive at all and I don't want to have to figure that out again next time