### PR TITLE
add KP_DIVIDE as an alternative to SLASH for keyboards that don't have

### DIFF
--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -1423,6 +1423,7 @@ begin
           ShowInteractiveBackground;
         end;
 
+      // SDLK_KP_DIVIDE is a temporary workaround for German keyboards
       SDLK_SLASH, SDLK_HASH, SDLK_KP_DIVIDE:
         begin
           CopyToUndo;
@@ -2422,6 +2423,7 @@ begin
               end;
           end;
         end;
+      // SDLK_KP_DIVIDE is a temporary workaround for German keyboards
       SDLK_SLASH, SDLK_KP_DIVIDE:
         begin
           CopyToUndo;

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -1423,7 +1423,7 @@ begin
           ShowInteractiveBackground;
         end;
 
-      SDLK_SLASH, SDLK_HASH:
+      SDLK_SLASH, SDLK_HASH, SDLK_KP_DIVIDE:
         begin
           CopyToUndo;
           if SDL_ModState = 0 then
@@ -2422,7 +2422,7 @@ begin
               end;
           end;
         end;
-      SDLK_SLASH:
+      SDLK_SLASH, SDLK_KP_DIVIDE:
         begin
           CopyToUndo;
           if SDL_ModState = KMOD_LCTRL then


### PR DESCRIPTION
This is not a general solution for the keybindings, but it removes a nuisance as SDLK_SLASH does not exist on all keyboards. SDLK_KP_DIVIDE was not used so far but would now be used as an alternative.