### PR TITLE
remove inline hints in ULog unit

### DIFF
--- a/src/base/ULog.pas
+++ b/src/base/ULog.pas
@@ -111,16 +111,16 @@ type
     function GetLogFileLevel(): integer;
 
     procedure LogMsg(const Text: string; Level: integer); overload;
-    procedure LogMsg(const Msg, Context: string; Level: integer); overload; {$IFDEF HasInline}inline;{$ENDIF}
-    procedure LogDebug(const Msg, Context: string); {$IFDEF HasInline}inline;{$ENDIF}
-    procedure LogInfo(const Msg, Context: string); {$IFDEF HasInline}inline;{$ENDIF}
-    procedure LogStatus(const Msg, Context: string); {$IFDEF HasInline}inline;{$ENDIF}
-    procedure LogWarn(const Msg, Context: string); {$IFDEF HasInline}inline;{$ENDIF}
-    procedure LogError(const Text: string); overload; {$IFDEF HasInline}inline;{$ENDIF}
-    procedure LogError(const Msg, Context: string); overload; {$IFDEF HasInline}inline;{$ENDIF}
+    procedure LogMsg(const Msg, Context: string; Level: integer); overload;
+    procedure LogDebug(const Msg, Context: string);
+    procedure LogInfo(const Msg, Context: string);
+    procedure LogStatus(const Msg, Context: string);
+    procedure LogWarn(const Msg, Context: string);
+    procedure LogError(const Text: string); overload;
+    procedure LogError(const Msg, Context: string); overload;
     //Critical Error (Halt + MessageBox)
-    procedure LogCritical(const Msg, Context: string); {$IFDEF HasInline}inline;{$ENDIF}
-    procedure CriticalError(const Text: string); {$IFDEF HasInline}inline;{$ENDIF}
+    procedure LogCritical(const Msg, Context: string);
+    procedure CriticalError(const Text: string);
 
     // voice
     procedure LogVoice(SoundNr: integer);


### PR DESCRIPTION
See #1039 and #1066 

Simply removing them _just_ from the ULog unit makes it go from 661 notes to 290 notes.

There's still some concentrations triggered by non-library code:
* USong -- can probably be mostly dealt with by using a helper function
* UJoystick -- some portion can probably be dealt with by using a temp variable instead of `Controllers.Data[index].someAttr` over and over and over.

but even so, the ULog one appears to be the big one. Weirdly, the ones in URecord don't appear to trigger this message in the first place -- implying they are actually getting inlined.

Already, there are so many useful notes suddenly not drowned out anymore. A lot of them are about unused things, followed by a bunch about string encoding hell. Personally I'd propose to park #1066 until we've had a closer look at USong, UJoystick and the unused stuff, and see what things look like after that.