### PR TITLE
refactor tracks global variable to local variable in USong

### DIFF
--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -613,10 +613,10 @@ begin
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    if not Tracks[Track].Lines[Tracks[Track].CurrentLine].HasLength(TempR) then TempR := 0
+    if not CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].HasLength(TempR) then TempR := 0
     else TempR := (Right-Left) / TempR;
 
-    with Tracks[Track].Lines[Tracks[Track].CurrentLine] do
+    with CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine] do
     begin
       for Count := 0 to HighNote do
       begin
@@ -638,7 +638,7 @@ begin
               glColor4f(1, 1, 1, 1);        // We set alpha to 1, cause we can control the transparency through the png itself
 
             // left part
-            Rec.Left  := (StartBeat - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left + 0.5;
+            Rec.Left  := (StartBeat - CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left + 0.5;
             Rec.Right := Rec.Left + NotesW[PlayerIndex];
             Rec.Top := Top - (Tone-BaseNote)*LineSpacing/2 - NotesH[PlayerIndex];
             Rec.Bottom := Rec.Top + 2 * NotesH[PlayerIndex];
@@ -663,7 +663,7 @@ begin
 
             // middle part
             Rec.Left := Rec.Right;
-            Rec.Right := (StartBeat + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left - NotesW[PlayerIndex] - 0.5;
+            Rec.Right := (StartBeat + Duration - CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left - NotesW[PlayerIndex] - 0.5;
 
             // the left note is more right than the right note itself, sounds weird - so we fix that xD
             if Rec.Right <= Rec.Left then
@@ -740,7 +740,7 @@ begin
 
     //if Player[NrGracza].LengthNote > 0 then
     begin
-      if not Tracks[Track].Lines[Tracks[Track].CurrentLine].HasLength(TempR) then TempR := 0
+      if not CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].HasLength(TempR) then TempR := 0
       else TempR := W / TempR;
 
       for N := 0 to Player[PlayerIndex].HighNote do
@@ -748,7 +748,7 @@ begin
         with Player[PlayerIndex].Note[N] do
         begin
           // Left part of note
-          Rec.Left  := Left + (Start - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + 0.5;
+          Rec.Left  := Left + (Start - CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + 0.5;
           Rec.Right := Rec.Left + NotesW[PlayerIndex];
 
           // Draw it in half size, if not hit
@@ -761,7 +761,7 @@ begin
             NotesH2 := int(NotesH[PlayerIndex] * 0.65);
           end;
 
-          Rec.Top    := Top - (Tone-Tracks[Track].Lines[Tracks[Track].CurrentLine].BaseNote)*LineSpacing/2 - NotesH2;
+          Rec.Top    := Top - (Tone-CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].BaseNote)*LineSpacing/2 - NotesH2;
           Rec.Bottom := Rec.Top + 2 * NotesH2;
 
           // draw the left part
@@ -783,7 +783,7 @@ begin
 
           // Middle part of the note
           Rec.Left  := Rec.Right;
-          Rec.Right := Left + (Start + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR - NotesW[PlayerIndex] - 0.5;
+          Rec.Right := Left + (Start + Duration - CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR - NotesW[PlayerIndex] - 0.5;
 
           // new
           if (Start + Duration - 1 = LyricsState.CurrentBeatD) then
@@ -872,10 +872,10 @@ begin
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    if not Tracks[Track].Lines[Tracks[Track].CurrentLine].HasLength(TempR) then TempR := 0
+    if not CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].HasLength(TempR) then TempR := 0
     else TempR := (Right-Left) / TempR;
 
-    with Tracks[Track].Lines[Tracks[Track].CurrentLine] do
+    with CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine] do
     begin
       for Count := 0 to HighNote do
       begin
@@ -889,15 +889,15 @@ begin
             H := NotesH[PlayerIndex] * 1.5 + 3.5;
 
             {
-            X2 := (Start-Tracks[Track].Lines[Tracks[Track].Current].Notes[0].Start) * TempR + Left + 0.5 + 4;
+            X2 := (Start-CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].Current].Notes[0].Start) * TempR + Left + 0.5 + 4;
             X1 := X2-W;
 
-            X3 := (Start+Length-Tracks[Track].Lines[Tracks[Track].Current].Notes[0].Start) * TempR + Left - 0.5 - 4;
+            X3 := (Start+Length-CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].Current].Notes[0].Start) * TempR + Left - 0.5 - 4;
             X4 := X3+W;
             }
 
             // left
