### PR TITLE
add -Ciro to linux and mac builds

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -97,7 +97,7 @@ PFLAGS_EXTRA   += @PFLAGS_EXTRA@
 # - Note that fpc.cfg already defines -vinw, so add -v0 first
 # - The stack check (-Ct) might not work with enabled threading
 # - Do we need -Coi?
-PFLAGS_BASE_DEFAULT    := -Si -Sg- -Sc- -v0Binwe -gl
+PFLAGS_BASE_DEFAULT    := -Si -Sg- -Sc- -v0Binwe -Ciro -gl
 PFLAGS_DEBUG_DEFAULT   := -Xs- -g -dDEBUG_MODE
 PFLAGS_RELEASE_DEFAULT := -Xs- -O2 -OoNOSTACKFRAME
 PFLAGS_EXTRA_DEFAULT   :=


### PR DESCRIPTION
Why we need this: https://github.com/UltraStar-Deluxe/USDX/issues/1071#issuecomment-3503626863

Fixes #786 

Without this PR: restarting a song "works" on Mac and Linux.

With this PR:
<img width="1600" height="600" alt="2025-11-19-155230_1600x600_scrot" src="https://github.com/user-attachments/assets/4e1c31e8-0384-4a02-afb4-4c970748b4b2" />
ie, the same as the photo of Windows in #1071 

From playing around a bit I couldn't immediately find new and interesting ways to crash the game, but we also have better error popups so fixing it should also be a lot faster.

I am willing to postpone merging this until January 2026 if people think this is too much of a risk to merge just before the holidays (but ironically, if this _does_ break things, the holidays are when I have a lot more time available to fix things...)