### PR TITLE
use stacktraces in installed versions on Linux

### DIFF
--- a/src/base/UPlatformLinux.pas
+++ b/src/base/UPlatformLinux.pas
@@ -96,7 +96,7 @@ begin
   if not UseLocalDirs then begin
     try
       // try to cd to the ExecutionDir -- this makes the stacktraces work when started from PATH
-      chdir(LocalDir.ToWide());
+      chdir(LocalDir.ToNative());
     except
       // this log statement is too early to be logged to the Error.log file, it'll only show up in stdout
       // Log.LogWarn('Cannot chdir to '+LocalDir.ToNative()+', stacktraces might be broken', 'TPlatformLinux.DetectLocalExecution');


### PR DESCRIPTION
Should fix #1111 

On ArchLinux:
* `make` in a git clone (=normal development workflow): has stacktraces

After git cloning https://aur.archlinux.org/packages/ultrastardx-git, setting `options=(!strip)` and running `makepkg`:
* `src/USDX/game/ultrastardx`: has stacktraces
* `pkg/ultrastardx-git/usr/bin/ultrastardx`: **does not have stacktraces**

After installing the package:
* `/usr/bin/ultrastardx`: has stacktraces
* `ultrastardx`: has stacktraces
* right-clicking the desktop (xfce4) and starting from there: has stacktraces

The one command where it doesn't work is the executable as a result of a `make DESTDIR="somewhere/" install` in the PKGBUILD. I assume a plain `make install` would just yeet the binary into `/usr/bin/` directly but I cannot (or am not willing to) test this bit.

@s09bQ5 this isn't quite the `/proc/self/exe` you mentioned in https://github.com/UltraStar-Deluxe/USDX/issues/1111#issuecomment-3678829214 but would this approach work? I also don't know if this will make the flatpak patch for this function completely obsolete or if we just need to instead of LocalDir just hardcode the path it currently hardcodes?