-            Rec.Right := (StartBeat - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left + 0.5 + 4;
+            Rec.Right := (StartBeat - CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left + 0.5 + 4;
             Rec.Left  := Rec.Right - W;
             Rec.Top := Top - (Tone-BaseNote)*LineSpacing/2 - H;
             Rec.Bottom := Rec.Top + 2 * H;
@@ -919,7 +919,7 @@ begin
 
             // middle part
             Rec.Left  := Rec.Right;
-            Rec.Right := (StartBeat + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left - 0.5 - 4;
+            Rec.Right := (StartBeat + Duration - CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + Left - 0.5 - 4;
 
             // the left note is more right than the right note itself, sounds weird - so we fix that xD
             if Rec.Right <= Rec.Left then
@@ -994,7 +994,7 @@ const
   BarMoveLimit = 40; // max. number of beats remaining before the bar starts to move
 begin
   // get current lyrics line and the time in beats of its first note
-  CurLine := @Tracks[CP].Lines[Tracks[CP].CurrentLine];
+  CurLine := @CurrentSong.Tracks[CP].Lines[CurrentSong.Tracks[CP].CurrentLine];
 
   // FIXME: accessing ScreenSing is not that generic
   if (CurrentSong.isDuet) and (PlayersPlay <> 1) then
@@ -1140,7 +1140,7 @@ const
 begin
 
   // get current lyrics line and the time in beats of its first note
-  CurLine := @Tracks[0].Lines[Tracks[0].CurrentLine];
+  CurLine := @CurrentSong.Tracks[0].Lines[CurrentSong.Tracks[0].CurrentLine];
 
   // FIXME: accessing ScreenSing is not that generic
   LyricEngine := ScreenJukebox.Lyrics;
@@ -1643,10 +1643,10 @@ begin
   glEnable(GL_BLEND);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-  if not Tracks[Track].Lines[Tracks[Track].CurrentLine].HasLength(TempR) then TempR := 0
+  if not CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].HasLength(TempR) then TempR := 0
   else TempR := W / TempR;
 
-  with Tracks[Track].Lines[Tracks[Track].CurrentLine] do
+  with CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine] do
   begin
     for Count := 0 to HighNote do
     begin
@@ -1663,7 +1663,7 @@ begin
         end; // case
 
         // left part
-        Rec.Left  := (StartBeat - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + X + 0.5;
+        Rec.Left  := (StartBeat - CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + X + 0.5;
         Rec.Right := Rec.Left + NotesW[0];
         Rec.Top := YBaseNote - (Tone-BaseNote)*Space/2 - NotesH[0];
         Rec.Bottom := Rec.Top + 2 * NotesH[0];
@@ -1691,7 +1691,7 @@ begin
 
         // middle part
         Rec.Left  := Rec.Right;
-        Rec.Right := (StartBeat + Duration - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + X - NotesW[0] - 0.5;
+        Rec.Right := (StartBeat + Duration - CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].Notes[0].StartBeat) * TempR + X - NotesW[0] - 0.5;
 
         If (NoteType = ntRap) or (NoteType = ntRapGolden) then
         begin
@@ -1787,23 +1787,23 @@ var
   TempR: real;
 begin
 
-  if not Tracks[Track].Lines[Tracks[Track].CurrentLine].HasLength(TempR) then TempR := 0
+  if not CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].HasLength(TempR) then TempR := 0
   else TempR := W / TempR;
 
-  if (Tracks[Track].Lines[Tracks[Track].CurrentLine].ScoreValue > 0) and ( W > 0 ) and ( (Tracks[Track].Lines[Tracks[Track].CurrentLine].EndBeat - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat) > 0 ) then
-      TempR := W / (Tracks[Track].Lines[Tracks[Track].CurrentLine].EndBeat - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat)
+  if (CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].ScoreValue > 0) and ( W > 0 ) and ( (CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].EndBeat - CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].Notes[0].StartBeat) > 0 ) then
+      TempR := W / (CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].EndBeat - CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].Notes[0].StartBeat)
     else
       TempR := 0;
   glEnable(GL_BLEND);
   glBegin(GL_LINES);
-  for Count := Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat to Tracks[Track].Lines[Tracks[Track].CurrentLine].EndBeat do
+  for Count := CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].Notes[0].StartBeat to CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].EndBeat do
   begin
-    if (Count mod Tracks[Track].Resolution) = Tracks[Track].NotesGAP then
+    if (Count mod CurrentSong.Tracks[Track].Resolution) = CurrentSong.Tracks[Track].NotesGAP then
       glColor4f(0, 0, 0, 1)
     else
       glColor4f(0, 0, 0, 0.3);
-    glVertex2f(X + TempR * (Count - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat), Y);
-    glVertex2f(X + TempR * (Count - Tracks[Track].Lines[Tracks[Track].CurrentLine].Notes[0].StartBeat), Y + H);
+    glVertex2f(X + TempR * (Count - CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].Notes[0].StartBeat), Y);
+    glVertex2f(X + TempR * (Count - CurrentSong.Tracks[Track].Lines[CurrentSong.Tracks[Track].CurrentLine].Notes[0].StartBeat), Y + H);
   end;
   glEnd;
   glDisable(GL_BLEND);

--- a/src/base/UEditorLyrics.pas
+++ b/src/base/UEditorLyrics.pas
@@ -37,6 +37,7 @@ uses
   SysUtils,
   dglOpenGL,
   UMusic,
+  UNote,
   UTexture;
 
 type
@@ -219,12 +220,12 @@ var
   CurrentNote: integer;
 begin
   Clear;
-  if (Length(Tracks[CurrentTrack].Lines[CurrentLine].Notes) > 0) then
+  if (Length(CurrentSong.Tracks[CurrentTrack].Lines[CurrentLine].Notes) > 0) then
   begin
-    for CurrentNote := 0 to Tracks[CurrentTrack].Lines[CurrentLine].HighNote do
+    for CurrentNote := 0 to CurrentSong.Tracks[CurrentTrack].Lines[CurrentLine].HighNote do
     begin
