### PR TITLE
Refactor Edit Screen ParseInput

### DIFF
--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -1134,7 +1134,7 @@ begin
 end;
 
       // SDLK_T: HandleFixTimings;
-procedure TScreenEditSub.HandleFixTimings(SDL_ModState: word);  
+procedure TScreenEditSub.HandleFixTimings(SDL_ModState: word);
 begin
   // Fixes timings between sentences
   CopyToUndo;
@@ -1192,7 +1192,7 @@ begin
     {$IFDEF UseMIDIPort} MidiTime  := USTime.GetTime;
     MidiStart := GetTimeFromBeat(Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat);
     MidiStop  := GetTimeFromBeat(Tracks[CurrentTrack].Lines[Tracks[CurrentTrack].CurrentLine].EndBeat); {$ENDIF}
-    
+
     LastClick := -100;
 
     PlaySentence := true;


### PR DESCRIPTION
Refactor the `ParseInput` method in `UScreenEditSub.pas` to improve code clarity and maintainability. The handling logic has been moved from the main case block into dedicated handler methods. No functional change. This is a first step towards splitting out the handling of operations far enough to later introduce keybindings.