### PR TITLE
Fix Crash In Medley Mode when 2 Screens Are Used

### DIFF
--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -1585,6 +1585,8 @@ begin
 
         SetLength(PlaylistMedley.Stats, len + 1);
         SetLength(PlaylistMedley.Stats[len].Player, num);
+        for I := 0 to num - 1 do
+          PlaylistMedley.Stats[len].Player[I].HighNote := -1;
 
         for J := 0 to len - 1 do
         begin


### PR DESCRIPTION
USDX crashes at the end of a medley when a dual screen setup is used, see #831.

The cause is a `TPlayer` record that is not properly initialized. The `HighNote` member is supposed to be initialized to -1 instead of 0. Setting it to -1 prevents the for loop [here](https://github.com/UltraStar-Deluxe/USDX/blob/f199c71ea31dc3ed50858b8280c1323480ad34bd/src/base/UDraw.pas#L746) from executing, which is the source of the access violation.

It doesn't crash in the 1 screen setup because the `SingDraw` function never executes again after the `TPlayer` record is improperly initialized. In the 2 screen setup, all the draw functions are executed twice (once for each screen), and it's only in the second execution that it encounters the improperly initialized `TPlayer` record which causes the crash.

Fixes #831 