-      Italic := Tracks[CurrentTrack].Lines[CurrentLine].Notes[CurrentNote].NoteType = ntFreestyle;
-      AddWord(Tracks[CurrentTrack].Lines[CurrentLine].Notes[CurrentNote].Text);
+      Italic := CurrentSong.Tracks[CurrentTrack].Lines[CurrentLine].Notes[CurrentNote].NoteType = ntFreestyle;
+      AddWord(CurrentSong.Tracks[CurrentTrack].Lines[CurrentLine].Notes[CurrentNote].Text);
     end;
   {end else
   begin

--- a/src/base/UFiles.pas
+++ b/src/base/UFiles.pas
@@ -69,11 +69,11 @@ procedure ResetSingTemp;
 var
   Count:  integer;
 begin
-  SetLength(Tracks, Length(Player));
+  SetLength(CurrentSong.Tracks, Length(Player));
   for Count := 0 to High(Player) do begin
-    SetLength(Tracks[Count].Lines, 1);
-    SetLength(Tracks[Count].Lines[0].Notes, 0);
-    Tracks[Count].Lines[0].Lyric := '';
+    SetLength(CurrentSong.Tracks[Count].Lines, 1);
+    SetLength(CurrentSong.Tracks[Count].Lines[0].Notes, 0);
+    CurrentSong.Tracks[Count].Lines[0].Lyric := '';
     Player[Count].Score := 0;
     Player[Count].LengthNote := 0;
     Player[Count].HighNote := -1;

--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -629,11 +629,8 @@ type
   end;
 
 var
-  // TODO: JB --- THESE SHOULD NOT BE GLOBAL
-  Tracks: array of TLines;
   LyricsState: TLyricsState;
   SoundLib: TSoundLibrary;
-
 
 procedure InitializeSound;
 procedure InitializeVideo;
@@ -1431,12 +1428,12 @@ var
 begin
   found := false;
 
-  for LineIndex := 0 to High(Tracks[0].Lines) do
+  for LineIndex := 0 to High(CurrentSong.Tracks[0].Lines) do
   begin
-    for NoteIndex := 0 to High(Tracks[0].Lines[LineIndex].Notes) do
+    for NoteIndex := 0 to High(CurrentSong.Tracks[0].Lines[LineIndex].Notes) do
     begin
-      if (beat >= Tracks[0].Lines[LineIndex].Notes[NoteIndex].StartBeat) and
-         (beat <= Tracks[0].Lines[LineIndex].Notes[NoteIndex].StartBeat + Tracks[0].Lines[LineIndex].Notes[NoteIndex].Duration) then
+      if (beat >= CurrentSong.Tracks[0].Lines[LineIndex].Notes[NoteIndex].StartBeat) and
+         (beat <= CurrentSong.Tracks[0].Lines[LineIndex].Notes[NoteIndex].StartBeat + CurrentSong.Tracks[0].Lines[LineIndex].Notes[NoteIndex].Duration) then
       begin
         Result.track := 0;
         Result.line := LineIndex;
@@ -1452,12 +1449,12 @@ begin
 
   if CurrentSong.isDuet and (PlayersPlay <> 1) then
   begin
-    for LineIndex := 0 to High(Tracks[1].Lines) do
+    for LineIndex := 0 to High(CurrentSong.Tracks[1].Lines) do
     begin
-      for NoteIndex := 0 to High(Tracks[1].Lines[LineIndex].Notes) do
+      for NoteIndex := 0 to High(CurrentSong.Tracks[1].Lines[LineIndex].Notes) do
       begin
-        if (beat >= Tracks[1].Lines[LineIndex].Notes[NoteIndex].StartBeat) and
-          (beat <= Tracks[1].Lines[LineIndex].Notes[NoteIndex].StartBeat + Tracks[1].Lines[LineIndex].Notes[NoteIndex].Duration) then
+        if (beat >= CurrentSong.Tracks[1].Lines[LineIndex].Notes[NoteIndex].StartBeat) and
+          (beat <= CurrentSong.Tracks[1].Lines[LineIndex].Notes[NoteIndex].StartBeat + CurrentSong.Tracks[1].Lines[LineIndex].Notes[NoteIndex].Duration) then
         begin
           Result.track := 1;
           Result.line := LineIndex;
@@ -1474,11 +1471,11 @@ begin
 
   min := high(integer);
   //second try (approximating)
-  for LineIndex := 0 to High(Tracks[0].Lines) do
+  for LineIndex := 0 to High(CurrentSong.Tracks[0].Lines) do
   begin
-    for NoteIndex := 0 to High(Tracks[0].Lines[LineIndex].Notes) do
+    for NoteIndex := 0 to High(CurrentSong.Tracks[0].Lines[LineIndex].Notes) do
     begin
-      diff := abs(Tracks[0].Lines[LineIndex].Notes[NoteIndex].StartBeat - beat);
+      diff := abs(CurrentSong.Tracks[0].Lines[LineIndex].Notes[NoteIndex].StartBeat - beat);
       if diff < min then
       begin
         Result.track := 0;
@@ -1491,11 +1488,11 @@ begin
 
   if CurrentSong.isDuet and (PlayersPlay <> 1) then
   begin
-    for LineIndex := 0 to High(Tracks[1].Lines) do
+    for LineIndex := 0 to High(CurrentSong.Tracks[1].Lines) do
     begin
-      for NoteIndex := 0 to High(Tracks[1].Lines[LineIndex].Notes) do
+      for NoteIndex := 0 to High(CurrentSong.Tracks[1].Lines[LineIndex].Notes) do
       begin
-        diff := abs(Tracks[1].Lines[LineIndex].Notes[NoteIndex].StartBeat - beat);
+        diff := abs(CurrentSong.Tracks[1].Lines[LineIndex].Notes[NoteIndex].StartBeat - beat);
         if diff < min then
         begin
           Result.track := 1;

--- a/src/base/UNote.pas
+++ b/src/base/UNote.pas
@@ -318,20 +318,19 @@ begin
     TrackIndex := CountGr;
 
     // old parts
-    LyricsState.OldLine := Tracks[TrackIndex].CurrentLine;
+    LyricsState.OldLine := CurrentSong.Tracks[TrackIndex].CurrentLine;
 
     // choose current parts
-    for LineIndex := 0 to Tracks[TrackIndex].High do
+    for LineIndex := 0 to CurrentSong.Tracks[TrackIndex].High do
     begin
-      if LyricsState.CurrentBeat >= Tracks[TrackIndex].Lines[LineIndex].StartBeat then
-        Tracks[TrackIndex].CurrentLine := LineIndex;
+      if LyricsState.CurrentBeat >= CurrentSong.Tracks[TrackIndex].Lines[LineIndex].StartBeat then
+        CurrentSong.Tracks[TrackIndex].CurrentLine := LineIndex;
     end;
 
     // clean player note if there is a new line
     // (optimization on halfbeat time)
-    if Tracks[TrackIndex].CurrentLine <> LyricsState.OldLine then
+    if CurrentSong.Tracks[TrackIndex].CurrentLine <> LyricsState.OldLine then
       NewSentence(TrackIndex, Screen);
-
   end; // for CountGr
 
   // make some operations on clicks
@@ -356,18 +355,18 @@ begin
   begin;
     CP := CountGr;
     // old parts
-    LyricsState.OldLine := Tracks[CP].CurrentLine;
+    LyricsState.OldLine := CurrentSong.Tracks[CP].CurrentLine;
 
     // choose current parts
-    for Count := 0 to Tracks[CP].High do
+    for Count := 0 to CurrentSong.Tracks[CP].High do
     begin
-      if LyricsState.CurrentBeat >= Tracks[CP].Lines[Count].StartBeat then
-        Tracks[CP].CurrentLine := Count;
+      if LyricsState.CurrentBeat >= CurrentSong.Tracks[CP].Lines[Count].StartBeat then
+        CurrentSong.Tracks[CP].CurrentLine := Count;
     end;
   end; // for CountGr
 
   // on sentence change...
-  Screen.onSentenceChange(Tracks[0].CurrentLine);
+  Screen.onSentenceChange(CurrentSong.Tracks[0].CurrentLine);
 end;
 
 procedure NewSentence(CP: integer; Screen: TScreenSingController);
@@ -385,7 +384,7 @@ begin
     end;
   end;
 
-  Screen.onSentenceChange(CP, Tracks[CP].CurrentLine)
+  Screen.onSentenceChange(CP, CurrentSong.Tracks[CP].CurrentLine)
 end;
 
 procedure NewBeatClick;
@@ -397,15 +396,15 @@ begin
   if not (CurrentSong.isDuet) or (PlayersPlay = 1) then
   begin
     if ((Ini.BeatClick = 1) and
-        ((LyricsState.CurrentBeatC + Tracks[0].Resolution + Tracks[0].NotesGAP) mod Tracks[0].Resolution = 0)) then
+        ((LyricsState.CurrentBeatC + CurrentSong.Tracks[0].Resolution + CurrentSong.Tracks[0].NotesGAP) mod CurrentSong.Tracks[0].Resolution = 0)) then
     begin
       AudioPlayback.PlaySound(SoundLib.Click);
     end;
 
