### PR TITLE
allow both ctrl + shift to change pitches while not in duet mode

### DIFF
--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -2186,7 +2186,9 @@ begin
   end;
 
   // decrease tone
-  if SDL_ModState = KMOD_LSHIFT then
+  if (SDL_ModState = KMOD_LSHIFT) or
+     (not CurrentSong.isDuet and
+      ((SDL_ModState = KMOD_LCTRL) or (SDL_ModState = KMOD_LCTRL + KMOD_LSHIFT))) then
   begin
     CopyToUndo;
     TransposeNote(-1);
@@ -2243,7 +2245,9 @@ begin
   end;
 
   // increase tone
-  if SDL_ModState = KMOD_LSHIFT then
+  if (SDL_ModState = KMOD_LSHIFT) or
+     (not CurrentSong.isDuet and
+      ((SDL_ModState = KMOD_LCTRL) or (SDL_ModState = KMOD_LCTRL + KMOD_LSHIFT))) then
   begin
     CopyToUndo;
     TransposeNote(1);


### PR DESCRIPTION
this PR changes the note pitch change behavior just slightly.
- previously: shift + up/down to change pitch
- now: shift and/or ctrl + up/down to change pitch unless we're in duet mode (which is much more rare than regular songs) and where ctrl + up/down is already occupied.

this matches the CMD behavior referenced in #1079 