### PR TITLE
Bugfix: fix unicode path issue on windows

### DIFF
--- a/src/base/UFont.pas
+++ b/src/base/UFont.pas
@@ -39,6 +39,9 @@ uses
   Math,
   Classes,
   SysUtils,
+  {$IFDEF MSWINDOWS}
+  Windows,
+  {$ENDIF}
   UUnicodeUtils,
   UCommon,
   URenderer,
@@ -1055,7 +1058,7 @@ begin
   // The result is our mipmap-level = the index of the mipmap to use.
 
   // Level > 0: Minification; < 0: Magnification
-  Result := Trunc(Log2(Max(WidthScale, HeightScale)) + cBias);
+  Result := Trunc(Log2(Math.Max(WidthScale, HeightScale)) + cBias);
 
   // clamp to valid range
   if (Result < 0) then
@@ -1270,20 +1273,49 @@ end;
  * TFTFontFace
  *}
 
- constructor TFTFontFace.Create(const Filename: IPath; Size: integer);
- var
-   b1: Integer;
- begin
-   inherited Create();
-   b1:=3;
+constructor TFTFontFace.Create(const Filename: IPath; Size: integer);
+var
+  b1: Integer;
+  Utf8FileName: UTF8String;
+  {$IFDEF MSWINDOWS}
+  FileHandle: THandle;
+  FileSize: DWORD;
+  BytesRead: DWORD;
+  WideFileName: WideString;
+  {$ENDIF}
+begin
+  inherited Create();
+  b1:=3;
 