-    for Count := 0 to Tracks[0].Lines[Tracks[0].CurrentLine].HighNote do
+    for Count := 0 to CurrentSong.Tracks[0].Lines[CurrentSong.Tracks[0].CurrentLine].HighNote do
     begin
       //basisbit todo
-      if (Tracks[0].Lines[Tracks[0].CurrentLine].Notes[Count].StartBeat = LyricsState.CurrentBeatC) then
+      if (CurrentSong.Tracks[0].Lines[CurrentSong.Tracks[0].CurrentLine].Notes[Count].StartBeat = LyricsState.CurrentBeatC) then
       begin
         // click assist
         if Ini.ClickAssist = 1 then
@@ -444,18 +443,18 @@ begin
     begin
       CP := J;
 
-      StartLine := Tracks[CP].CurrentLine - 1;
+      StartLine := CurrentSong.Tracks[CP].CurrentLine - 1;
       if StartLine < 0 then
         StartLine := 0;
       EndLine := StartLine + 1;
-      if EndLine > Tracks[CP].High then
-        EndLine := Tracks[CP].High;
+      if EndLine > CurrentSong.Tracks[CP].High then
+        EndLine := CurrentSong.Tracks[CP].High;
 
       NewNote(CP, Screen);
 
       for I := StartLine to EndLine do
       begin
-        with Tracks[CP].Lines[I] do
+        with CurrentSong.Tracks[CP].Lines[I] do
         begin
           if (HighNote >= 0) then
           begin
@@ -497,14 +496,14 @@ begin
   NoteHit := false;
 
   // TODO: add duet mode support
