### PR TITLE
allow setting a per player delay via the .ini file

### DIFF
--- a/src/base/UIni.pas
+++ b/src/base/UIni.pas
@@ -127,6 +127,7 @@ type
       Name:           array[0..15] of UTF8String;
       PlayerColor:    array[0..(IMaxPlayerCount-1)] of integer;
       TeamColor:      array[0..2] of integer;
+      PlayerDelay:    array[0..(IMaxPlayerCount-1)] of integer;
 
       PlayerAvatar:   array[0..(IMaxPlayerCount-1)] of UTF8String;
       PlayerLevel:    array[0..(IMaxPlayerCount-1)] of integer;
@@ -290,6 +291,7 @@ type
       procedure Load();
       procedure Save();
       procedure SaveNames;
+      procedure SaveDelays;
       function ReloadNames: boolean;
       procedure SaveLevel;
       procedure SavePlayerColors;
@@ -1435,6 +1437,8 @@ begin
     PlayerAvatar[I] := IniFile.ReadString('PlayerAvatar', 'P'+IntToStr(I+1), '');
     // Level Player
     PlayerLevel[I] := IniFile.ReadInteger('PlayerLevel', 'P'+IntToStr(I+1), 1);
+    // Player Delay
+    PlayerDelay[I] := IniFile.ReadInteger('PlayerDelay', 'P'+IntToStr(I+1), 0);
   end;
 
   // Color Team
@@ -2047,6 +2051,22 @@ begin
       IniFile.WriteString('NameTeam', 'T' + IntToStr(I+1), NameTeam[I]);
     for I := 0 to High(NameTemplate) do
       IniFile.WriteString('NameTemplate', 'Name' + IntToStr(I+1), NameTemplate[I]);
+
+    IniFile.Free;
+  end;
+end;
+
+procedure TIni.SaveDelays;
+var
+  IniFile: TIniFile;
+  I:       integer;
+begin
+  if not Filename.IsReadOnly() then
+  begin
+    IniFile := TIniFile.Create(Filename.ToNative);
+
+    for I := 0 to High(PlayerDelay) do
+      IniFile.WriteInteger('PlayerDelay', 'P' + IntToStr(I+1), PlayerDelay[I]);
 
     IniFile.Free;
   end;

--- a/src/base/UIni.pas
+++ b/src/base/UIni.pas
@@ -127,6 +127,7 @@ type
       Name:           array[0..15] of UTF8String;
       PlayerColor:    array[0..(IMaxPlayerCount-1)] of integer;
       TeamColor:      array[0..2] of integer;
+      PlayerDelay:    array[0..(IMaxPlayerCount-1)] of integer;
 
       PlayerAvatar:   array[0..(IMaxPlayerCount-1)] of UTF8String;
       PlayerLevel:    array[0..(IMaxPlayerCount-1)] of integer;
@@ -290,11 +291,14 @@ type
       // default encoding for texts (lyrics, song-name, ...)
       DefaultEncoding: TEncoding;
       LastReadNames: LongInt;
+      LastReadDelays: LongInt;
 
       procedure Load();
       procedure Save();
       procedure SaveNames;
-      function ReloadNames: boolean;
+      procedure SaveDelays;
+      procedure ReloadDelays;
+      function  ReloadNames: boolean;
       procedure SaveLevel;
       procedure SavePlayerColors;
       procedure SavePlayerAvatars;
@@ -1525,6 +1529,8 @@ begin
     PlayerAvatar[I] := IniFile.ReadString('PlayerAvatar', 'P'+IntToStr(I+1), '');
     // Level Player
     PlayerLevel[I] := IniFile.ReadInteger('PlayerLevel', 'P'+IntToStr(I+1), 1);
+    // Player Delay
+    PlayerDelay[I] := IniFile.ReadInteger('PlayerDelay', 'P'+IntToStr(I+1), 0);
   end;
 
   // Color Team
@@ -2130,6 +2136,41 @@ begin
   end;
 end;
 
+procedure TIni.SaveDelays;
+var
+  IniFile: TIniFile;
+  I:       integer;
+begin
+  if not Filename.IsReadOnly() then
+  begin
+    IniFile := TIniFile.Create(Filename.ToNative);
+
+    for I := 0 to High(PlayerDelay) do
+      IniFile.WriteInteger('PlayerDelay', 'P' + IntToStr(I+1), PlayerDelay[I]);
+
+    IniFile.Free;
+  end;
+end;
+
+
+procedure TIni.ReloadDelays;
+var
+  IniFile: TIniFile;
+  I:       integer;
+begin
+  if not FileExists(Filename.ToNative) or (FileAge(Filename.ToNative) <= LastReadDelays) then
+  begin
+    Exit;
+  end;
+  LastReadDelays := FileAge(Filename.ToNative);
+
+  IniFile := TIniFile.Create(Filename.ToNative);
+
+  for I := 0 to IMaxPlayerCount-1 do
+    PlayerDelay[I] := IniFile.ReadInteger('PlayerDelay', 'P'+IntToStr(I+1), 0);
+
+  IniFile.Free;
+end;
 
 function TIni.ReloadNames: boolean;
 var

