### PR TITLE
change TSelectSlide.Lines to an integer

### DIFF
--- a/src/menu/UMenuSelectSlide.pas
+++ b/src/menu/UMenuSelectSlide.pas
@@ -70,7 +70,7 @@ type
       PData:            ^integer;
 
       //For automatically Setting LineCount
-      Lines: byte;
+      Lines: integer;
 
       //Arrows on/off
       showArrows: boolean;      //default is false


### PR DESCRIPTION
using a byte for this is irrelevant optimization

context: this change doesn't really do anything in the current codebase, but locally I run a bunch of resolution hacks which can cause this value to become bigger than 255. so _yes_ it's currently a me-only issue, but also one that took me and complexlogic like 25 minutes to figure out why the hell it was causing range errors on this line:

`Lines := floor((TextureSBG.W - MinSideSpacing * 2) / (maxlength + MinItemSpacing));`

this isn't super critical code anyway, we can use sane types here.