-  // use Tracks[LineSetIndex] with LineSetIndex depending on the current player
+  // use CurrentSong.Tracks[LineSetIndex] with LineSetIndex depending on the current player
 
   // count min and max sentence range for checking
   // (detection is delayed to the notes we see on the screen)
-  SentenceMin := Tracks[CP].CurrentLine-1;
+  SentenceMin := CurrentSong.Tracks[CP].CurrentLine-1;
   if (SentenceMin < 0) then
     SentenceMin := 0;
-  SentenceMax := Tracks[CP].CurrentLine;
+  SentenceMax := CurrentSong.Tracks[CP].CurrentLine;
 
   for ActualBeat := LyricsState.OldBeatD+1 to LyricsState.CurrentBeatD do
   begin
@@ -518,7 +517,7 @@ begin
         SentenceDetected := SentenceMin;
         for SentenceIndex := SentenceMin to SentenceMax do
         begin
-          Line := @Tracks[CP].Lines[SentenceIndex];
+          Line := @CurrentSong.Tracks[CP].Lines[SentenceIndex];
           for LineFragmentIndex := 0 to Line.HighNote do
           begin
             CurrentLineFragment := @Line.Notes[LineFragmentIndex];
@@ -560,7 +559,7 @@ begin
         if (CurrentSound.ToneValid and NoteAvailable) then
         begin
           CurrentNoteType := ntNormal;
-          Line := @Tracks[CP].Lines[SentenceDetected];
+          Line := @CurrentSong.Tracks[CP].Lines[SentenceDetected];
           // process until last note
           for LineFragmentIndex := 0 to Line.HighNote do
           begin
@@ -610,7 +609,7 @@ begin
                 // gets for a hit of one beat of a normal note
                 // CurNotePoints is the amount of points that is meassured
                 // for a hit of the note per full beat
-                CurNotePoints := (MaxSongPoints / Tracks[CP].ScoreValue) * ScoreFactor[CurrentLineFragment.NoteType];
+                CurNotePoints := (MaxSongPoints / CurrentSong.Tracks[CP].ScoreValue) * ScoreFactor[CurrentLineFragment.NoteType];
 
                 case CurrentLineFragment.NoteType of
                   ntNormal:    CurrentPlayer.Score       := CurrentPlayer.Score       + CurNotePoints;

--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -62,7 +62,8 @@ uses
   UTexture,
   UTextEncoding,
   UUnicodeStringHelper,
-  UUnicodeUtils;
+  UUnicodeUtils,
+  UMusic; // for TLines
 
 const
   DEFAULT_RESOLUTION = 4; // default #RESOLUTION
@@ -132,6 +133,8 @@ type
     function GetFolderCategory(const aFileName: IPath): UTF8String;
     function FindSongFile(Dir: IPath; Mask: UTF8String): IPath;
     function LoadOpenedSong(SongFile: TTextFileStream; FileNamePath: IPath; DuetChange: boolean; RapToFreestyle: boolean; OutOfBoundsToFreestyle: boolean; AudioLength: real): boolean;
+  public
+    Tracks: array of TLines; // Per-song track storage
   public
     Path:         IPath; // kust path component of file (only set if file was found)
     Folder:       UTF8String; // for sorting by folder (only set if file was found)
@@ -248,7 +251,6 @@ uses
   UIni,
   UPathUtils,
   USongs,
-  UMusic,  //needed for Tracks
   UNote;   //needed for Player
 
 const
@@ -687,7 +689,7 @@ begin
       SetLength(Tracks, 0);
       if (CurLine[1] = 'P') then
       begin
-        CurrentSong.isDuet := true;
+        Self.isDuet := true;
         SetLength(Tracks, 2);
         CurrentTrack := -1;
       end
@@ -762,7 +764,7 @@ begin
           // sets the rap icon if the song has rap notes
           if(Param0 in ['R', 'G']) then
           begin
-            CurrentSong.hasRap := true;
+            Self.hasRap := true;
           end;
           // read notes
           Param1 := ParseLyricIntParam(CurLine, LinePos);
@@ -781,13 +783,13 @@ begin
             Param0 := 'F';
           end;
 
-          if (OutOfBoundsToFreestyle and (((CurrentSong.Start > 0) and (GetTimeFromBeat(Param1, Self) < CurrentSong.Start)) or ((AudioLength > 0) and (GetTimeFromBeat(Param1 + Param3, Self) >= AudioLength)))) then
+          if (OutOfBoundsToFreestyle and (((Self.Start > 0) and (GetTimeFromBeat(Param1, Self) < Self.Start)) or ((AudioLength > 0) and (GetTimeFromBeat(Param1 + Param3, Self) >= AudioLength)))) then
           begin
             // convert to freestyle note
             Param0 := 'F';
             Log.LogWarn(
               Format('Note at "%s %d %d %d %s" is before audio start (%.2f < %.2f) or after audio end (%.2f >= %.2f) -> converted to freestyle note',
-              [Param0, Param1, Param2, Param3, ParamLyric, GetTimeFromBeat(Param1, Self), CurrentSong.Start, GetTimeFromBeat(Param1 + Param3, Self), AudioLength]),
+              [Param0, Param1, Param2, Param3, ParamLyric, GetTimeFromBeat(Param1, Self), Self.Start, GetTimeFromBeat(Param1 + Param3, Self), AudioLength]),
               'TSong.LoadSong'
             );
           end;
