### PR TITLE
fix: in party mode: don't show duets, don't use playlists when there are none selected

### DIFF
--- a/src/base/UPlaylist.pas
+++ b/src/base/UPlaylist.pas
@@ -340,6 +340,9 @@ begin
   CatSongs.LastVisChecked := 0;
   CatSongs.LastVisIndex := 0;
 
+  if Assigned(ScreenSong) then
+    ScreenSong.FilterDuetsInPartyMode; // in party mode
+
   //Set CatSongsMode + Playlist Mode
   CatSongs.CatNumShow := -3;
   Mode := smPlayList;

--- a/src/screens/UScreenPartyOptions.pas
+++ b/src/screens/UScreenPartyOptions.pas
@@ -131,7 +131,7 @@ begin
           //  ScreenSong.CurrentPartyTime := 0;
 
           //Don't start when Playlist is Selected and there are no Playlists
-          if (Playlist = 3) and (Length(PlaylistMan.Playlists) = 0) then
+          if (Playlist = 2) and (Length(PlaylistMan.Playlists) = 0) then
             Exit;
 
           //Save Difficulty
@@ -393,12 +393,18 @@ begin
     if PlaylistMan.CurPlayList = -1 then
       Exit;
   end
+  else if Playlist = 2 then
+  begin
+    // Playlist selected: ensure there is at least one playlist and the selected index is valid
+    if (Length(PlaylistMan.Playlists) = 0) or (Playlist2 < 0) or (Playlist2 > High(PlaylistMan.Playlists)) then
+      Exit
+    else
+      PlaylistMan.CurPlayList := Playlist2;
+  end
   else
   begin
-    //if Playlist = 2 then
-    //  PlayListMan.SetPlayList(Playlist2)
-    //else
-      PlaylistMan.CurPlayList := Playlist2;
+    // All selected: no specific playlist
+    PlaylistMan.CurPlayList := -1;
   end;
 
   ScreenSong.Mode := smPartyClassic;

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -284,6 +284,7 @@ type
       procedure SelectRandomSong;
       procedure SetJoker;
       procedure SetStatics;
+      procedure FilterDuetsInPartyMode;
       procedure ColorizeJokers;
       //procedure PartyTimeLimit;
       function PermitCategory(ID: integer): boolean;
@@ -3196,9 +3197,6 @@ begin
   //Party Mode
   else
   begin
-    SelectRandomSong;
-    //Show Menu directly in PartyMode
-    //But only if selected in Options
     if (Ini.PartyPopup = 1) then
     begin
       ScreenSongMenu.MenuShow(SM_Party_Main);
@@ -3227,8 +3225,13 @@ begin
       PlaylistMan.SetPlayList(PlaylistMan.CurPlayList, SongIndex);
   end;
 
-  SetScrollRefresh;
+  FilterDuetsInPartyMode; // in party mode
 
+  if (Mode = smPartyClassic) then
+    SelectRandomSong;
+
+  SetScrollRefresh;
+  FixSelected;
   //if (Mode = smPartyTournament) then
   //  PartyTime := SDL_GetTicks();
 
@@ -3952,6 +3955,8 @@ var
   I, I2, Count, RealTarget: integer;
   Target: cardinal;
 begin
+  if (CatSongs.VisibleSongs <= 0) then
+    Exit;
   case PlayListMan.Mode of
       smAll:  // all songs just select random song
         begin
@@ -4219,6 +4224,21 @@ begin
   end;
 end;
 
+procedure TScreenSong.FilterDuetsInPartyMode;
+var
+  I: integer;
+begin
+  if (Mode in [smPartyClassic, smPartyFree, smPartyTournament]) then
+  begin
+    for I := 0 to High(CatSongs.Song) do
+      if CatSongs.Song[I].isDuet then
+        CatSongs.Song[I].Visible := false;
+    // Reset visible-index cache so VisibleIndex() recomputes correctly
+    CatSongs.LastVisChecked := 0;
+    CatSongs.LastVisIndex := 0;
+  end;
+end;
+
 procedure TScreenSong.SetStatics;
 var
   I:       integer;
@@ -4298,6 +4318,8 @@ begin
 
     SelectRandomSong;
     SetJoker;
+    SetScrollRefresh;
+    FixSelected;
   end;
 end;
 


### PR DESCRIPTION
this builds on #1127. it fixes multiple bugs in the party mode (including the ones in #1114 i think):
1. a RangeError in `SelectRandomSong` when no songs are there + don't select playlist mode unless there is a playlist and it has been selected
2. Force immediate UI refresh after a Joker use so that the right song is shown
3. Hide duet songs in Party modes to prevent the runtime "Duet! Not playable in Party Mode!" popup
4. Defer the initial random song selection to OnShowFinish (after playlist reload/visibility finalization) and reset the CatSongs visible-index cache after filtering so initial scroll/centering is correct