### PR TITLE
Cache build environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,11 +117,25 @@ jobs:
           key: linux-docker-${{ hashFiles('dists/linux/dl.sh', 'dists/linux/tasks.sh') }}
           path: |
             dists/linux/prefix
+      - name: Start container builder
+        uses: docker/setup-buildx-action@v3
+      - name: Generate Dockerfile
+        run: |
+          cd dists/linux
+          ./dockerenv.sh --dockerfile > Dockerfile
+      - name: Build container
+        uses: docker/build-push-action@v6
+        with:
+          context: dists/linux
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,ignore-error=true
+          load: true
+          tags: usdx/buildenv:latest
       - name: Build
         run: |
           cd dists/linux
           sed -i '/docker/s/-it\>//' dockerenv.sh
-          ./dockerenv.sh make compress
+          ./dockerenv.sh --use-existing=usdx/buildenv:latest make compress
           mv UltraStar*.AppImage ../../UltraStarDeluxe-linux-${{ env.versionName }}.AppImage
       - name: Upload Image Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
To speed up builds and to reduce dependency on Sourceforge, which has become unreliable.

The Windows build caches 330 MB. Docker caches 414 MB for Linux and adds one 3.9 kB index-buildkit-something file with each build. As far as I know the cache limit is 10 GB per repository.

I tried using docker's gha cache method without the docker/build-push-action@v6 action, but it looks like the environment variables expected by docker in that case are available only when using a Github action. That's why I had to split dockerenv.sh into multiple steps.

Since homebrew bottles are served from Github servers, caching them probably doesn't make much sense.

Fixes #1123