### PR TITLE
comment out joystick LogDebug statements

### DIFF
--- a/src/base/UJoystick.pas
+++ b/src/base/UJoystick.pas
@@ -323,18 +323,19 @@ begin
   // sanity check
   if (Joy = nil) then Exit;
 
+  // the LogDebug statements here are commented out because this is extremely spammy if a joystick/controller is used
   case Event.type_ of
   SDL_JOYAXISMOTION:
     with Event.jaxis do
     begin
-      Log.LogDebug(Format('JOYAXISMOTION [%d] Axis:%d  Value:%d  Time:%d', [which, axis, value, timestamp]), 'TJoy.Polling');
+      // Log.LogDebug(Format('JOYAXISMOTION [%d] Axis:%d  Value:%d  Time:%d', [which, axis, value, timestamp]), 'TJoy.Polling');
       Joy.OnControllerMotion(which, axis, EnsureRange((1.0*value) / JOYSTICK_AXIS_MAX_RANGE, -1.0, 1.0), timestamp, true);
     end;
 
   SDL_JOYHATMOTION:
     with Event.jhat do
     begin
-      Log.LogDebug(Format('JOYHATMOTION [%d] Pad:%d  Value:%d  Time:%d', [which, hat, value, timestamp]), 'TJoy.Polling');
+      // Log.LogDebug(Format('JOYHATMOTION [%d] Pad:%d  Value:%d  Time:%d', [which, hat, value, timestamp]), 'TJoy.Polling');
       Joy.OnControllerDPad(which, hat, ifthen(value and SDL_HAT_LEFT <> 0, -1, ifthen(value and SDL_HAT_RIGHT <> 0, 1, 0)),
                                        ifthen(value and SDL_HAT_DOWN <> 0, -1, ifthen(value and SDL_HAT_UP <> 0, 1, 0)),
                                        true);
@@ -342,42 +343,42 @@ begin
   SDL_JOYBUTTONUP, SDL_JOYBUTTONDOWN:
     with Event.jbutton do
     begin
-      Log.LogDebug(Format('JOYBUTTON [%d] Button:%d  State:%d  Type:%d  Time:%d', [which, button, state, type_, timestamp]), 'TJoy.Polling');
+      // Log.LogDebug(Format('JOYBUTTON [%d] Button:%d  State:%d  Type:%d  Time:%d', [which, button, state, type_, timestamp]), 'TJoy.Polling');
       Joy.OnControllerButton(which, button, ifthen(state = SDL_PRESSED, bsPressed, bsReleased), true);
     end;
 
   SDL_CONTROLLERDEVICEADDED:
     begin
-      Log.LogDebug(Format('CONTROLLERDEVICEADDED [DeviceID=%d]', [Event.cdevice.which]), 'TJoy.Polling');
+      // Log.LogDebug(Format('CONTROLLERDEVICEADDED [DeviceID=%d]', [Event.cdevice.which]), 'TJoy.Polling');
       Joy.OnControllerAdded(Event.cdevice.which);
     end;
   SDL_CONTROLLERDEVICEREMOVED:
     begin
-      Log.LogDebug(Format('CONTROLLERDEVICEREMOVED [InstanceID=%d]', [Event.cdevice.which]), 'TJoy.Polling');
+      // Log.LogDebug(Format('CONTROLLERDEVICEREMOVED [InstanceID=%d]', [Event.cdevice.which]), 'TJoy.Polling');
       Joy.OnControllerRemoved(Event.cdevice.which);
     end;
   SDL_CONTROLLERDEVICEREMAPPED:
     begin
-      Log.LogDebug(Format('CONTROLLERDEVICEREMAPPED [InstanceID=%d]', [Event.cdevice.which]), 'TJoy.Polling');
+      // Log.LogDebug(Format('CONTROLLERDEVICEREMAPPED [InstanceID=%d]', [Event.cdevice.which]), 'TJoy.Polling');
       Joy.OnControllerRemapped(Event.cdevice.which);
     end;
 
   SDL_CONTROLLERAXISMOTION:
     with Event.caxis do
     begin
-      Log.LogDebug(Format('CONTROLLERAXISMOTION [%d] Axis:%d  Value:%d  Time:%d', [which, axis, value, timestamp]), 'TJoy.Polling');
+      // Log.LogDebug(Format('CONTROLLERAXISMOTION [%d] Axis:%d  Value:%d  Time:%d', [which, axis, value, timestamp]), 'TJoy.Polling');
       Joy.OnControllerMotion(which, axis, EnsureRange((1.0*value) / JOYSTICK_AXIS_MAX_RANGE, -1.0, 1.0), timestamp);
     end;
   SDL_CONTROLLERBUTTONDOWN:
     with Event.cbutton do
     begin
-      Log.LogDebug(Format('CONTROLLERBUTTONDOWN [%d] Button:%d  State:%d  Type:%d  Time:%d', [which, button, state, type_, timestamp]), 'TJoy.Polling');
+      // Log.LogDebug(Format('CONTROLLERBUTTONDOWN [%d] Button:%d  State:%d  Type:%d  Time:%d', [which, button, state, type_, timestamp]), 'TJoy.Polling');
       Joy.OnControllerButton(which, button, ifthen(state = SDL_PRESSED, bsPressed, bsReleased));
     end;
   SDL_CONTROLLERBUTTONUP:
     with Event.cbutton do
     begin
-      Log.LogDebug(Format('CONTROLLERBUTTONUP [%d] Button:%d  State:%d  Type:%d  Time:%d', [which, button, state, type_, timestamp]), 'TJoy.Polling');
+      // Log.LogDebug(Format('CONTROLLERBUTTONUP [%d] Button:%d  State:%d  Type:%d  Time:%d', [which, button, state, type_, timestamp]), 'TJoy.Polling');
       Joy.OnControllerButton(which, button, ifthen(state = SDL_PRESSED, bsPressed, bsReleased));
     end;
   SDL_JOYDEVICEADDED:


### PR DESCRIPTION
because unless it's the thing you actually want to debug, it's spam

Part 3 of 3 of looking into #1021, though this one's more of a side bonus. But I do believe:
* this kind of spam is useless to end users. Most controllers should Just Work anyway
* this kind of spam is useless to developers. It's normal that when developing something, you temporarily have a bunch of extra log statements. Maybe even something that logs every frame. But _especially_ that latter is not something that should be in shipped code, for it will just drown out anything else.