### PR TITLE
fix: avoid using wrong song length when preview from previous track is still active

### DIFF
--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -469,6 +469,7 @@ type
       procedure Rewind;
       function  Finished: boolean;
       function  Length: real;
+      function  GetFileName: string;
 
       function Open(const Filename: IPath; const FilenameKaraoke: IPath): boolean; // true if succeed
       procedure Close;

--- a/src/media/UAudioPlaybackBase.pas
+++ b/src/media/UAudioPlaybackBase.pas
@@ -50,6 +50,7 @@ type
       MusicStream: TAudioPlaybackStream;
       KaraokeMusicStream: TAudioPlaybackStream;
       KaraokeMode: boolean;
+      CurrentFileName: string;
 
       function CreatePlaybackStream(): TAudioPlaybackStream; virtual; abstract;
       procedure ClearOutputDeviceList();
@@ -62,6 +63,7 @@ type
     public
       constructor Create(); virtual;
       function GetName: string; virtual; abstract;
+      function GetFileName: string;
 
       function Open(const Filename: IPath; const FilenameKaraoke: IPath): boolean; // true if succeed
       procedure Close;
@@ -148,11 +150,20 @@ begin
   Result := true;
 end;
 
+function TAudioPlaybackBase.GetFileName: string;
+begin
+  if assigned(MusicStream) then
+    Result := CurrentFileName
+  else
+    Result := '';
+end;
+
 function TAudioPlaybackBase.Open(const Filename: IPath; const FilenameKaraoke: IPath): boolean;
 begin
   // free old MusicStream
   MusicStream.Free;
   KaraokeMusicStream.Free;
+  CurrentFileName := Filename.ToNative;
 
   MusicStream := OpenStream(Filename);
   if not assigned(MusicStream) then

--- a/src/media/UMedia_dummy.pas
+++ b/src/media/UMedia_dummy.pas
@@ -56,6 +56,7 @@ type
 
       function Open(const aFileName: IPath; const aFileNameKaraoke: IPath): boolean; // true if succeed
       procedure Close;
+      function  GetFileName: string;
 
       procedure Play;
       procedure ToggleKaraoke;
@@ -195,6 +196,11 @@ end;
 
 procedure TAudio_Dummy.Close;
 begin
+end;
+
+function TAudio_Dummy.GetFileName: string;
+begin
+  Result := '';
 end;
 
 procedure TAudio_Dummy.Play;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -1050,7 +1050,7 @@ begin
   end;
 
   CurrentSong := CatSongs.Song[CatSongs.Selected];
-  if (not Assigned(AudioPlayback)) or (AudioPlayback.Length = 0) then
+  if (not Assigned(AudioPlayback)) or (AudioPlayback.Length = 0) or (CurrentSong.Path.Append(CurrentSong.Audio).ToNative <> AudioPlayback.GetFileName) then
   begin
     if (not Assigned(CurrentSong.Karaoke)) or (CurrentSong.Karaoke = PATH_NONE) then
       AudioPlayback.Open(CurrentSong.Path.Append(CurrentSong.Audio), nil)


### PR DESCRIPTION
add filename tracking to `AudioPlayback` and ensure preview belongs to current song before using its length.
prevents race condition where leftover preview caused incorrect duration being used for the song end check as reported by @complexlogic 