### PR TITLE
get rid of inlined warnings

### DIFF
--- a/src/switches.inc
+++ b/src/switches.inc
@@ -13,6 +13,7 @@
 
   // {$DEFINE HasInline} // disabled as it generates a lot of warnings on current fpc versions
   {$WARN 6058 OFF}
+  {$notes off}
 {$ELSE}
   {$DEFINE Delphi}
 


### PR DESCRIPTION
we can disable inlining in our code but can only disable the notes for included libraries

largely fixes #1039 