### PR TITLE
Fix: Correctly handle song end - set unfinished notes after audio end to freestyle

### DIFF
--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -885,9 +885,13 @@ begin
     Line := ScreenSing.Lyrics.GetUpperLine();
     if Line.LastLine then
     begin
-      LastWord := Line.Words[Length(Line.Words)-1];
-      if CurLyricsTime >= GetTimeFromBeat(LastWord.Start + LastWord.Length) then
-        ScreenSing.SungToEnd := true;
+      ScreenSing.SungToEnd := true;
+      for T := 0 to High(Line.Words) do
+      begin
+        if (CurLyricsTime < GetTimeFromBeat(Line.Words[T].Start + Line.Words[T].Length)) and
+           (not Line.Words[T].Freestyle) then
+          ScreenSing.SungToEnd := false;
+      end;
     end;
   end
   else


### PR DESCRIPTION
This PR improves handling of song endings by ensuring that notes extending beyond the audio's actual length (or configured #END) are converted to freestyle notes. It also improves the SungToEnd logic.

* **TSong:**

  * Add `AudioLength` param to `LoadOpenedSong`/`Analyse`.
  * Notes past audio end become freestyle; logs a warning.

* **TScreenSingController:**

  * Computes/passes `AudioEnd` to `Analyse` if available.
  * Falls back gracefully if audio length is not yet known.

* **TScreenSingView:**

  * `SungToEnd` so far only was set if the last note of the last non-freestyle line was completed. I fixed this: now it checks whether the in this last line the last non-freestyle note was completed for setting this flag. This is more important now as a too short audio may end within a line but would still not enter the highscore as the last line cannot be finished.