### PR TITLE
convert UScreenSongMenu lineendings from CRLF to LF

### DIFF
--- a/src/screens/UScreenSongMenu.pas
+++ b/src/screens/UScreenSongMenu.pas
@@ -917,7 +917,7 @@ begin
               Visible := False;
 
             end;
-            
+
           6: //Button 4
             begin
               ScreenSong.StartMedley(5, msCalculated);


### PR DESCRIPTION
it was discovered in #1049 that this specific file was using Windows line endings in the source repository itself. this obviously shouldn't happen.

this PR changes them to LF. Additionally, turns out there actually _was_ trailing whitespace somewhere! but it wasn't reporting that particular place in any kind of useful way.

**NOTE: DO NOT MERGE THIS BEFORE #1094**