@@ -841,7 +843,7 @@ begin
   begin
     if ((Both) or (TrackIndex = 0)) then
     begin
-      if (Length(Tracks[TrackIndex].Lines) < 1) then
+  if (Length(Tracks[TrackIndex].Lines) < 1) then
       begin
         LastError := 'ERROR_CORRUPT_SONG_NO_BREAKS';
         Log.LogError('Error loading file: Can''t find any linebreaks in "' + FileNamePath.ToNative + '"');
@@ -854,7 +856,7 @@ begin
         Tracks[TrackIndex].High := Tracks[TrackIndex].High - 1;
         Tracks[TrackIndex].Number := Tracks[TrackIndex].Number - 1;
         // HACK DUET ERROR
-        if not (CurrentSong.isDuet) then
+        if not Self.isDuet then
           Log.LogError('Error loading Song, sentence w/o note found in last line before E: ' + FileNamePath.ToNative);
       end;
     end;
@@ -1548,7 +1550,7 @@ begin
   else
   begin //use old line if it there were no notes added since last call of NewSentence
     // HACK DUET ERROR
-    if not (CurrentSong.isDuet) then
+    if not Self.isDuet then
       Log.LogError('Error loading Song, sentence w/o note found in line ' +
                  InttoStr(FileLineNo) + ': ' + Filename.ToNative);
   end;
@@ -1682,8 +1684,8 @@ begin
     found_end := false;
 
     //set end if duration > MEDLEY_MIN_DURATION
-    if GetTimeFromBeat(self.Medley.StartBeat) + MEDLEY_MIN_DURATION >
-      GetTimeFromBeat(self.Medley.EndBeat) then
+    if GetTimeFromBeat(self.Medley.StartBeat, self) + MEDLEY_MIN_DURATION >
+      GetTimeFromBeat(self.Medley.EndBeat, self) then
     begin
       found_end := true;
     end;
@@ -1697,9 +1699,9 @@ begin
         len_notes := length(Tracks[0].Lines[I].Notes);
         for J := 0 to len_notes - 1 do
         begin
-          if GetTimeFromBeat(self.Medley.StartBeat) + MEDLEY_MIN_DURATION >
+          if GetTimeFromBeat(self.Medley.StartBeat, self) + MEDLEY_MIN_DURATION >
             GetTimeFromBeat(Tracks[0].Lines[I].Notes[J].StartBeat +
-            Tracks[0].Lines[I].Notes[J].Duration) then
+            Tracks[0].Lines[I].Notes[J].Duration, self) then
           begin
             found_end := true;
             self.Medley.EndBeat := Tracks[0].Lines[I].Notes[len_notes-1].StartBeat +
@@ -1724,7 +1726,7 @@ begin
   if self.PreviewStart = 0 then
   begin
     if self.Medley.Source = msCalculated then
-      self.PreviewStart := GetTimeFromBeat(self.Medley.StartBeat);
+      self.PreviewStart := GetTimeFromBeat(self.Medley.StartBeat, self);
   end;
 end;
 
@@ -1870,7 +1872,7 @@ begin
     Result := Self.ReadTxTHeader(SongFile, ReadCustomTags);
 
     //Load Song for Medley Tags
-    CurrentSong := self;
+    CurrentSong := Self;
     Result := Result and LoadOpenedSong(SongFile, FileNamePath, DuetChange, RapToFreestyle, OutOfBoundsToFreestyle, AudioLength);
 
     if Result then

--- a/src/lua/ULuaScreenSing.pas
+++ b/src/lua/ULuaScreenSing.pas
@@ -441,7 +441,7 @@ function ULuaScreenSing_GetSongLines(L: Plua_State): Integer; cdecl;
     I, J: Integer;
 begin
   Result := 1;
-  if  (Length(Tracks) >= 1) then
+  if  (Length(CurrentSong.Tracks) >= 1) then
   begin
     lua_ClearStack(L);
 
@@ -449,10 +449,10 @@ begin
       luaL_Error(L, PChar('can''t allocate enough stack space in ULuaScreenSing_GetSongLines'));
 
     // lines array table
-    lua_CreateTable(L, Length(Tracks[0].Lines), 0);
+    lua_CreateTable(L, Length(CurrentSong.Tracks[0].Lines), 0);
 
-    for I := 0 to High(Tracks[0].Lines) do
-    with Tracks[0].Lines[I] do
+    for I := 0 to High(CurrentSong.Tracks[0].Lines) do
+    with CurrentSong.Tracks[0].Lines[I] do
     begin
       lua_pushInteger(L, I+1);
 

--- a/src/screens/UScreenJukebox.pas
+++ b/src/screens/UScreenJukebox.pas
@@ -2457,8 +2457,8 @@ begin
     (not Lyrics.IsQueueFull) do
   begin
     // add the next line to the queue or a dummy if no more lines are available
-    if (Lyrics.LineCounter <= High(Tracks[0].Lines)) then
-      Lyrics.AddLine(@Tracks[0].Lines[Lyrics.LineCounter])
+    if (Lyrics.LineCounter <= High(CurrentSong.Tracks[0].Lines)) then
+      Lyrics.AddLine(@CurrentSong.Tracks[0].Lines[Lyrics.LineCounter])
     else
       Lyrics.AddLine(nil);
   end;
@@ -2696,9 +2696,9 @@ begin
 
   // initialize lyrics by filling its queue
   while (not Lyrics.IsQueueFull) and
