### PR TITLE
Improve loading time: do not look for automatic covers/backgrounds + defer note checking until starting a song

### DIFF
--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -111,6 +111,8 @@ type
   TSong = class
   private
     FileLineNo  : integer;  // line, which is read last, for error reporting
+    FMD5        : string;
+    FMD5Cached  : boolean;
 
     function DecodeFilename(Filename: RawByteString): IPath;
     procedure ParseNote(Track: integer; TypeP: char; StartP, DurationP, NoteP: integer; LyricS: UTF8String; RapToFreestyle: boolean);
@@ -126,15 +128,15 @@ type
     function ReadTXTHeader(SongFile: TTextFileStream; ReadCustomTags: Boolean): boolean;
 
     function GetFolderCategory(const aFileName: IPath): UTF8String;
-    function FindSongFile(Dir: IPath; Mask: UTF8String): IPath;
     function LoadOpenedSong(SongFile: TTextFileStream; FileNamePath: IPath; DuetChange: boolean; RapToFreestyle: boolean; OutOfBoundsToFreestyle: boolean; AudioLength: real): boolean;
+    function GetMD5: string;
+    procedure SetMD5(const Value: string);
   public
     Tracks: array of TLines; // Per-song track storage
   public
     Path:         IPath; // kust path component of file (only set if file was found)
     Folder:       UTF8String; // for sorting by folder (only set if file was found)
     FileName:     IPath; // just name component of file (only set if file was found)
-    MD5:          string; //MD5 Hash of Current Song
 
     FormatVersion: TVersion;
 
@@ -206,13 +208,14 @@ type
     LastError:  AnsiString;
     function    GetErrorLineNo: integer;
     property    ErrorLineNo: integer read GetErrorLineNo;
+    property    MD5: string read GetMD5 write SetMD5; //MD5 Hash of Current Song
 
 
     constructor Create(); overload;
     constructor Create(const aFileName : IPath); overload;
     destructor  Destroy; override;
     function    LoadSong(DuetChange: boolean): boolean;
-    function    Analyse(const ReadCustomTags: Boolean = false; DuetChange: boolean = false; RapToFreestyle: boolean = false; OutOfBoundsToFreestyle: boolean = false; AudioLength: real = 0): boolean;
+    function    Analyse(const ReadCustomTags: Boolean = false; DuetChange: boolean = false; RapToFreestyle: boolean = false; OutOfBoundsToFreestyle: boolean = false; AudioLength: real = 0; ForceLoadNotes: boolean = false): boolean;
     procedure   SetMedleyMode();
     procedure   Clear();
     function    MD5SongFile(SongFileR: TTextFileStream): string;
@@ -372,6 +375,9 @@ constructor TSong.Create();
 begin
   inherited;
 
+  FMD5 := '';
+  FMD5Cached := false;
+
   // to-do : special create for category "songs"
   //dirty fix to fix folders=on
   Self.Path     := PATH_NONE();
@@ -425,6 +431,9 @@ constructor TSong.Create(const aFileName: IPath);
 begin
   inherited Create();
 
+  FMD5 := '';
+  FMD5Cached := false;
+
   Mult    := 1;
 
   LastError := '';
@@ -453,17 +462,6 @@ destructor TSong.Destroy;
 begin
   FreeAndNil(Self.FormatVersion);
   inherited;
-end;
-
-function TSong.FindSongFile(Dir: IPath; Mask: UTF8String): IPath;
-var
-  Iter: IFileIterator;
-begin
-  Iter := FileSystem.FileFind(Dir.Append(Mask), faDirectory);
-  if (Iter.HasNext) then
-    Result := Iter.Next.Name
-  else
-    Result := PATH_NONE;
 end;
 
 function TSong.DecodeFilename(Filename: RawByteString): IPath;
@@ -615,6 +613,7 @@ begin
     Exit;
   end;
 
+  CurrentSong := self;
   Result := LoadOpenedSong(SongFile, FileNamePath, DuetChange, false, false, 0);
   SongFile.Free;
 end;
@@ -669,7 +668,6 @@ begin
   Rel[1]            := 0;
 
   try
-    MD5 := MD5SongFile(SongFile);
     SongFile.Position := 0;
 
       //Search for Note Beginning
@@ -924,6 +922,21 @@ var
     Result := TagMap.TryGetData(Key, Data);
   end;
 
