### PR TITLE
don't check all sentences for every beat

### DIFF
--- a/src/base/UNote.pas
+++ b/src/base/UNote.pas
@@ -426,20 +426,14 @@ end;
 
 procedure NewBeatDetect(Screen: TScreenSingController);
   var
-    MaxCP, CP, SentenceEnd: integer;
+    MaxCP, CP, SentenceEnd, StartLine, EndLine: integer;
     I, J: cardinal;
 begin
   // check for sentence end
-  // we check all lines here because a new sentence may
-  // have been started even before the old one finishes
-  // due to corrupt lien breaks
-  // checking only current line works to, but may lead to
-  // weird ratings for the song files w/ the mentioned
-  // errors
-  // To-Do Philipp : check current and last line should
-  // do it for most corrupt txt and for lines in
-  // non-corrupt txts that start immediatly after the prev.
-  // line ends
+  // we check three lines (previous, current, next)
+  // here because a new sentence may have started
+  // before the old one finished due to corrupt line breaks
+
   MaxCP := 0;
   if (CurrentSong.isDuet) and (PlayersPlay <> 1) then
     MaxCP := 1;
@@ -450,9 +444,16 @@ begin
     begin
       CP := J;
 
+      StartLine := Tracks[CP].CurrentLine - 1;
+      if StartLine < 0 then
+        StartLine := 0;
+      EndLine := StartLine + 1;
+      if EndLine > Tracks[CP].High then
+        EndLine := Tracks[CP].High;
+
       NewNote(CP, Screen);
 
-      for I := 0 to Tracks[CP].High do
+      for I := StartLine to EndLine do
       begin
         with Tracks[CP].Lines[I] do
         begin


### PR DESCRIPTION
so far usdx scanned for every beat through all lines and all notes, apparently as a workaround for buggy txts. i changed this to previous, current, next.
interestingly, it did not work with just current+next (0 points) as the comment suggested, my suspicion is, because the score is computed at the end of the line, that the line break --> change of current sentence happens just a few lines earlier, so unless checking the previous sentence, this cannot possibly work.
this now has a bit of tolerance while reducing the computation overhead for most txts significantly from checking 30+ lines to checking 3 lines.