-        (Lyrics.LineCounter <= High(Tracks[0].Lines)) do
+        (Lyrics.LineCounter <= High(CurrentSong.Tracks[0].Lines)) do
   begin
-    Lyrics.AddLine(@Tracks[0].Lines[Lyrics.LineCounter]);
+    Lyrics.AddLine(@CurrentSong.Tracks[0].Lines[Lyrics.LineCounter]);
   end;
 
   Max := 9;

--- a/src/screens/UScreenOptionsJukebox.pas
+++ b/src/screens/UScreenOptionsJukebox.pas
@@ -46,6 +46,7 @@ uses
   UMenuText,
   UMusic,
   UPath,
+  UNote,
   UThemes,
   sdl2,
   TextGL;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -1093,7 +1093,7 @@ begin
 
     //medley start and end timestamps
     StartNote := FindNote(CurrentSong.Medley.StartBeat - round(CurrentSong.BPM[0].BPM*CurrentSong.Medley.FadeIn_time/60));
-    MedleyStart := GetTimeFromBeat(Tracks[0].Lines[StartNote.line].Notes[0].StartBeat);
+    MedleyStart := GetTimeFromBeat(CurrentSong.Tracks[0].Lines[StartNote.line].Notes[0].StartBeat);
 
     //check Medley-Start
     if (MedleyStart+CurrentSong.Medley.FadeIn_time*0.5>GetTimeFromBeat(CurrentSong.Medley.StartBeat)) then
@@ -1223,25 +1223,25 @@ begin
   begin
     // initialize lyrics by filling its queue
     while (not LyricsDuetP1.IsQueueFull) and
-          (LyricsDuetP1.LineCounter <= High(Tracks[0].Lines)) do
+          (LyricsDuetP1.LineCounter <= High(CurrentSong.Tracks[0].Lines)) do
     begin
-      LyricsDuetP1.AddLine(@Tracks[0].Lines[LyricsDuetP1.LineCounter]);
+      LyricsDuetP1.AddLine(@CurrentSong.Tracks[0].Lines[LyricsDuetP1.LineCounter]);
     end;
 
     // initialize lyrics by filling its queue
     while (not LyricsDuetP2.IsQueueFull) and
-          (LyricsDuetP2.LineCounter <= High(Tracks[1].Lines)) do
+          (LyricsDuetP2.LineCounter <= High(CurrentSong.Tracks[1].Lines)) do
     begin
-      LyricsDuetP2.AddLine(@Tracks[1].Lines[LyricsDuetP2.LineCounter]);
+      LyricsDuetP2.AddLine(@CurrentSong.Tracks[1].Lines[LyricsDuetP2.LineCounter]);
     end;
   end
   else
   begin
     // initialize lyrics by filling its queue
     while (not Lyrics.IsQueueFull) and
-          (Lyrics.LineCounter <= High(Tracks[0].Lines)) do
+          (Lyrics.LineCounter <= High(CurrentSong.Tracks[0].Lines)) do
     begin
-      Lyrics.AddLine(@Tracks[0].Lines[Lyrics.LineCounter]);
+      Lyrics.AddLine(@CurrentSong.Tracks[0].Lines[Lyrics.LineCounter]);
     end;
   end;
 
@@ -1257,18 +1257,18 @@ begin
 
   if (CurrentSong.isDuet) and (PlayersPlay <> 1) then
   begin
-    for Index := Low(Tracks[1].Lines) to High(Tracks[1].Lines) do
-    if Tracks[1].Lines[Index].ScoreValue = 0 then
-      Inc(NumEmptySentences[1]);
+    for Index := Low(CurrentSong.Tracks[1].Lines) to High(CurrentSong.Tracks[1].Lines) do
+      if CurrentSong.Tracks[1].Lines[Index].ScoreValue = 0 then
+        Inc(NumEmptySentences[1]);
 
-    for Index := Low(Tracks[0].Lines) to High(Tracks[0].Lines) do
-    if Tracks[0].Lines[Index].ScoreValue = 0 then
-      Inc(NumEmptySentences[0]);
+    for Index := Low(CurrentSong.Tracks[0].Lines) to High(CurrentSong.Tracks[0].Lines) do
+      if CurrentSong.Tracks[0].Lines[Index].ScoreValue = 0 then
+        Inc(NumEmptySentences[0]);
   end
   else
   begin
-    for Index := Low(Tracks[0].Lines) to High(Tracks[0].Lines) do
-      if Tracks[0].Lines[Index].ScoreValue = 0 then
+    for Index := Low(CurrentSong.Tracks[0].Lines) to High(CurrentSong.Tracks[0].Lines) do
+      if CurrentSong.Tracks[0].Lines[Index].ScoreValue = 0 then
         Inc(NumEmptySentences[0]);
   end;
 
@@ -1284,9 +1284,9 @@ var
   i1: integer;
 
 begin
-  for i1 := 0 to High(Tracks) do
+  for i1 := 0 to High(CurrentSong.Tracks) do
   begin
-    Tracks[i1].CurrentLine := 0;
+    CurrentSong.Tracks[i1].CurrentLine := 0;
     OnSentenceChange(i1, 0);
   end;
 end;
@@ -1707,7 +1707,7 @@ const
   // TODO: move this to a better place
   MAX_LINE_RATING = 8;        // max. rating for singing performance
 begin
