### PR TITLE
Fix string conversion warnings by changing more strings to UTF8String

### DIFF
--- a/src/base/UDLLManager.pas
+++ b/src/base/UDLLManager.pas
@@ -67,11 +67,11 @@ type
       procedure UnLoadWebsite;
 
       function  WebsiteSendScore (var SendInfo: TSendInfo): byte;
-      function  WebsiteEncryptScore (var SendInfo: TSendInfo): string;
+      function  WebsiteEncryptScore (var SendInfo: TSendInfo): UTF8String;
       function  WebsiteLogin (var LoginInfo: TLoginInfo): byte;
-      function  WebsiteEncryptPassword (var LoginInfo: TLoginInfo): string;
-      function  WebsiteDownloadScore (List_MD5Song: widestring; Level: byte): string;
-      function  WebsiteVerifySong (MD5Song: widestring): string;
+      function  WebsiteEncryptPassword (var LoginInfo: TLoginInfo): UTF8String;
+      function  WebsiteDownloadScore (List_MD5Song: UTF8String; Level: byte): UTF8String;
+      function  WebsiteVerifySong (MD5Song: UTF8String): UTF8String;
   end;
 
 var
@@ -224,10 +224,15 @@ begin
     Result := 0;
 end;
 
-function TDLLMan.WebsiteEncryptScore (var SendInfo: TSendInfo): string;
+function TDLLMan.WebsiteEncryptScore (var SendInfo: TSendInfo): UTF8String;
+var
+  WideResult: WideString;
 begin
   if (@P_EncryptScore <> nil) then
-    Result := P_EncryptScore (SendInfo)
+  begin
+    WideResult := P_EncryptScore(SendInfo);
+    Result := UTF8Encode(WideResult);
+  end
   else
     Result := '';
 end;
@@ -240,28 +245,45 @@ begin
     Result := 0;
 end;
 
-function TDLLMan.WebsiteEncryptPassword (var LoginInfo: TLoginInfo): string;
+function TDLLMan.WebsiteEncryptPassword (var LoginInfo: TLoginInfo): UTF8String;
+var
+  WideResult: WideString;
 begin
   if (@P_EncryptPassword <> nil) then
   begin
-    Result := P_EncryptPassword (LoginInfo);
+    WideResult := P_EncryptPassword(LoginInfo);
+    Result := UTF8Encode(WideResult);
   end
   else
     Result := '';
 end;
 
-function TDLLMan.WebsiteDownloadScore (List_MD5Song: widestring; Level: byte): string;
+function TDLLMan.WebsiteDownloadScore (List_MD5Song: UTF8String; Level: byte): UTF8String;
+var
+  WideList: WideString;
+  WideResult: WideString;
 begin
   if (@P_DownloadScore <> nil) then
-    Result := P_DownloadScore (List_MD5Song, Level)
+  begin
+    WideList := UTF8Decode(List_MD5Song);
+    WideResult := P_DownloadScore(WideList, Level);
+    Result := UTF8Encode(WideResult);
+  end
   else
     Result := '';
 end;
 
-function TDLLMan.WebsiteVerifySong (MD5Song: widestring): string;
+function TDLLMan.WebsiteVerifySong (MD5Song: UTF8String): UTF8String;
+var
+  WideMd5: WideString;
+  WideResult: WideString;
 begin
   if (@P_VerifySong <> nil) then
-    Result := P_VerifySong (MD5Song)
+  begin
+    WideMd5 := UTF8Decode(MD5Song);
+    WideResult := P_VerifySong(WideMd5);
+    Result := UTF8Encode(WideResult);
+  end
   else
     Result := '';
 end;

--- a/src/base/UDataBase.pas
+++ b/src/base/UDataBase.pas
@@ -140,15 +140,15 @@ type
 
       procedure AddMax_Score (Song: TSong; WebID: integer; Receive_Max_Score: integer; Level: integer);
       procedure AddMedia_Score (Song: TSong; WebID: integer; Receive_Media_Score: integer; Level: integer);
-      procedure AddUser_Score (Song: TSong; WebID: integer; Receive_User_Score: string; Level: integer);
+      procedure AddUser_Score (Song: TSong; WebID: integer; Receive_User_Score: UTF8String; Level: integer);
 
       function ReadMax_Score(Artist, Title: UTF8String; WebID, Level: integer): integer;
       function ReadMedia_Score(Artist, Title: UTF8String; WebID, Level: integer): integer;
-      function ReadUser_Score(Artist, Title: UTF8String; WebID, Level: integer): string;
+      function ReadUser_Score(Artist, Title: UTF8String; WebID, Level: integer): UTF8String;
 
       function ReadMax_ScoreLocal(Artist, Title: UTF8String; Level: integer): integer;
       function ReadMedia_ScoreLocal(Artist, Title: UTF8String; Level: integer): integer;
-      function ReadUser_ScoreLocal(Artist, Title: UTF8String; Level: integer): string;
+      function ReadUser_ScoreLocal(Artist, Title: UTF8String; Level: integer): UTF8String;
 
       function Delete_Score(Song: TSong; WebID: integer): integer;
 