-   fFilename := Filename;
-   fSize := Size;
-   try
-     b1 := FT_New_Face(TFreeType.GetLibrary(), PChar(Filename.ToNative), 0, fFace);
-   except
-     raise EFontError.Create('FT_New_Face: Error - Could not load font file to memory on Windows '''  + Filename.ToNative + '''');
-   end;
+  fFilename := Filename;
+  fSize := Size;
+  try
+    {$IFDEF MSWINDOWS}
+    WideFileName := Filename.ToWide();
+    FileHandle := CreateFileW(PWideChar(WideFileName), GENERIC_READ, FILE_SHARE_READ, nil, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
+    if (FileHandle = INVALID_HANDLE_VALUE) then
+      raise EFontError.Create('FT_New_Face: Error - Could not open font file '''  + Filename.ToNative + '''');
+
+    try
+      FileSize := GetFileSize(FileHandle, nil);
+      if (FileSize = INVALID_FILE_SIZE) or (FileSize = 0) or (FileSize > High(Integer)) then
+        raise EFontError.Create('FT_New_Face: Error - Could not read font file size '''  + Filename.ToNative + '''');
+
+      SetLength(byarr1, FileSize);
+      if (not ReadFile(FileHandle, byarr1[0], FileSize, BytesRead, nil)) or (BytesRead <> FileSize) then
+        raise EFontError.Create('FT_New_Face: Error - Could not read font file '''  + Filename.ToNative + '''');
+    finally
+      CloseHandle(FileHandle);
+    end;
+
+    b1 := FT_New_Memory_Face(TFreeType.GetLibrary(), @byarr1[0], Length(byarr1), 0, fFace);
+    {$ELSE}
+    Utf8FileName := Filename.ToUTF8();
+    b1 := FT_New_Face(TFreeType.GetLibrary(), PAnsiChar(Utf8FileName), 0, fFace);
+    {$ENDIF}
+  except
+    raise EFontError.Create('FT_New_Face: Error - Could not load font file to memory on Windows '''  + Filename.ToNative + '''');
+  end;
    // load font information
    if (b1 <> 0) then
      raise EFontError.Create('FT_New_Face: Could not load font '''  + Filename.ToNative + '''');

--- a/src/base/UPlatform.pas
+++ b/src/base/UPlatform.pas
@@ -44,7 +44,7 @@ uses
 
 type
   TPlatform = class
-    function GetExecutionDir(): IPath;
+    function GetExecutionDir(): IPath; virtual;
     procedure Init; virtual;
 
     function TerminateIfAlreadyRunning(var WndTitle: string): boolean; virtual;

--- a/src/base/UPlatformWindows.pas
+++ b/src/base/UPlatformWindows.pas
@@ -52,6 +52,7 @@ type
     public
       procedure Init; override;
       function TerminateIfAlreadyRunning(var WndTitle: String): Boolean; override;
+      function GetExecutionDir(): IPath; override;
 
       function GetLogPath: IPath; override;
       function GetGameSharedPath: IPath; override;
@@ -100,6 +101,24 @@ begin
       else
         Result := true;
     end;
+end;
+
+{**
+ * Returns the directory of the executable (Unicode-safe on Windows)
+ *}
+function TPlatformWindows.GetExecutionDir(): IPath;
+var
+  Buffer: array [0..MAX_PATH-1] of WideChar;
+  Len: DWORD;
+  ExecName: IPath;
+begin
+  Len := GetModuleFileNameW(0, @Buffer, Length(Buffer));
+  if (Len > 0) then
+    ExecName := Path(WideString(Buffer))
+  else
+    ExecName := Path(ParamStr(0));
+
+  Result := ExecName.GetPath().GetAbsolutePath();
 end;
 
 (**

--- a/src/lib/SQLite/SQLite3.pas
+++ b/src/lib/SQLite/SQLite3.pas
@@ -98,6 +98,7 @@ type
     
 
 function SQLite3_Open(filename: PAnsiChar; out db: TSQLiteDB): integer; cdecl; external SQLiteDLL name 'sqlite3_open';
+function SQLite3_Open16(filename: PWideChar; out db: TSQLiteDB): integer; cdecl; external SQLiteDLL name 'sqlite3_open16';
 function SQLite3_Close(db: TSQLiteDB): integer; cdecl; external SQLiteDLL name 'sqlite3_close';
 function SQLite3_Exec(db: TSQLiteDB; SQLStatement: PAnsiChar; CallbackPtr: TSQLiteExecCallback; UserData: Pointer; var ErrMsg: PAnsiChar): integer; cdecl; external SQLiteDLL name 'sqlite3_exec';
 function SQLite3_Version(): PAnsiChar; cdecl; external SQLiteDLL name 'sqlite3_libversion';

--- a/src/lib/SQLite/SQLiteTable3.pas
+++ b/src/lib/SQLite/SQLiteTable3.pas
@@ -274,7 +274,6 @@ constructor TSQLiteDatabase.Create(const FileName: string);
 var
   Msg: PAnsiChar;
   iResult: integer;
-  utf8FileName: UTF8string;
 begin
   inherited Create;
   fParams := TList.Create;
@@ -283,8 +282,11 @@ begin
 
   Msg := nil;
   try
-    utf8FileName := UTF8String(FileName);
-    iResult := SQLite3_Open(PAnsiChar(utf8FileName), Fdb);
+    {$IFDEF MSWINDOWS}
+    iResult := SQLite3_Open16(PWideChar(UTF8Decode(UTF8String(FileName))), Fdb);
+    {$ELSE}
+    iResult := SQLite3_Open(PAnsiChar(UTF8String(FileName)), Fdb);
+    {$ENDIF}
 
     if iResult <> SQLITE_OK then
       if Assigned(Fdb) then

--- a/src/lua/ULuaCore.pas
+++ b/src/lua/ULuaCore.pas
@@ -37,7 +37,8 @@ uses
   SysUtils,
   UHookableEvent,
   ULua,
-  UPath;
+  UPath,
+  UFilesystem;
 
 type
   { this exception is raised when the lua panic function
@@ -205,7 +206,6 @@ implementation
 uses
   StrUtils,
   ULog,
-  UFilesystem,
   ULuaUsdx,
   UPathUtils,
   ULuaUtils;
@@ -685,6 +685,10 @@ end;
 { does the main loading part
   can not be called by create, because Plugins[Id] isn't defined there }
 procedure TLuaPlugin.Load;
+var
+  FileHandle: TFileHandle;
+  FileSize: int64;
+  Source: RawByteString;
 begin
   // create Lua state for this plugin
   State := luaL_newstate;
@@ -693,7 +697,24 @@ begin
   // we don't expect
   lua_atPanic(State, TLua_CustomPanic);
 
-  if (LuaL_LoadFile(State, PChar(Filename.ToNative)) = 0) then
+  FileHandle := Filename.Open(fmOpenRead or fmShareDenyNone);
+  if (FileHandle <> TFileHandle(-1)) then
+  begin
+    FileSize := FileSeek(FileHandle, 0, 2);
+    FileSeek(FileHandle, 0, 0);
+    SetLength(Source, FileSize);
+    if (Length(Source) = 0) or
+       (FileRead(FileHandle, Source[1], Length(Source)) = Length(Source)) then
+      FileSize := Length(Source)
+    else
+      FileSize := -1;
+    FileClose(FileHandle);
+  end
+  else
+    FileSize := -1;
+
+  if (FileSize >= 0) and
+     (luaL_loadbuffer(State, PChar(Source), FileSize, PChar(Filename.ToUTF8)) = 0) then
   begin // file loaded successful
     { note: we run the file here, but the environment isn't
             set up now. it just causes the functions to
@@ -719,7 +740,7 @@ begin
       lua_pop(State, Lua_GetTop(State));
 
       // make current plugin filename (with absolute path) available to the plugin
-      lua_pushstring(State, PChar(Filename.ToNative));
+      lua_pushstring(State, PChar(Filename.ToUTF8));
       lua_setglobal(State, PChar('current_filename'));
 
       // now run the plugin_init function
@@ -737,7 +758,7 @@ begin
       else
       begin
         sStatus := psErrorInInit;
-        Log.LogError('error in plugin_init: ' + Self.Filename.ToNative, 'lua');
+        Log.LogError('error in plugin_init: ' + Self.Filename.ToUTF8, 'lua');
         Unload;
       end;
     end
@@ -745,7 +766,7 @@ begin
     begin
       sStatus := psErrorOnLoad;
       Log.LogError(String(lua_toString(State, 1)), 'lua');
-      Log.LogError('unable to call file: ' + Self.Filename.ToNative, 'lua');
+      Log.LogError('unable to call file: ' + Self.Filename.ToUTF8, 'lua');
       Unload;
     end;
 
@@ -754,7 +775,7 @@ begin
   begin
     sStatus := psErrorOnLoad;
     Log.LogError(String(lua_toString(State, 1)), 'lua');
-    Log.LogError('unable to load file: ' + Self.Filename.ToNative, 'lua');
+    Log.LogError('unable to load file: ' + Self.Filename.ToUTF8, 'lua');
     Unload;
   end;
 end;


### PR DESCRIPTION
Fixes #926, a unicode path issue. Tested on Windows 11 with the path from the issue.

Also fixes #123.

Place the game in a folder "测试" and try it out. On master: themes fail to load. even if fixed, plugins fails then. With this: both work.