-  Line := @Tracks[Track].Lines[SentenceIndex];
+  Line := @CurrentSong.Tracks[Track].Lines[SentenceIndex];
 
   // check for empty sentence
   if Line.ScoreValue <= 0 then
@@ -1720,7 +1720,7 @@ begin
     MaxSongScore := MAX_SONG_SCORE - MAX_SONG_LINE_BONUS;
 
   // Note: ScoreValue is the sum of all note values of the song
-  MaxLineScore := MaxSongScore * (Line.ScoreValue / Tracks[Track].ScoreValue);
+  MaxLineScore := MaxSongScore * (Line.ScoreValue / CurrentSong.Tracks[Track].ScoreValue);
 
   for PlayerIndex := 0 to High(Player) do
   begin
@@ -1755,7 +1755,7 @@ begin
       if Ini.LineBonus > 0 then
       begin
         // line-bonus points (same for each line, no matter how long the line is)
-        LineBonus := MAX_SONG_LINE_BONUS / (Length(Tracks[Track].Lines) -
+        LineBonus := MAX_SONG_LINE_BONUS / (Length(CurrentSong.Tracks[Track].Lines) -
           NumEmptySentences[Track]);
         // apply line-bonus
         CurrentPlayer.ScoreLine :=
@@ -1821,9 +1821,9 @@ begin
     (not tmp_Lyric.IsQueueFull) do
   begin
     // add the next line to the queue or a dummy if no more lines are available
-    if (tmp_Lyric.LineCounter <= High(Tracks[Track].Lines)) then
+    if (tmp_Lyric.LineCounter <= High(CurrentSong.Tracks[Track].Lines)) then
     begin
-      tmp_Lyric.AddLine(@Tracks[Track].Lines[tmp_Lyric.LineCounter]);
+      tmp_Lyric.AddLine(@CurrentSong.Tracks[Track].Lines[tmp_Lyric.LineCounter]);
     end
     else
       tmp_Lyric.AddLine(nil);

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -1277,9 +1277,9 @@ begin
   SongDuration := SongEnd - SongStart;
   gapInBeats := CurrentSong.BPM[0].BPM*CurrentSong.GAP/1000/60;
   // draw sentence boxes
-  for CurrentTrack := 0 to High(Tracks) do //for P1 of duet or solo lyrics, P2 of duet,..
+  for CurrentTrack := 0 to High(CurrentSong.Tracks) do //for P1 of duet or solo lyrics, P2 of duet,..
   begin
-    numLines := Length(Tracks[CurrentTrack].Lines); //Lyric lines
+    numLines := Length(CurrentSong.Tracks[CurrentTrack].Lines); //Lyric lines
     //set color to player.color
     if (CurrentTrack = 0) then
       glColor4f(GetLyricColor(Ini.SingColor[0]).R, GetLyricColor(Ini.SingColor[0]).G, GetLyricColor(Ini.SingColor[0]).B, 0.6)
@@ -1289,12 +1289,12 @@ begin
     glbegin(gl_quads);
     for LineIndex := 0 to numLines - 1 do
     begin
-      if (Tracks[CurrentTrack].Lines[LineIndex].Notes = nil) then Continue;
-      if (ScreenSong.Mode = smMedley) and (Tracks[CurrentTrack].Lines[LineIndex].Notes[0].StartBeat < CurrentSong.Medley.StartBeat) then Continue;
-      pos := (gapInBeats + Tracks[CurrentTrack].Lines[LineIndex].Notes[0].StartBeat - SongStart) / SongDuration*w;
-      br := (Tracks[CurrentTrack].Lines[LineIndex].Notes[Tracks[CurrentTrack].Lines[LineIndex].HighNote].StartBeat +
-                Tracks[CurrentTrack].Lines[LineIndex].Notes[Tracks[CurrentTrack].Lines[LineIndex].HighNote].Duration -
-                Tracks[CurrentTrack].Lines[LineIndex].Notes[0].StartBeat) / SongDuration*w; //br = last note of sentence position + its duration - first note of sentence position
+      if (CurrentSong.Tracks[CurrentTrack].Lines[LineIndex].Notes = nil) then Continue;
+      if (ScreenSong.Mode = smMedley) and (CurrentSong.Tracks[CurrentTrack].Lines[LineIndex].Notes[0].StartBeat < CurrentSong.Medley.StartBeat) then Continue;
+      pos := (gapInBeats + CurrentSong.Tracks[CurrentTrack].Lines[LineIndex].Notes[0].StartBeat - SongStart) / SongDuration*w;
+      br := (CurrentSong.Tracks[CurrentTrack].Lines[LineIndex].Notes[CurrentSong.Tracks[CurrentTrack].Lines[LineIndex].HighNote].StartBeat +
+                CurrentSong.Tracks[CurrentTrack].Lines[LineIndex].Notes[CurrentSong.Tracks[CurrentTrack].Lines[LineIndex].HighNote].Duration -
+                CurrentSong.Tracks[CurrentTrack].Lines[LineIndex].Notes[0].StartBeat) / SongDuration*w;  //br = last note of sentence position + its duration - first note of sentence position
 
       //draw a square
       glVertex2f(x+pos, y); //left top


### PR DESCRIPTION
So far the Tracks variable was a global variable. This makes it impossible to work with 2 songs simultaneously anywhere in the code. It is now a member variable in USong, where it belongs. This is a refactor commit in preparation for #1098 