### PR TITLE
Fix Score Screen Crash

### DIFF
--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -498,10 +498,10 @@ begin
   max_y := Button[button_s].Y + Button[button_s].H;
 
   // transfer mousecords to the 800x600 raster we use to draw
-  X := Round((X / (Screen^.w / Screens)) * RenderW);
+  X := Round((X / (ScreenW / Screens)) * RenderW);
   if (X > RenderW) then
     X := X - RenderW;
-  Y := Round((Y / Screen^.h) * RenderH);
+  Y := Round((Y / ScreenH) * RenderH);
 
   if (Button[button_s].Visible) and (InRegion(X, Y, Button[button_s].GetMouseOverArea)) then
     SetInteraction(button_s)


### PR DESCRIPTION
On my Linux build of current `master`, the game crashes if I move the mouse while on the score screen. This was presumably introduced by the new compiler flag (#1081). Stacktrace below:
```
Exception class: ERangeError
Message: Range check error
  $000000000056C97B  PARSEMOUSE,  line 501 of screens/UScreenScore.pas
  $0000000000464527  PARSEMOUSE,  line 681 of menu/UDisplay.pas
  $00000000004874D0  CHECKEVENTS,  line 497 of base/UMain.pas
  $000000000048689F  MAINLOOP,  line 341 of base/UMain.pas
  $00000000004865FF  MAIN,  line 269 of base/UMain.pas
  $000000000040743E  main,  line 382 of ultrastardx.dpr
```

At the time of the exception, `Screen^.W` and `Screen^.H` were both 0, leading to a divide by zero case which is undefined behavior.

According to the [SDL2 documentation](https://wiki.libsdl.org/SDL2/SDL_Window), `SDL_Window` is an opaque type, meaning we shouldn't be accessing its members directly. Instead, we should be using one of the provided API getter functions. The `UGraphic` unit already does this, and stores the results in the global variables `ScreenW` and `ScreenH`. The code is changed to use those instead, which fixes the crash.

Since `SDL_Window` has an unstable ABI, reproducing this bug may depend on the specific version of SDL2 being used with USDX. I'm running sdl2-compat 2.32.56 with sdl3 3.2.24.