### PR TITLE
Fix Legend for Jukebox Options Screen

### DIFF
--- a/game/themes/Modern.ini
+++ b/game/themes/Modern.ini
@@ -11498,7 +11498,7 @@ Text = SING_LEGEND_NAVIGATE
 
 [JukeboxPlaylistText5]
 Inherits = DefaultLegendText
-Y = 548
+X = 428
 Text = SING_LEGEND_CONTINUE
 
 [JukeboxPlaylistSelectPlayList]


### PR DESCRIPTION
Minor regression from #1135. Specified the Y coordinate instead of X.

<img width="1920" height="980" alt="screen66" src="https://github.com/user-attachments/assets/8fe4a523-b840-43c4-8c3b-92fe08e30402" />