@@ -1011,9 +1011,9 @@ end;
 (**
  * Add User to Song
  *)
-procedure TDataBaseSystem.AddUser_Score (Song: TSong; WebID: integer; Receive_User_Score: string; Level: integer);
+procedure TDataBaseSystem.AddUser_Score (Song: TSong; WebID: integer; Receive_User_Score: UTF8String; Level: integer);
 var
-  User_Score: string;
+  User_Score: UTF8String;
   ID: integer;
   TableData: TSQLiteTable;
 begin
@@ -1042,7 +1042,7 @@ begin
           'UPDATE ['+cUS_Webs_Stats+'] ' +
           'SET [User_Score_' + IntToStr(Level) + '] = ? ' +
           ' WHERE [WebID] = ? AND [SongID] = ?;',
-          [UTF8Encode(Receive_User_Score), WebID, ID]);
+          [Receive_User_Score, WebID, ID]);
     end;
 
   except on E: Exception do
@@ -1129,9 +1129,9 @@ end;
 (**
  * Read User_Score
  *)
-function TDataBaseSystem.ReadUser_Score(Artist, Title: UTF8String; WebID, Level: integer): string;
+function TDataBaseSystem.ReadUser_Score(Artist, Title: UTF8String; WebID, Level: integer): UTF8String;
 var
-  User_Score: string;
+  User_Score: UTF8String;
   SongID: integer;
   TableData: TSQLiteTable;
 begin
@@ -1158,7 +1158,7 @@ begin
 
   TableData.Free;
 
-  Result := UTF8Decode(User_Score);
+  Result := User_Score;
 
 end;
 
@@ -1241,9 +1241,9 @@ end;
 (**
  * Read User_Score
  *)
-function TDataBaseSystem.ReadUser_ScoreLocal(Artist, Title: UTF8String; Level: integer): string;
+function TDataBaseSystem.ReadUser_ScoreLocal(Artist, Title: UTF8String; Level: integer): UTF8String;
 var
-  User_Score: string;
+  User_Score: UTF8String;
   ID: integer;
   TableData: TSQLiteTable;
 begin

--- a/src/base/UFilesystem.pas
+++ b/src/base/UFilesystem.pas
@@ -654,7 +654,7 @@ end;
 
 function TFileSystemImpl.FindFirst(const FilePattern: IPath; Attr: integer; var F: TSytemSearchRec): integer;
 begin
-  Result := SysUtils.FindFirst(FilePattern.ToNative(), Attr, F);
+  Result := SysUtils.FindFirst(UTF8Decode(FilePattern.ToUTF8()), Attr, F);
 end;
 
 function TFileSystemImpl.FindNext(var F: TSytemSearchRec): integer;

--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -918,7 +918,7 @@ var
   Done: byte;      // bit-vector of mandatory fields
   MedleyFlags: byte; //bit-vector for medley/preview tags
   EncFile: IPath; // encoded filename
-  FullFileName: string;
+  FullFileName: UTF8String;
   I: integer;
   TagMap: TFPGMap<string, string>;
 
@@ -1012,7 +1012,7 @@ begin
 
   //SetLength(tmpEdition, 0);
 
-  FullFileName := Path.Append(Filename).ToWide;
+  FullFileName := Path.Append(Filename).ToUTF8;
 
   //Read first Line
   SongFile.ReadLine(Line);
@@ -1929,4 +1929,3 @@ begin
 end;
 
 end.
-

--- a/src/base/USongs.pas
+++ b/src/base/USongs.pas
@@ -282,7 +282,7 @@ begin
     if ((FileInfo.Attr and faDirectory) <> 0) then
     begin
       if Recursive and (not FileName.Equals('.')) and (not FileName.Equals('..')) and (not FileName.Equals('')) then begin
-        Log.LogDebug('Recursing: ' + Dir.Append(FileName).ToWide, 'TSongs.FindFilesByExtension');
+        Log.LogDebug('Recursing: ' + Dir.Append(FileName).ToUTF8, 'TSongs.FindFilesByExtension');
         FindFilesByExtension(Dir.Append(FileName), Ext, true, Files);
       end;
     end
@@ -291,7 +291,7 @@ begin
       // do not load files which either have wrong extension or start with a point
       if (Ext.Equals(FileName.GetExtension(), true) and not (FileName.ToUTF8()[1] = '.')) then
       begin
-        Log.LogDebug('Found file ' + Dir.Append(FileName).ToWide, 'TSongs.FindFilesByExtension');
+        Log.LogDebug('Found file ' + Dir.Append(FileName).ToUTF8, 'TSongs.FindFilesByExtension');
         SetLength(Files, Length(Files)+1);
         Files[High(Files)] := Dir.Append(FileName);
       end;
@@ -307,7 +307,7 @@ var
   //CloneSong: TSong;
   Extension: IPath;
 begin
