### PR TITLE
Smarter debug logging

### DIFF
--- a/src/base/ULog.pas
+++ b/src/base/ULog.pas
@@ -145,6 +145,7 @@ implementation
 uses
   SysUtils,
   DateUtils,
+  UIni,
   URecord,
   UMain,
   UMusic,  
@@ -395,7 +396,9 @@ end;
 
 procedure TLog.LogDebug(const Msg, Context: string);
 begin
-  LogMsg(Msg, Context, LOG_LEVEL_DEBUG);
+  if {$IFDEF DEBUG_MODE}true or {$ENDIF}boolean(Ini.Debug) then begin
+    LogMsg(Msg, Context, LOG_LEVEL_DEBUG);
+  end
 end;
 
 procedure TLog.LogInfo(const Msg, Context: string);

--- a/src/menu/UDisplay.pas
+++ b/src/menu/UDisplay.pas
@@ -838,10 +838,9 @@ begin
   SetFontPos(695, 0);
   glPrint ('FPS: ' + InttoStr(LastFPS));
 
-  // muffins
   SetFontPos(695, 13);
   glColor4f(0.8, 0.5, 0.2, 1);
-  glPrint ('Muffins!');
+  glPrint ('Game.Debug');
 
   glColor4f(1, 1, 1, 1);
 end;


### PR DESCRIPTION
Part 1 of 3 of looking into #1021, though this is generic enough that it should be useful in general. What it does is completely ignore Log.LogDebug statements _unless_:
* `./configure` was run with `--enable-debug`, and/or
* Options -> Game -> Debug is enabled

In the current codebase this will mostly benefit people using joystick/gaming controllers, as those spam an obscene amount of log statements.