### PR TITLE
add debug statements to song loading

### DIFF
--- a/src/base/USongs.pas
+++ b/src/base/USongs.pas
@@ -279,18 +279,22 @@ begin
   Iter := FileSystem.FileFind(Dir.Append('*'), faAnyFile);
   while (Iter.HasNext) do
   begin
+    // the debug statements in this function have exactly the same message length before it prints the path
     FileInfo := Iter.Next;
     FileName := FileInfo.Name;
     if ((FileInfo.Attr and faDirectory) <> 0) then
     begin
-      if Recursive and (not FileName.Equals('.')) and (not FileName.Equals('..')) and (not FileName.Equals('')) then
+      if Recursive and (not FileName.Equals('.')) and (not FileName.Equals('..')) and (not FileName.Equals('')) then begin
+        Log.LogDebug('Recursing: ' + Dir.Append(FileName).ToWide, 'TSongs.FindFilesByExtension');
         FindFilesByExtension(Dir.Append(FileName), Ext, true, Files);
+      end;
     end
     else
     begin
       // do not load files which either have wrong extension or start with a point
       if (Ext.Equals(FileName.GetExtension(), true) and not (FileName.ToUTF8()[1] = '.')) then
       begin
+        Log.LogDebug('Found file ' + Dir.Append(FileName).ToWide, 'TSongs.FindFilesByExtension');
         SetLength(Files, Length(Files)+1);
         Files[High(Files)] := Dir.Append(FileName);
       end;
@@ -306,6 +310,7 @@ var
   //CloneSong: TSong;
   Extension: IPath;
 begin
+  Log.LogDebug('Searching directory ' + Dir.ToWide + ' for txt files', 'TSongs.BrowseTXTFiles');
   SetLength(Files, 0);
   Extension := Path('.txt');
   FindFilesByExtension(Dir, Extension, true, Files);


### PR DESCRIPTION
**Do not merge before #1033 is merged**

Part 2 of 3 of looking into #1021. This isn't the first time we get a ticket about a specific/some/a lot of songs seemingly not loading. It might not be enough to fix that particular issue in one go, but for example during #837 this would also have been very useful.

The order in which it traverses files/directories is _not_ alphabetical (it never was). So you'll still want to have something Ctrl^F-able or just very few songs if you're actually debugging something specific, but I'd argue it's _better_ than not logging anything at all.

It is a bit jank in the sense that, for each song directory, it will first find all the txt files (and print debug messages about what it has found) and only then will it start to try and actually load them. So if it logs that it found the txt, it _will_ try to Song.Analyse it, but the error will be a bit further down the logfile. But it does imply that if it found it and it didn't log an error about it further down, it should have loaded it.