### PR TITLE
Fix Audio Playback Crash

### DIFF
--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -133,7 +133,7 @@ type
       // state-vars for AudioCallback (locked by DecoderLock)
       fAudioBufferPos:  integer;
       fAudioBufferSize: integer;
-      fAudioBuffer:     PByteArray;
+      fAudioBuffer:     PByte;
       fAudioBufferFrame: PAVFrame;
 
       fFilename: IPath;
@@ -1118,7 +1118,7 @@ begin
       if(got_frame_ptr <> 0) then
       begin
         DataSize := fAudioBufferFrame.nb_samples * fBytesPerSample;
-        fAudioBuffer := PByteArray(fAudioBufferFrame.data[0]);
+        fAudioBuffer := fAudioBufferFrame.data[0];
       end
       else
         DataSize := 0;


### PR DESCRIPTION
When compiled with `-Ciro`, some audio files are causing the game to crash with `ERangeError` during playback.

The reason is because the FFmpeg-provided audio buffer is typecasted to a pointer to the Pascal type [TByteArray](https://www.freepascal.org/docs-html/rtl/sysutils/tbytearray.html), which is a static array type with a maximum index value of 32767. However, the FFmpeg audio buffer is dynamically allocated and does not have a fixed size.

If the size of the FFmpeg buffer exceeds 32768 (only happens for some files), the compiler incorrectly believes that the program is exceeding the bounds of the audio buffer when copying data past an offset of 32767, and raises the exception. Switching `fAudioBuffer` to type `PByte`, which corresponds to the underlying FFmpeg audio buffer type (dynamically allocated array), fixes the issue.

