### PR TITLE
initialize LastLineSungToEnd variable as otherwise we run into undefined behavior

### DIFF
--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -880,6 +880,7 @@ begin
   ScreenSing.Text[TextTimeText].Text := Format('%s%.2d:%.2d', [DisplayPrefix, DisplayMin, DisplaySec]);
   ScreenSing.Text[TextTimeText].Visible := ScreenSing.Settings.TimeBarVisible;
 
+  LastLineSungToEnd := false;
   //the song was sung to the end?
   if not (ScreenSing.SungToEnd) and not(CurrentSong.isDuet) and not(ScreenSong.RapToFreestyle) then
   begin


### PR DESCRIPTION
@barbeque-squared found a bug (surprising that no one noticed it earlier) and reported it in #1082 where scores are saved although they should not. the origin for this is #1062 where the LastLineSungToEnd variable was introduced to keep track of whether the last line was sung to the end or stopped in the middle. unfortunately I overlooked that i'm not initializing LastLineSungToEnd when not entering the if. so that's an unitialized boolean that may be true or false depending on whatever remains are on the stack when we get there.

the only case where this code reliably worked was actually aborting exactly on the last line.