### PR TITLE
Improvement: MIDI emulator backend (sine synth) for platforms that don't support MIDI otherwise

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -441,6 +441,22 @@ AC_SUBST_DEFINE(HAVE_PORTMIXER, $portmixer_HAVE)
 AC_ARG_ENABLE(portmidi, [AS_HELP_STRING([--disable-portmidi], [Disable PortTime Midi loop])])
 AC_ARG_WITH(porttime, [AS_HELP_STRING([--with-porttime], [Use PortTime instead of SDL Midi loop])])
 
+
+# Default to MIDI emulation on Linux and macOS unless --disable-midiemu is given
+case "$host_os" in
+    linux*|darwin*)
+        default_midiemu=yes ;;
+    *)
+        default_midiemu=no ;;
+esac
+AC_ARG_ENABLE(midiemu, [AS_HELP_STRING([--enable-midiemu],[Enable built-in MIDI emulation backend (default on Linux/macOS)])],
+    [enable_midiemu=$enableval],
+    [enable_midiemu=$default_midiemu])
+
+AC_ARG_ENABLE(disable-midiemu, [AS_HELP_STRING([--disable-midiemu],[Disable built-in MIDI emulation backend and use system MIDI backend if available])],
+    [if test x$enableval = xyes; then enable_midiemu=no; fi])
+
+
 if [[ x$enable_portmidi != xno ]] ; then
     AC_CHECK_LIB([portmidi], [Pm_Initialize], [
         portmidi_HAVE=yes
@@ -466,6 +482,19 @@ AC_SUBST_DEFINE(HAVE_PORTMIDI, $portmidi_HAVE)
 AC_SUBST_DEFINE(HAVE_PORTTIME, $porttime_HAVE)
 AC_SUBST(porttime_LIB_NAME)
 fi
+
+## MIDI emulation backend
+if [[ x$enable_midiemu = xyes ]] ; then
+    midiemu_HAVE=yes
+    PFLAGS_EXTRA="$PFLAGS_EXTRA -dUseMidiEmu"
+    # Avoid platform MIDI backends with system synths if built-in MIDI emulation is enabled
+    portmidi_HAVE=no
+    porttime_HAVE=no
+else
+    midiemu_HAVE=no
+fi
+AC_SUBST_DEFINE(HAVE_MIDI_EMU, $midiemu_HAVE)
+AC_SUBST(PFLAGS_EXTRA)
 
 # determine linker-flags
 if test x$FPC_PLATFORM = xdarwin; then

--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -519,6 +519,7 @@ type
       function GetPCMData(var Data: TPCMData): Cardinal;
 
       function CreateVoiceStream(ChannelMap: integer; FormatInfo: TAudioFormatInfo): TAudioVoiceStream;
+      function CreatePlaybackStreamForSource(SourceStream: TAudioSourceStream): TAudioPlaybackStream;
   end;
 
   IGenericDecoder = Interface

--- a/src/config-win.inc
+++ b/src/config-win.inc
@@ -73,6 +73,16 @@
 
 {$UNDEF HavePortmixer}
 
-{$DEFINE UseMIDIPort}
+{$DEFINE UsePortMidi}
+{$IF Defined(UsePortMidi)}
+  {$DEFINE UseMIDIPort}
+{$IFEND}
+{$IF Defined(UseMidiEmu)}
+  {$DEFINE UseMidiEmu}
+  {$DEFINE UseMIDIPort}
+  // Avoid platform MIDI backends with system synths if built-in MIDI emulation is enabled
+  {$UNDEF UsePortMidi}
+  {$UNDEF UsePortTime}
+{$IFEND}
 
 {$DEFINE UseOpenCVWrapper}

--- a/src/config.inc.in
+++ b/src/config.inc.in
@@ -77,6 +77,17 @@
 {$IF Defined(UsePortMidi)}
   {$DEFINE UseMIDIPort}
 {$IFEND}
+{$@DEFINE_HAVE_MIDI_EMU@ UseMidiEmu}
+{$IF Defined(UseMidiEmu)}
+  {$DEFINE UseMidiEmu}
+  // Ensure the midi unit block is compiled so the emulation unit is included
+  {$DEFINE UseMIDIPort}
+  // When MidiEmu is enabled we want to avoid compiling other midi backends
+  // to prevent accidental use of system synths or PortMidi. Undef those
+  // flags here so downstream conditional blocks stay disabled.
+  {$UNDEF UsePortMidi}
+  {$UNDEF UsePortTime}
+{$IFEND}
 {$@DEFINE_HAVE_PORTTIME@ UsePortTime}
 {$@DEFINE_HAVE_PORTTIME@ PortTime_in_@porttime_LIB_NAME@}
 {$IF Defined(IncludeConstants)}

--- a/src/lib/midiemu/MidiAudioSourceStream.pas
+++ b/src/lib/midiemu/MidiAudioSourceStream.pas
@@ -34,6 +34,7 @@ type
     FRelease: Boolean;
     FEnvLevel: Double;
     FOvertoneLevel: Double;
+    FOvertoneDecay: Double;
     FLock: TCriticalSection;
   protected
     function IsEOF: boolean; override;
@@ -65,6 +66,7 @@ begin
   FFreq := 440.0;
   FVel := 0.0;
   FOvertoneLevel := 0.0;
+  FOvertoneDecay := Power(3e-10, 1 / FFormat.SampleRate); // after 1s amplitude has fallen to 3e-10
   FLock := TCriticalSection.Create;
   Log.LogDebug('MidiAudioSourceStream: Created', 'MidiSynth');
 end;
@@ -142,7 +144,7 @@ begin
         overtone := Sin(2 * FPhase) * FOvertoneLevel * FEnvLevel;
         sample := sample + overtone;
         // Decay overtone
-        FOvertoneLevel := FOvertoneLevel * 0.995;
+        FOvertoneLevel := FOvertoneLevel * FOvertoneDecay;
         // FPhase handling: keep between -Pi and +Pi
         FPhase := FPhase + phaseInc;
         if FPhase > Pi then FPhase := FPhase - 2 * Pi;

--- a/src/lib/midiemu/MidiAudioSourceStream.pas
+++ b/src/lib/midiemu/MidiAudioSourceStream.pas
@@ -1,0 +1,238 @@
+{* UltraStar Deluxe - MIDI Audio Source Stream
+ *
+ * Generates synthesized audio from MIDI events for playback via the standard audio interface.
+ *}
+
+unit MidiAudioSourceStream;
+
+interface
+
+{$IFDEF FPC}
+  {$MODE Delphi}
+{$ENDIF}
+
+uses
+  Classes,
+  SysUtils,
+  UAudioPlaybackBase,
+  Math,
+  UMusic,
+  ULog,
+  SyncObjs;
+
+type
+  TMidiAudioSourceStream = class(TAudioSourceStream)
+  private
+    FFormat: TAudioFormatInfo;
+    FPosition: real;
+    // Synthesizer state
+    FActive: Boolean;
+    FNote: Integer;
+    FFreq: Double;
+    FVel: Double;
+    FPhase: Double;
+    FRelease: Boolean;
+    FEnvLevel: Double;
+    FOvertoneLevel: Double;
+    FOvertonePhase: Double;
+    FLock: TCriticalSection;
+  protected
+    function IsEOF: boolean; override;
+    function IsError: boolean; override;
+    function GetLength: real; override;
+    function GetPosition: real; override;
+    procedure SetPosition(Time: real); override;
+    function GetLoop(): boolean; override;
+    procedure SetLoop(Enabled: boolean); override;
+  public
+    constructor Create(MidiFile: Pointer; Format: TAudioFormatInfo); // MidiFile unused for now
+    function ReadData(Buffer: PByte; BufferSize: integer): integer; override;
+    function GetAudioFormatInfo: TAudioFormatInfo; override;
+    procedure Close; override;
+    procedure HandleMidiEvent(MidiMessage: byte; Data1: byte; Data2: byte);
+  end;
+
+implementation
+
+constructor TMidiAudioSourceStream.Create(MidiFile: Pointer; Format: TAudioFormatInfo);
+begin
+  FFormat := Format.Copy;
+  FEnvLevel := 0;
+  FPhase := 0;
+  FActive := False;
+  FRelease := False;
+  FPosition := 0;
+  FNote := -1;
+  FFreq := 440.0;
+  FVel := 0.0;
+  FOvertoneLevel := 0.0;
+  FOvertonePhase := 0.0;
+  FLock := TCriticalSection.Create;
+  Log.LogDebug('MidiAudioSourceStream: Created', 'MidiSynth');
+end;
+
+function TMidiAudioSourceStream.IsEOF: boolean;
+begin
+  Result := False;
+end;
+
+function TMidiAudioSourceStream.IsError: boolean;
+begin
+  Result := false;
+end;
+
+function TMidiAudioSourceStream.GetLength: real;
+begin
+  Result := 0; // Not implemented
+end;
+
+function TMidiAudioSourceStream.GetPosition: real;
+begin
+  Result := FPosition;
+end;
+
+procedure TMidiAudioSourceStream.SetPosition(Time: real);
+begin
+  FPosition := Time;
+end;
+
+function TMidiAudioSourceStream.ReadData(Buffer: PByte; BufferSize: integer): integer;
+
+var
+  SampleRate: Integer;
+  Channels: Integer;
+  Frames: Integer;
+  s: PSmallInt;
+  i, j: Integer;
+  phaseInc, overtoneInc, sample, overtone: Double;
+  attackStep, releaseStep: Double;
+  outSample: SmallInt;
+  tempSample: Int64;
+begin
+  SampleRate := Trunc(FFormat.SampleRate);
+  Channels := Trunc(FFormat.Channels);
+  Frames := BufferSize div (Channels * 2); // 2 bytes per sample
+  s := PSmallInt(Buffer);
+  attackStep := 1.0 / (0.005 * SampleRate);  // 5ms attack
+  releaseStep := 1.0 / (0.005 * SampleRate); // 5ms release
+  phaseInc := 2 * Pi * FFreq / SampleRate;
+  overtoneInc := 4 * Pi * FFreq / SampleRate; // 2nd harmonic
+
+  FLock.Enter;
+  try
+    for i := 0 to Frames - 1 do
+    begin
+      // Envelope
+      if FRelease then
+      begin
+        FEnvLevel := FEnvLevel - releaseStep;
+        if FEnvLevel <= 0 then
+        begin
+          FEnvLevel := 0;
+          FActive := False;
+        end;
+      end
+      else if FEnvLevel < 1.0 then
+      begin
+        FEnvLevel := FEnvLevel + attackStep;
+        if FEnvLevel > 1.0 then FEnvLevel := 1.0;
+      end;
+
+      if FActive then
+      begin
+        sample := Sin(FPhase) * FVel * FEnvLevel;
+        // Add overtone with exponential decay for note restart detection
+        overtone := Sin(FOvertonePhase) * FOvertoneLevel * FEnvLevel;
+        sample := sample + overtone;
+        // Decay overtone
+        FOvertoneLevel := FOvertoneLevel * 0.995;
+        // FPhase handling: keep between -Pi and +Pi
+        FPhase := FPhase + phaseInc;
+        if FPhase > Pi then FPhase := FPhase - 2 * Pi;
+        if FPhase < -Pi then FPhase := FPhase + 2 * Pi;
+        FOvertonePhase := FOvertonePhase + overtoneInc;
+        if FOvertonePhase > Pi then FOvertonePhase := FOvertonePhase - 2 * Pi;
+        if FOvertonePhase < -Pi then FOvertonePhase := FOvertonePhase + 2 * Pi;
+      end
+      else
+        sample := 0;
+
+      // Convert to SmallInt once per frame
+      tempSample := Round(sample * High(SmallInt));
+      if tempSample > High(SmallInt) then
+        outSample := High(SmallInt)
+      else if tempSample < Low(SmallInt) then
+        outSample := Low(SmallInt)
+      else
+        outSample := SmallInt(tempSample);
+      for j := 0 to Channels - 1 do
+      begin
+        s^ := outSample;
+        Inc(s);
+      end;
+    end;
+
+    // If envelope is finished, deactivate
+    if (FEnvLevel <= 0) then
+    begin
+      FActive := False;
+      FRelease := False;
+    end;
+  finally
+    FLock.Leave;
+  end;
+
+  Result := BufferSize;
+end;
+
+function TMidiAudioSourceStream.GetAudioFormatInfo: TAudioFormatInfo;
+begin
+  Result := FFormat;
+end;
+
+procedure TMidiAudioSourceStream.Close;
+begin
+  FreeAndNil(FFormat);
+  FreeAndNil(FLock);
+end;
+
+procedure TMidiAudioSourceStream.HandleMidiEvent(MidiMessage: byte; Data1: byte; Data2: byte);
+begin
+  FLock.Enter;
+  try
+    // NOTE ON
+    if ((MidiMessage and $F0) = $90) and (Data2 <> 0) then
+    begin
+      FNote := Data1;
+      FFreq := 440.0 * Power(2.0, (FNote - 69)/12.0);
+      // Velocity mapping: amplitude proportional to square of velocity
+      FVel := Sqr(Data2 / 127.0);
+      FActive := True;
+      FRelease := False;
+      FEnvLevel := 0;
+      // Add overtone for note restart detection
+      FOvertoneLevel := 0.5 * FVel; // Start overtone at half velocity
+      FOvertonePhase := 0;
+      Exit;
+    end;
+    // NOTE OFF
+    if (((MidiMessage and $F0) = $90) and (Data2 = 0)) or ((MidiMessage and $F0) = $80) then
+    begin
+      FRelease := True;
+    end;
+  finally
+    FLock.Leave;
+  end;
+end;
+
+function TMidiAudioSourceStream.GetLoop(): boolean;
+begin
+  Result := False;
+end;
+
+procedure TMidiAudioSourceStream.SetLoop(Enabled: boolean);
+begin
+  // Do nothing, MIDI synthesis doesn't loop
+end;
+
+end.

--- a/src/lib/midiemu/MidiAudioSourceStream.pas
+++ b/src/lib/midiemu/MidiAudioSourceStream.pas
@@ -195,7 +195,6 @@ begin
       FVel := Sqr(Data2 / 127.0);
       FActive := True;
       FRelease := False;
-      FEnvLevel := 0;
       // Add overtone for note restart detection
       FOvertoneLevel := 0.5 * FVel; // Start overtone at half velocity
       Exit;

--- a/src/lib/midiemu/MidiAudioSourceStream.pas
+++ b/src/lib/midiemu/MidiAudioSourceStream.pas
@@ -113,10 +113,10 @@ begin
   s := PSmallInt(Buffer);
   attackStep := 1.0 / (0.005 * SampleRate);  // 5ms attack
   releaseStep := 1.0 / (0.005 * SampleRate); // 5ms release
-  phaseInc := 2 * Pi * FFreq / SampleRate;
 
   FLock.Enter;
   try
+    phaseInc := 2 * Pi * FFreq / SampleRate;
     for i := 0 to Frames - 1 do
     begin
       // Envelope

--- a/src/lib/midiemu/MidiAudioSourceStream.pas
+++ b/src/lib/midiemu/MidiAudioSourceStream.pas
@@ -146,7 +146,6 @@ begin
         // FPhase handling: keep between -Pi and +Pi
         FPhase := FPhase + phaseInc;
         if FPhase > Pi then FPhase := FPhase - 2 * Pi;
-        if FPhase < -Pi then FPhase := FPhase + 2 * Pi;
       end
       else
         sample := 0;

--- a/src/lib/midiemu/MidiAudioSourceStream.pas
+++ b/src/lib/midiemu/MidiAudioSourceStream.pas
@@ -164,13 +164,6 @@ begin
         Inc(s);
       end;
     end;
-
-    // If envelope is finished, deactivate
-    if (FEnvLevel <= 0) then
-    begin
-      FActive := False;
-      FRelease := False;
-    end;
   finally
     FLock.Leave;
   end;

--- a/src/lib/midiemu/MidiAudioSourceStream.pas
+++ b/src/lib/midiemu/MidiAudioSourceStream.pas
@@ -200,7 +200,7 @@ begin
       Exit;
     end;
     // NOTE OFF
-    if (((MidiMessage and $F0) = $90) and (Data2 = 0)) or ((MidiMessage and $F0) = $80) then
+    if ((((MidiMessage and $F0) = $90) and (Data2 = 0)) or ((MidiMessage and $F0) = $80)) and (FNote = Data1) then
     begin
       FRelease := True;
     end;

--- a/src/lib/midiemu/MidiOut.pas
+++ b/src/lib/midiemu/MidiOut.pas
@@ -1,0 +1,143 @@
+{* UltraStar Deluxe - MIDI Emulation (synth)
+   Drop-in replacement for MidiOut unit. *}
+
+unit MidiOut;
+
+interface
+
+{$IFDEF FPC}
+  {$MODE Delphi}
+  {$H+}
+{$ENDIF}
+
+uses
+  Classes,
+  SysUtils,
+  ULog,
+  UPathUtils,
+  UMusic,
+  Math,
+  SyncObjs,
+  MidiAudioSourceStream,
+  UAudioPlaybackBase;
+
+type
+  TMidiOutput = class(TComponent)
+  private
+    FProductName: string;
+    FFormat: TAudioFormatInfo;
+    FOpened: Boolean;
+    FPlaybackStream: TAudioPlaybackStream;
+    FSourceStream: TMidiAudioSourceStream;
+    FLock: TCriticalSection;
+  public
+    constructor Create(AOwner: TComponent); override;
+    destructor Destroy; override;
+
+    function Open: boolean; virtual;
+    function Close: boolean; virtual;
+
+    procedure PutShort(MidiMessage: byte; Data1: byte; Data2: byte); virtual;
+    procedure Play;
+    procedure Stop;
+
+    property ProductName: string read FProductName write FProductName;
+  end;
+
+procedure Register;
+
+implementation
+
+constructor TMidiOutput.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FProductName := 'MIDI Emulation (synth)';
+  FOpened := False;
+  FPlaybackStream := nil;
+  FSourceStream := nil;
+  FLock := TCriticalSection.Create;
+end;
+
+destructor TMidiOutput.Destroy;
+begin
+  if Assigned(FPlaybackStream) then
+    FreeAndNil(FPlaybackStream);
+  if Assigned(FSourceStream) then
+    FreeAndNil(FSourceStream);
+  FreeAndNil(FFormat);
+  FreeAndNil(FLock);
+  inherited Destroy;
+end;
+
+function TMidiOutput.Open: boolean;
+var AP: IAudioPlayback;
+begin
+  Result := False;
+  AP := AudioPlayback;
+  if AP = nil then
+  begin
+    Log.LogWarn('MidiEmu: AudioPlayback not initialized', 'MidiEmu');
+    Exit;
+  end;
+  try
+    FreeAndNil(FFormat);
+    FFormat := TAudioFormatInfo.Create(1, 44100, asfS16);
+    if Assigned(FSourceStream) then FreeAndNil(FSourceStream);
+    FSourceStream := TMidiAudioSourceStream.Create(nil, FFormat); // nil for now, can pass TMidiFile if needed
+    if Assigned(FPlaybackStream) then FreeAndNil(FPlaybackStream);
+    FPlaybackStream := AP.CreatePlaybackStreamForSource(FSourceStream);
+    if not Assigned(FPlaybackStream) then
+    begin
+      Log.LogError('MidiEmu: CreatePlaybackStreamForSource failed', 'MidiEmu');
+      Exit;
+    end;
+    Result := True;
+    FOpened := True;
+    Log.LogDebug('MidiEmu: synthesized MIDI stream opened', 'MidiEmu');
+  except
+    on E: Exception do
+      Log.LogError('MidiEmu: Open failed: ' + E.Message, 'MidiEmu');
+  end;
+end;
+
+function TMidiOutput.Close: boolean;
+begin
+  Result := True;
+  FOpened := False;
+  if Assigned(FPlaybackStream) then
+  begin
+    FPlaybackStream.Stop;
+    FreeAndNil(FPlaybackStream);
+  end;
+  if Assigned(FSourceStream) then
+    FreeAndNil(FSourceStream);
+end;
+
+procedure TMidiOutput.PutShort(MidiMessage: byte; Data1: byte; Data2: byte);
+begin
+  if ((MidiMessage and $F0) = $90) and (Data2 <> 0) then
+  begin
+    Play;
+  end;
+  
+  if Assigned(FSourceStream) then
+    FSourceStream.HandleMidiEvent(MidiMessage, Data1, Data2);
+end;
+
+procedure TMidiOutput.Play;
+begin
+  if Assigned(FPlaybackStream) then
+    FPlaybackStream.Play;
+end;
+
+procedure TMidiOutput.Stop;
+begin
+  if Assigned(FPlaybackStream) then
+    FPlaybackStream.Stop;
+end;
+
+procedure Register;
+begin
+end;
+
+end.

--- a/src/lib/midiemu/MidiOut.pas
+++ b/src/lib/midiemu/MidiOut.pas
@@ -118,6 +118,11 @@ begin
   if ((MidiMessage and $F0) = $90) and (Data2 <> 0) then
   begin
     Play;
+  end
+  else if ((MidiMessage and $F0) = $B0) and (Data1 = 7) then
+  begin
+    if Assigned(FPlaybackStream) then
+       FPlaybackStream.Volume := Sqr(Data2 / 127);
   end;
   
   if Assigned(FSourceStream) then

--- a/src/media/UAudioPlaybackBase.pas
+++ b/src/media/UAudioPlaybackBase.pas
@@ -109,6 +109,7 @@ type
       function GetPCMData(var Data: TPCMData): Cardinal;
 
       function CreateVoiceStream(Channel: integer; FormatInfo: TAudioFormatInfo): TAudioVoiceStream; virtual; abstract;
+      function CreatePlaybackStreamForSource(SourceStream: TAudioSourceStream): TAudioPlaybackStream;
   end;
 
   TAudioBufferSourceStream = class(TAudioSourceStream)
@@ -202,6 +203,22 @@ function TAudioPlaybackBase.OpenDecodeStream(const Filename: IPath): TAudioDecod
 var
   i: integer;
 begin
+  // If MIDI emulation is enabled, avoid letting generic audio decoders
+  // open .mid/.midi files as PCM. These files should be handled by the
+  // MIDI subsystem (MidiFile/MidiOut) so that our MidiEmu receives events.
+  {$IFDEF UseMidiEmu}
+  try
+    if (LowerCase(ExtractFileExt(Filename.ToNative)) = '.mid') or
+       (LowerCase(ExtractFileExt(Filename.ToNative)) = '.midi') then
+    begin
+      Log.LogInfo('Skipping generic audio decoder for MIDI file (using MidiEmu): ' + Filename.ToNative, 'TAudioPlaybackBase.OpenDecodeStream');
+      Result := nil;
+      Exit;
+    end;
+  except
+    // ignore any exception from ExtractFileExt and continue
+  end;
+  {$ENDIF}
   for i := 0 to AudioDecoders.Count-1 do
   begin
     Result := IAudioDecoder(AudioDecoders[i]).Open(Filename);
@@ -536,6 +553,17 @@ procedure TAudioBufferSourceStream.Close();
 begin
   FreeAndNil(fFormat);
   fStream := nil;
+end;
+
+function TAudioPlaybackBase.CreatePlaybackStreamForSource(SourceStream: TAudioSourceStream): TAudioPlaybackStream;
+begin
+  Result := CreatePlaybackStream();
+  if not Assigned(Result) then
+    Exit;
+  if not Result.Open(SourceStream) then
+  begin
+    FreeAndNil(Result);
+  end;
 end;
 
 end.

--- a/src/media/UAudioPlayback_SoftMixer.pas
+++ b/src/media/UAudioPlayback_SoftMixer.pas
@@ -453,7 +453,9 @@ var
   Mixer: TAudioMixerStream;
 begin
   // only paused streams are not flushed
-  if (Status = ssPaused) then
+  if Status = ssPlaying then
+    Exit
+  else if Status = ssPaused then
     NeedsRewind := false;
 
   // rewind if necessary. Cases that require no rewind are:

--- a/src/media/UMedia_dummy.pas
+++ b/src/media/UMedia_dummy.pas
@@ -102,6 +102,7 @@ type
       procedure StopSound(stream: TAudioPlaybackStream);
 
       function CreateVoiceStream(Channel: integer; FormatInfo: TAudioFormatInfo): TAudioVoiceStream;
+      function CreatePlaybackStreamForSource(SourceStream: TAudioSourceStream): TAudioPlaybackStream;
       procedure CloseVoiceStream(var VoiceStream: TAudioVoiceStream);
     end;
 
@@ -352,6 +353,11 @@ begin
 end;
 
 function TAudio_Dummy.CreateVoiceStream(Channel: integer; FormatInfo: TAudioFormatInfo): TAudioVoiceStream;
+begin
+  Result := nil;
+end;
+
+function TAudio_Dummy.CreatePlaybackStreamForSource(SourceStream: TAudioSourceStream): TAudioPlaybackStream;
 begin
   Result := nil;
 end;

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -5575,6 +5575,15 @@ begin
     CurrentBeat := Floor(GetMidBeat(MidiPos - CurrentSong.GAP / 1000));
     Text[TextInfo].Text := Language.Translate('EDIT_INFO_CURRENT_BEAT') + ' ' + IntToStr(CurrentBeat);
 
+    if (MidiLastNote >= 0) and (MidiLastTrack = CurrentTrack) and (MidiLastLine = CurrentSong.Tracks[CurrentTrack].CurrentLine) then
+    begin
+      if (CurrentBeat >= CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[MidiLastNote].StartBeat + CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[MidiLastNote].Duration) then
+      begin
+        MidiOut.PutShort(MIDI_NOTEOFF or 1, CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[MidiLastNote].Tone + 60, 127);
+        MidiLastNote := -1;
+      end;
+    end;
+
     if CurrentBeat <> LastClick then
     begin
       for NoteIndex := 0 to CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].HighNote do

--- a/src/ultrastardx.dpr
+++ b/src/ultrastardx.dpr
@@ -115,13 +115,19 @@ uses
       DelphiMcb       in 'lib\midi\DelphiMcb.pas',
       MidiDefs        in 'lib\midi\MidiDefs.pas',
       MidiType        in 'lib\midi\MidiType.pas',
-      MidiOut         in 'lib\midi\MidiOut.pas',
+      {$IFNDEF UseMidiEmu}
+        MidiOut       in 'lib\midi\MidiOut.pas',
+      {$ENDIF}
       MidiIn          in 'lib\midi\MidiIn.pas',
       UMidiInput      in 'media\UMidiInput.pas',
     {$ELSE}
       {$IFDEF UsePortMidi}
         MidiOut       in 'lib\portmidi\MidiOut.pas',
       {$ENDIF}
+    {$ENDIF}
+    {$IFDEF UseMidiEmu}
+      MidiOut               in 'lib\midiemu\MidiOut.pas',
+      MidiAudioSourceStream in 'lib\midiemu\MidiAudioSourceStream.pas',
     {$ENDIF}
   {$ENDIF}
 


### PR DESCRIPTION
This PR makes it possible to build and run USDX with synthesized, emulated MIDI output instead of using an actual MIDI audio device. The MIDI emulation backend is compile-time-selectable (`--enable-midiemu`) for systems without native MIDI (e.g., Raspberry Pi, macOS??). It synthesizes a single-voice sine wave with simple ADSR envelope, exposed behind the existing `MidiOut` interface. No changes required for existing code using `TMidiOutput`. It also fixes note-off logic in the editor: notes now stop exactly at their end, even with gaps, and repeated notes retrigger cleanly.

All changes are minimal and isolated; existing MIDI backends are untouched and the new code is only activated with `--enable-midiemu`.