### PR TITLE
support midi keyboards in the usdx editor

### DIFF
--- a/src/lib/midi/MidiIn.pas
+++ b/src/lib/midi/MidiIn.pas
@@ -229,10 +229,6 @@ procedure Register;
 {====================================================================}
 implementation
 
-uses
-  Controls,
-  Graphics;
-
 (* Not used in Delphi 3
 { This is the callback procedure in the external DLL.
   It's used when midiInOpen is called by the Open method.

--- a/src/media/UMidiInput.pas
+++ b/src/media/UMidiInput.pas
@@ -1,0 +1,122 @@
+{* UltraStar Deluxe - Karaoke Game
+ *
+ * UltraStar Deluxe is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING. If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ * $URL$
+ * $Id$
+ *}
+
+unit UMidiInput;
+
+interface
+
+{$IFDEF FPC}
+  {$MODE Delphi}
+{$ENDIF}
+{$I switches.inc}
+
+uses
+  Classes, Windows, MMSystem, SysUtils,
+  MidiIn, MidiType, ULog;
+
+type
+  TMidiNoteProc = procedure (Note : Byte) of object;
+
+procedure OpenMidiIn  (CB : TMidiNoteProc);
+procedure CloseMidiIn;
+
+implementation
+
+var
+  InDev   : TMidiInput  = nil;
+  OnNote  : TMidiNoteProc;
+
+type
+  TMidiInBridge = class(TObject)
+    procedure HandleInput(Sender: TObject);
+  end;
+
+var
+  Bridge : TMidiInBridge;
+
+procedure TMidiInBridge.HandleInput(Sender: TObject);
+var Ev : TMyMidiEvent;
+begin
+  repeat
+    Ev := InDev.GetMidiEvent;
+    if Ev = nil then Break;
+    try
+      if (Ev.MidiMessage and $F0 = $90) and (Ev.Data2 <> 0) then
+        if Assigned(OnNote) then
+          OnNote(Ev.Data1);   // pass note number
+    finally
+      Ev.Free;
+    end;
+  until False;
+end;
+
+procedure ListDevices;
+var i,n:Integer; caps: TMidiInCaps;
+begin
+  n := midiInGetNumDevs;
+  Log.LogInfo('---------- MIDI INPUT DEVICES ----------','UMidiInput.ListDevices');
+  for i := 0 to n-1 do
+  begin
+    midiInGetDevCaps(i,@caps,SizeOf(caps));
+    Log.LogInfo(Format('ID %d : %s',[i,caps.szPname]),'UMidiInput.ListDevices');
+  end;
+end;
+
+procedure OpenMidiIn(CB : TMidiNoteProc);
+var caps: TMidiInCaps;
+    dev : Integer;
+begin
+  if Assigned(InDev) then Exit;
+
+  ListDevices;
+
+  dev := 0;
+  InDev := TMidiInput.Create(nil);
+  InDev.DeviceID := dev;
+  InDev.Open;
+  midiInGetDevCaps(dev,@caps,SizeOf(caps));
+  Log.LogInfo(Format('Opened MIDI-IN ID %d (%s)',[dev,caps.szPname]),'UMidiInput.OpenMidiIn');
+
+  if Bridge=nil then Bridge := TMidiInBridge.Create;
+  InDev.OnMidiInput := Bridge.HandleInput;
+  InDev.Start;
+
+  OnNote := CB;
+end;
+
+procedure CloseMidiIn;
+begin
+  if Assigned(InDev) then
+  begin
+    Log.LogInfo('Closing MIDI-IN','UMidiInput.CloseMidiIn');
+    InDev.Stop;
+    InDev.Close;
+    InDev.Free;
+    InDev := nil;
+  end;
+  FreeAndNil(Bridge);
+end;
+
+end.

--- a/src/media/UMidiInput.pas
+++ b/src/media/UMidiInput.pas
@@ -34,6 +34,12 @@ interface
 
 uses
   Classes,
+  {$IFDEF MSWINDOWS}
+  MMSystem,
+  {$ENDIF}
+  {$IFDEF UsePortTime}
+  PortTime,
+  {$ENDIF}
   SysUtils,
   MidiIn,
   MidiType,

--- a/src/media/UMidiInput.pas
+++ b/src/media/UMidiInput.pas
@@ -36,13 +36,13 @@ uses
   Classes,
   {$IFDEF MSWINDOWS}
   MMSystem,
+  MidiIn,
+  MidiType,
   {$ENDIF}
   {$IFDEF UsePortTime}
   PortTime,
   {$ENDIF}
   SysUtils,
-  MidiIn,
-  MidiType,
   ULog;
 
 type

--- a/src/media/UMidiInput.pas
+++ b/src/media/UMidiInput.pas
@@ -34,7 +34,6 @@ interface
 
 uses
   Classes,
-  MMSystem,
   SysUtils,
   MidiIn,
   MidiType,

--- a/src/media/UMidiInput.pas
+++ b/src/media/UMidiInput.pas
@@ -33,8 +33,12 @@ interface
 {$I switches.inc}
 
 uses
-  Classes, Windows, MMSystem, SysUtils,
-  MidiIn, MidiType, ULog;
+  Classes,
+  MMSystem,
+  SysUtils,
+  MidiIn,
+  MidiType,
+  ULog;
 
 type
   TMidiNoteProc = procedure (Note : Byte) of object;
@@ -86,11 +90,18 @@ end;
 
 procedure OpenMidiIn(CB : TMidiNoteProc);
 var caps: TMidiInCaps;
-    dev : Integer;
+    dev, numDevs : Integer;
 begin
   if Assigned(InDev) then Exit;
 
   ListDevices;
+
+  numDevs := midiInGetNumDevs;
+  if numDevs = 0 then
+  begin
+    Log.LogWarn('No MIDI input devices found. MIDI-IN will not be opened.','UMidiInput.OpenMidiIn');
+    Exit;
+  end;
 
   dev := 0;
   InDev := TMidiInput.Create(nil);

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -4714,12 +4714,16 @@ begin
   PianoKeysLow := Ini.PianoKeysLow;
   PianoKeysHigh := Ini.PianoKeysHigh;
 
+  {$IFDEF UseMIDIPort}
   OpenMidiIn(OnMidiNote);
+  {$ENDIF}
 end;
 
 destructor TScreenEditSub.Destroy;
 begin
+  {$IFDEF UseMIDIPort}
   CloseMidiIn;
+  {$ENDIF}
   inherited;
 end;
 

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -53,9 +53,11 @@ uses
   dglOpenGL,
   Math,
   {$IFDEF UseMIDIPort}
-  MidiOut,
-  MidiCons,
-  UMidiInput,
+    MidiOut,
+    MidiCons,
+    {$IFDEF MSWINDOWS}
+    UMidiInput,
+    {$ENDIF}
   {$ENDIF}
   sdl2,
   strutils,
@@ -4715,14 +4717,18 @@ begin
   PianoKeysHigh := Ini.PianoKeysHigh;
 
   {$IFDEF UseMIDIPort}
-  OpenMidiIn(OnMidiNote);
+    {$IFDEF MSWINDOWS}
+    OpenMidiIn(OnMidiNote);
+    {$ENDIF}
   {$ENDIF}
 end;
 
 destructor TScreenEditSub.Destroy;
 begin
   {$IFDEF UseMIDIPort}
-  CloseMidiIn;
+    {$IFDEF MSWINDOWS}
+    CloseMidiIn;
+    {$ENDIF}
   {$ENDIF}
   inherited;
 end;

--- a/src/ultrastardx.dpr
+++ b/src/ultrastardx.dpr
@@ -107,6 +107,7 @@ uses
   {$ENDIF}
 
   {$IFDEF UseMIDIPort}
+    UMidiInput        in 'media\UMidiInput.pas',
     MidiCons          in 'lib\midi\MidiCons.pas',
     MidiFile          in 'lib\midi\MidiFile.pas',
 
@@ -117,6 +118,7 @@ uses
       MidiDefs        in 'lib\midi\MidiDefs.pas',
       MidiType        in 'lib\midi\MidiType.pas',
       MidiOut         in 'lib\midi\MidiOut.pas',
+      MidiIn          in 'lib\midi\MidiIn.pas',
     {$ELSE}
       {$IFDEF UsePortMidi}
         MidiOut       in 'lib\portmidi\MidiOut.pas',

--- a/src/ultrastardx.dpr
+++ b/src/ultrastardx.dpr
@@ -107,7 +107,6 @@ uses
   {$ENDIF}
 
   {$IFDEF UseMIDIPort}
-    UMidiInput        in 'media\UMidiInput.pas',
     MidiCons          in 'lib\midi\MidiCons.pas',
     MidiFile          in 'lib\midi\MidiFile.pas',
 
@@ -119,6 +118,7 @@ uses
       MidiType        in 'lib\midi\MidiType.pas',
       MidiOut         in 'lib\midi\MidiOut.pas',
       MidiIn          in 'lib\midi\MidiIn.pas',
+      UMidiInput      in 'media\UMidiInput.pas',
     {$ELSE}
       {$IFDEF UsePortMidi}
         MidiOut       in 'lib\portmidi\MidiOut.pas',


### PR DESCRIPTION
Building on #820, this PR adds support on Windows for MIDI keyboards.

I tested this with a Native Instruments Komplete M32. Since this is extra input it is not necessary to enable the Piano Edit Mode, they MIDI keyboard keys just always work.