### PR TITLE
Remove warning and let score indicator drop instead

### DIFF
--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -983,9 +983,9 @@ begin
               aPlayers[PopUp.Player].ScoreDisplayed := Players[PopUp.Player].ScoreDisplayed + ScoreToAdd;
 
               // change bar positions
-	      if PopUp.ScoreDiff = 0 then
-		Log.LogError('TSingScores.DrawPopUp', 'PopUp.ScoreDiff is 0 and we want to divide by it. No idea how this happens.')
-	      else
+              if PopUp.ScoreDiff = 0 then
+                aPlayers[PopUp.Player].RBTarget := 0
+              else
                 aPlayers[PopUp.Player].RBTarget := aPlayers[PopUp.Player].RBTarget + ScoreToAdd/PopUp.ScoreDiff * (PopUp.Rating / 20 - 0.26);
               if (aPlayers[PopUp.Player].RBTarget > 1) then
                 aPlayers[PopUp.Player].RBTarget := 1


### PR DESCRIPTION
Tried it with freestyle and regular notes, I think this is what should happen instead of the warning described in #1053 