### PR TITLE
document how to fix the pipeline if the mxe token has expired

### DIFF
--- a/PIPELINE.md
+++ b/PIPELINE.md
@@ -1,0 +1,13 @@
+# Pipeline
+This document lists some quirks and how-to's about the pipeline.
+
+## Windows CI fails to download DLLs
+It fails with a message that it can't find some zip file, and a little further up is `HTTP Error 401: Unauthorized`.
+
+The pipeline uses a [fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) which expire at some point.
+To get a new one:
+* Go to [Settings - Personal access tokes](https://github.com/settings/personal-access-tokens)
+* Resource owner = UltraStar-Deluxe
+* Repository access = Only select repositories (`mxe`)
+* Permissions: readonly for Actions on the `mxe` repository
+* And then in the [USDX repository actions secrets](https://github.com/UltraStar-Deluxe/USDX/settings/secrets/actions) the token needs to be a `Repository secret` named `MXEACTIONSREADACCESSTOKEN`

--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ For extended information, dependencies, OS-specific notes and configure flags, s
 
 ### 6. Making a release
 See [RELEASING.md](RELEASING.md)
+
+Other useful documents for maintainers: [pipeline info](PIPELINE.md).


### PR DESCRIPTION
this is basically https://github.com/UltraStar-Deluxe/USDX/issues/1045#issuecomment-3237230952 but in a place where I can actually find it.

fixes #1045 (it was kept open until it is properly documented, obviously the token itself has long been fixed, the whole point is to make it trivial the _next_ time)