### PR TITLE
Full backtraces

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -99,7 +99,7 @@ PFLAGS_EXTRA   += @PFLAGS_EXTRA@
 # - Do we need -Coi?
 PFLAGS_BASE_DEFAULT    := -Si -Sg- -Sc- -v0Binwe -gl
 PFLAGS_DEBUG_DEFAULT   := -Xs- -g -dDEBUG_MODE
-PFLAGS_RELEASE_DEFAULT := -Xs- -O2
+PFLAGS_RELEASE_DEFAULT := -Xs- -O2 -OoNOSTACKFRAME
 PFLAGS_EXTRA_DEFAULT   :=
 
 # Debug/Release mode flags


### PR DESCRIPTION
Probably a requirement for #1007, also see #786 , specifically https://github.com/UltraStar-Deluxe/USDX/issues/786#issuecomment-1868319744 and further.

This PR **does** increase the size of the executable, it's the `-gl` that causes it. On my system it goes from 6.6MB to around 16.3MB. `-OoNOSTACKFRAME` doesn't really increase the size, regardless of whether it's used in combination with `-gl` or not.

If it was the other way around (showing one line with barely an increase versus showing all lines with a big increase) one could argue there's a tradeoff somewhere, but it's having any kind of line info at all where the size comes from.

It's extremely worth it in my opinion. Tested on Linux.