-  Log.LogDebug('Searching directory ' + Dir.ToWide + ' for txt files', 'TSongs.BrowseTXTFiles');
+  Log.LogDebug('Searching directory ' + Dir.ToUTF8 + ' for txt files', 'TSongs.BrowseTXTFiles');
   SetLength(Files, 0);
   Extension := Path('.txt');
   FindFilesByExtension(Dir, Extension, true, Files);

--- a/src/encoding/Locale.inc
+++ b/src/encoding/Locale.inc
@@ -42,14 +42,13 @@ end;
 
 function TEncoderLocale.Decode(const InStr: AnsiString; out OutStr: UCS4String): boolean;
 begin
-  OutStr := WideStringToUCS4String(InStr); // use implicit conversion
+  OutStr := WideStringToUCS4String(WideString(InStr));
   Result := true;
 end;
 
 function TEncoderLocale.Encode(const InStr: UCS4String; out OutStr: AnsiString): boolean;
 begin
-  OutStr := UCS4StringToWideString(InStr); // use implicit conversion
+  OutStr := AnsiString(UCS4StringToWideString(InStr));
   // any way to check for errors?
   Result := true;
 end;
-

--- a/src/screens/UScreenJukebox.pas
+++ b/src/screens/UScreenJukebox.pas
@@ -530,7 +530,7 @@ begin
 
   if (Filter <> '') then
   begin
-    Filter := LowerCase(TransliterateToASCII(UTF8Decode(Filter)));
+    Filter := UTF8LowerCase(TransliterateToASCII(Filter));
 
     SetLength(JukeboxVisibleSongs, 0);
     for I := 0 to High(JukeboxSongsList) do
@@ -2925,4 +2925,3 @@ begin
 end;
 
 end.
-

--- a/src/screens/UScreenOptionsNetwork.pas
+++ b/src/screens/UScreenOptionsNetwork.pas
@@ -95,7 +95,7 @@ uses
   SysUtils;
 
 var
-  Receive_String: widestring;
+  Receive_String: UTF8String;
 
 // My   *silly*   write function just counts the number of "<" characters.
 // Your *serious* write function will probably want to do something else...
@@ -104,7 +104,7 @@ var I:LongInt;
 begin
   Result:= ( ItemSize * ItemCount );
   for I:=0 to Result-1 do
-    Receive_String := Receive_String + widechar(IncomingData[I]);
+    Receive_String := Receive_String + UTF8String(AnsiChar(IncomingData[I]));
 end;
 
 procedure OnDeleteUser(Value: boolean; Data: Pointer);
@@ -695,4 +695,3 @@ begin
 end;
 
 end.
-

--- a/src/screens/UScreenPopup.pas
+++ b/src/screens/UScreenPopup.pas
@@ -179,8 +179,8 @@ type
 
       Texture_ProgressBar: TTexture;
 
-      List_MD5Song: widestring;
-      Receive_List: array[0..2] of widestring;
+      List_MD5Song: UTF8String;
+      Receive_List: array[0..2] of UTF8String;
       Actual_Level: integer;
       Position_Receive_List: array[0..2] of integer;
 
@@ -959,7 +959,7 @@ end;
 
 procedure TScreenPopupScoreDownload.SaveScoreSong();
 var
-  String_Text, User_Score, Max_Score, Media_Score: string;
+  String_Text, User_Score, Max_Score, Media_Score: UTF8String;
   J, Update: integer;
   DeleteSongLevel: array [0..2] of boolean;
 begin
@@ -1032,7 +1032,7 @@ end;
 
 procedure TScreenPopupScoreDownload.FileSaveScoreSong();
 var
-  String_Text, User_Score, Max_Score, Media_Score, MD5_Song: string;
+  String_Text, User_Score, Max_Score, Media_Score, MD5_Song: UTF8String;
   Level: byte;
   Update: integer;
   SongExist: boolean;

--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -251,7 +251,7 @@ procedure SendScore(SendInfo: TSendInfo; Website: integer);
 var
   LoginInfo: TLoginInfo;
   SendStatus: integer;
-  EncryptPassword: widestring;
+  EncryptPassword: UTF8String;
 begin
 
   // Encrypt Password (with username and password)
@@ -283,9 +283,9 @@ end;
 procedure SaveScore(SendInfo: TSendInfo; Website: integer);
 var
   LoginInfo: TLoginInfo;
-  EncryptPassword: widestring;
+  EncryptPassword: UTF8String;
   ScoreFile: TextFile;
-  EncryptText: string;
+  EncryptText: UTF8String;
   WebName: UTF8String;
 begin
   // Encrypt Password (with username and password)

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -649,7 +649,7 @@ var
   UpperLetter: UCS4Char;
   TempLetter: UCS4Char;
   TempStr: UTF8String;
-  VerifySong, WebList: string;
+  VerifySong, WebList: UTF8String;
   Fix: boolean;
   VS: integer;
 


### PR DESCRIPTION
as discussed on Discord, there still were a bunch of warnings related to implicit string conversions.
this PR replaces WideString and AnsiString in several places to UTF8String, reducing the need for conversions, and adds correct explicit conversions where necessary