### PR TITLE
Add keywords to desktop file

### DIFF
--- a/dists/ultrastardx.desktop
+++ b/dists/ultrastardx.desktop
@@ -14,3 +14,4 @@ Terminal=false
 
 Type=Application
 Categories=Game;ArcadeGame;
+Keywords=game;karaoke;singing;song;microphone;sound;


### PR DESCRIPTION
At least GNOME shell is using the keyword field to match search strings against. All desktop files should contain keywords, to yield a satisfactory search experience.