### PR TITLE
Implement Crash Dialog on Linux/Mac

### DIFF
--- a/src/base/UCommon.pas
+++ b/src/base/UCommon.pas
@@ -136,6 +136,9 @@ uses
   {$ENDIF}
   sdl2,
   UFilesystem,
+  {$IFNDEF MSWINDOWS}
+  UGraphic,
+  {$ENDIF}
   UMain,
   UUnicodeUtils;
 
@@ -542,6 +545,8 @@ end;
 procedure ShowMessage(const msg: String; msgType: TMessageType);
 {$IFDEF MSWINDOWS}
 var Flags: cardinal;
+{$ELSE}
+var Flags: UInt32;
 {$ENDIF}
 begin
 {$IF Defined(MSWINDOWS)}
@@ -553,6 +558,11 @@ begin
   MessageBox(0, PChar(msg), PChar(USDXVersionStr()), Flags);
 {$ELSE}
   ConsoleWriteln(msg);
+  case msgType of
+    mtInfo:  Flags := SDL_MESSAGEBOX_INFORMATION;
+    mtError: Flags := SDL_MESSAGEBOX_ERROR;
+  end;
+  SDL_ShowSimpleMessageBox(Flags, PChar(USDXVersionStr()), PChar(msg), Screen);
 {$IFEND}
 end;
 


### PR DESCRIPTION
On Windows, when a crash occurs, a dialog will pop up informing the user of the problem. This functionality does not exist for the Linux/Mac versions. It prints the message to the terminal only. If the user is not running the game from the terminal, then the crash will be silent.

The Windows crash dialog is currently implemented using the WIN32 API, which is obviously not portable. However, SDL has a convenient abstraction `SDL_ShowSimpleMessageBox` which can be used to show a dialog using the OS's native window system.

See the below screenshot for an example of the Linux/Xorg crash dialog, using #1006 as a test case.

![Screenshot](https://github.com/user-attachments/assets/de0b8a6c-d809-4c84-b024-0ed6d942a67c)


