### PR TITLE
Improve the splitting point in the editor

### DIFF
--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -1423,7 +1423,7 @@ begin
           ShowInteractiveBackground;
         end;
 
-      SDLK_SLASH, SDLK_HASH:
+      SDLK_SLASH, SDLK_HASH, SDLK_KP_DIVIDE:
         begin
           CopyToUndo;
           if SDL_ModState = 0 then
@@ -2422,7 +2422,7 @@ begin
               end;
           end;
         end;
-      SDLK_SLASH:
+      SDLK_SLASH, SDLK_KP_DIVIDE:
         begin
           CopyToUndo;
           if SDL_ModState = KMOD_LCTRL then


### PR DESCRIPTION
Builds on #1001 because otherwise I can't test it.

This one just selects a better split for the note split operation. The previous default was a split of one note

[ original note length = 50 ] --> [ first new note length = 1 ]  [ second new note length = 49 ]
[ original note length = 50 ] --> [ first new note length = 25 ]  [ second new note length = 25 ]

I use the editor a lot and you almost never want the first of these two --> change it to middle of the note.