### PR TITLE
Fix Preview Fading Setting

### DIFF
--- a/src/screens/UScreenOptionsSound.pas
+++ b/src/screens/UScreenOptionsSound.pas
@@ -111,7 +111,7 @@ begin
         InteractPrev;
       SDLK_RIGHT:
       begin
-        if (SelInteraction >= 0) and (SelInteraction < 6) then
+        if (SelInteraction >= 0) and (SelInteraction <= 6) then
         begin
           AudioPlayback.PlaySound(SoundLib.Option);
           InteractInc;
@@ -119,7 +119,7 @@ begin
       end;
       SDLK_LEFT:
       begin
-        if (SelInteraction >= 0) and (SelInteraction < 6) then
+        if (SelInteraction >= 0) and (SelInteraction <= 6) then
         begin
           AudioPlayback.PlaySound(SoundLib.Option);
           InteractDec;


### PR DESCRIPTION
When I removed the test widgets in #1094 before it was merged, the maximum interaction number was off by one, so now the preview fade time setting can't be adjusted in the menu. This PR fixes the issue.