--- a/src/base/UNote.pas
+++ b/src/base/UNote.pas
@@ -395,6 +395,9 @@ var
   MaxSongPoints:       integer; // max. points for the song (without line bonus)
   CurNotePoints:       real;    // Points for the cur. Note (PointsperNote * ScoreFactor[CurNote])
   CurrentNoteType:     TNoteType;
+  DelayBeats:          real;
+  PlayerOldBeat:       integer;
+  PlayerCurBeat:       integer;
 begin
   ActualTone := 0;
   NoteHit := false;
@@ -409,12 +412,20 @@ begin
     SentenceMin := 0;
   SentenceMax := CurrentSong.Tracks[CP].CurrentLine;
 
-  for ActualBeat := LyricsState.OldBeatD+1 to LyricsState.CurrentBeatD do
+  // analyze player signals
+  for PlayerIndex := 0 to PlayersPlay-1 do
   begin
-    // analyze player signals
-    for PlayerIndex := 0 to PlayersPlay-1 do
+    if (not CurrentSong.isDuet) or (PlayerIndex mod 2 = CP) then
     begin
-      if (not CurrentSong.isDuet) or (PlayerIndex mod 2 = CP) then
+
+      // delay in beats (Ini.PlayerDelay is ms)
+      DelayBeats := GetBeats(CurrentSong.BPM[0].BPM, Ini.PlayerDelay[PlayerIndex] / 1000);
+
+      PlayerOldBeat := Floor(LyricsState.OldBeatD - DelayBeats);
+      if PlayerOldBeat < 0 then PlayerOldBeat := 0;
+      PlayerCurBeat := Floor(LyricsState.CurrentBeatD - DelayBeats);
+
+      for ActualBeat := PlayerOldBeat+1 to PlayerCurBeat do
       begin
         // check for an active note at the current time defined in the lyrics
         NoteAvailable := false;
@@ -608,9 +619,9 @@ begin
           end; // if SentenceDetected = SentenceMax
 
         end; // if Detected
-      end;
-    end; // for PlayerIndex
-  end; // for ActualBeat
+      end; // for ActualBeat
+    end;
+  end; // for PlayerIndex
   //Log.LogStatus('EndBeat', 'NewBeat');
 end;
 

--- a/src/base/UNote.pas
+++ b/src/base/UNote.pas
@@ -357,6 +357,8 @@ begin
     end;
   end;
 
+  Ini.ReloadDelays;
+
   Screen.onSentenceChange(CP, CurrentSong.Tracks[CP].CurrentLine)
 end;
 
@@ -464,6 +466,9 @@ var
   MaxSongPoints:       integer; // max. points for the song (without line bonus)
   CurNotePoints:       real;    // Points for the cur. Note (PointsperNote * ScoreFactor[CurNote])
   CurrentNoteType:     TNoteType;
+  DelayBeats:          real;
+  PlayerOldBeat:       integer;
+  PlayerCurBeat:       integer;
 begin
   ActualTone := 0;
   NoteHit := false;
@@ -478,12 +483,20 @@ begin
     SentenceMin := 0;
   SentenceMax := CurrentSong.Tracks[CP].CurrentLine;
 
-  for ActualBeat := LyricsState.OldBeatD+1 to LyricsState.CurrentBeatD do
+  // analyze player signals
+  for PlayerIndex := 0 to PlayersPlay-1 do
   begin
-    // analyze player signals
-    for PlayerIndex := 0 to PlayersPlay-1 do
+    if (not CurrentSong.isDuet) or (PlayerIndex mod 2 = CP) then
     begin
-      if (not CurrentSong.isDuet) or (PlayerIndex mod 2 = CP) then
+
+      // delay in beats (Ini.PlayerDelay is ms)
+      DelayBeats := GetBeats(CurrentSong.BPM, Ini.PlayerDelay[PlayerIndex] / 1000);
+
+      PlayerOldBeat := Floor(LyricsState.OldBeatD - DelayBeats);
+      if PlayerOldBeat < 0 then PlayerOldBeat := 0;
+      PlayerCurBeat := Floor(LyricsState.CurrentBeatD - DelayBeats);
+
+      for ActualBeat := PlayerOldBeat+1 to PlayerCurBeat do
       begin
         // check for an active note at the current time defined in the lyrics
         NoteAvailable := false;
@@ -654,9 +667,9 @@ begin
           end; // if SentenceDetected = SentenceMax
 
         end; // if Detected
-      end;
-    end; // for PlayerIndex
-  end; // for ActualBeat
+      end; // for ActualBeat
+    end;
+  end; // for PlayerIndex
   //Log.LogStatus('EndBeat', 'NewBeat');
 end;
 

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -1079,6 +1079,7 @@ begin
   if Ini.ReloadNames then
   begin
     OnShow;
+    Ini.ReloadDelays;
   end;
 
   if isScrolling then


### PR DESCRIPTION
If you have a set of different microphones with different delays (e.g. some cable, some wireless, different vendors, different smartphones when using smartphones as mics), then the one centrally configured delay doesn't cut it.
this allows setting the microphone delay in the ini.

I introduced a new PlayerDelay section for this tied to the player rather than the microphone under the assumption that people will use the same microphones for the same player (e.g. because microphones are colored) even if the soundcard labeling changes. Also i didn't want to interfere with the soundcard part in the ini as it is not so pretty...

this is a simple and clean fix. works like a charm with smartphones as mics.