+  function GetFirstNonWhitespaceChar(const S: string): AnsiChar;
+  var
+    P: integer;
+  begin
+    Result := #0;
+    for P := 1 to Length(S) do
+    begin
+      if not (S[P] in [#9, ' ']) then
+      begin
+        Result := UpCase(S[P]);
+        Exit;
+      end;
+    end;
+  end;
+
   { adds a custom header tag to the song
     if there is no ':' in the read line, Tag should be empty
     and the whole line should be in Content }
@@ -1083,6 +1096,11 @@ begin
         Break;
       end;
     end; // while
+
+    // Lightweight duet detection for song list: if the first non-header
+    // note-section line starts with a P-track marker, this is a duet.
+    if GetFirstNonWhitespaceChar(Line) = 'P' then
+      Self.isDuet := true;
 
     //Read the songs attributes stored in the TagMap
 
@@ -1422,15 +1440,6 @@ begin
     TagMap.Free;
   end;
 
-  //MD5 of File
-  self.MD5 := MD5SongFile(SongFile);
-
-  if self.Cover.IsUnset then
-    self.Cover := FindSongFile(Path, '*[CO].jpg');
-
-  if self.Background.IsUnset then
-    self.Background := FindSongFile(Path, '*[BG].jpg');
-
   //Check if all Required Values are given
   if (Done <> 15) then
   begin
@@ -1482,6 +1491,42 @@ begin
     Result := FileLineNo
   else
     Result := -1;
+end;
+
+function TSong.GetMD5: string;
+var
+  SongFile: TMemTextFileStream;
+  FileNamePath: IPath;
+begin
+  if not FMD5Cached then
+  begin
+    FMD5Cached := true;
+    FMD5 := '';
+
+    if Assigned(Path) and Assigned(FileName) and not Path.IsUnset and not FileName.IsUnset then
+    begin
+      FileNamePath := Path.Append(FileName);
+      try
+        SongFile := TMemTextFileStream.Create(FileNamePath, fmOpenRead);
+        try
+          FMD5 := MD5SongFile(SongFile);
+        finally
+          SongFile.Free;
+        end;
+      except
+        on E: Exception do
+          Log.LogWarn('Failed to compute MD5 for ' + FileNamePath.ToUTF8(true) + ': ' + E.Message, 'TSong.GetMD5');
+      end;
+    end;
+  end;
+
+  Result := FMD5;
+end;
+
+procedure TSong.SetMD5(const Value: string);
+begin
+  FMD5 := Value;
+  FMD5Cached := Value <> '';
 end;
 
 procedure TSong.ParseNote(Track: integer; TypeP: char; StartP, DurationP, NoteP: integer; LyricS: UTF8String; RapToFreestyle: boolean);
@@ -1799,6 +1844,9 @@ end;
 
 procedure TSong.Clear();
 begin
+  FMD5 := '';
+  FMD5Cached := false;
+
   //Main Information
   Title  := '';
   Artist := '';
@@ -1844,12 +1892,14 @@ begin
   Relative := false;
 end;
 
-function TSong.Analyse(const ReadCustomTags: Boolean; DuetChange: boolean; RapToFreestyle: boolean; OutOfBoundsToFreestyle: boolean; AudioLength: real): boolean;
+function TSong.Analyse(const ReadCustomTags: Boolean; DuetChange: boolean; RapToFreestyle: boolean; OutOfBoundsToFreestyle: boolean; AudioLength: real; ForceLoadNotes: boolean): boolean;
 var
   SongFile: TTextFileStream;
   FileNamePath: IPath;
+  NotesLoaded: boolean;
 begin
   Result := false;
+  NotesLoaded := false;
 
   //Reset LineNo
   FileLineNo := 0;
@@ -1871,11 +1921,15 @@ begin
     //Read Header
     Result := Self.ReadTxTHeader(SongFile, ReadCustomTags);
 
-    //Load Song for Medley Tags
-    CurrentSong := Self;
-    Result := Result and LoadOpenedSong(SongFile, FileNamePath, DuetChange, RapToFreestyle, OutOfBoundsToFreestyle, AudioLength);
+    if Result and ForceLoadNotes then
+    begin
+      //Load Song for Medley Tags
+      CurrentSong := Self;
+      NotesLoaded := LoadOpenedSong(SongFile, FileNamePath, DuetChange, RapToFreestyle, OutOfBoundsToFreestyle, AudioLength);
+      Result := Result and NotesLoaded;
+    end;
 
-    if Result then
+    if Result and NotesLoaded then
     begin
       //Medley and Duet - is it possible? Perhaps later...
       if not Self.isDuet then

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -5136,7 +5136,7 @@ begin
 
   try
     // reread header with custom tags
-    Error := not CurrentSong.Analyse(true, false);
+    Error := not CurrentSong.Analyse(true, false, false, false, 0, true);
 
     // with the duet/medley code, TSong.Analyse is already loading the song
     //if not Error then

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -1082,7 +1082,7 @@ begin
   success := false;
   // FIXME: bad style, put the try-except into loadsong() and not here
   try
-    success := CurrentSong.Analyse(false, ScreenSong.DuetChange, ScreenSong.RapToFreestyle, true, AudioEnd); // and CurrentSong.LoadSong();
+    success := CurrentSong.Analyse(false, ScreenSong.DuetChange, ScreenSong.RapToFreestyle, true, AudioEnd, true); // and CurrentSong.LoadSong();
   except
     on E: EInOutError do Log.LogWarn(E.Message, 'TScreenSing.LoadNextSong');
   end;


### PR DESCRIPTION
This PR adds a config option to skip the search for background and covers if they are not set and caches the directory search result otherwise
it also lazy-loads the MD5 hash that is (only?) used for the sendscore feature (that maybe is also not used by anyone?)

- current master: real 0m27.374s
- search result cached: real 0m26.219s
- disabled via config.ini: real 0m25.402s
- with MD5 not computed on loading: real 0m22.235s

Skipping the parsing of the note part of the songs would get it down to ~14s from here but then the note part of the song would not be checked on launch