### PR TITLE
don't echo every single file that's being copied

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -282,7 +282,6 @@ install-data-recursive:
 	@for file in "$(RECURSIVE_SRC_DIR)"/*; do \
 	  if test -f "$$file"; then \
 	    filename=`basename "$$file"`; \
-	    echo "$(INSTALL_DATA) \"$$file\" \"$(RECURSIVE_DST_DIR)/$$filename\""; \
 	    $(INSTALL_DATA) "$$file" "$(RECURSIVE_DST_DIR)/$$filename" || exit 1; \
 	  fi; \
 	  if test -d "$$file"; then \


### PR DESCRIPTION
Is it normal to echo these all the time? I've never really looked at them but they seem to just copy mostly 644 files, it doesn't feel particularly useful.

It's also an attempt to make the CI Build log more useful, there's like a 1000 lines of this plus another 2000 from ProjectM alone (I'm not sure if this also catches the latter, but I don't have ProjectM locally) and the actual compilation step (with its notes and warnings) is a bit hard to find.