### PR TITLE
fix flathub linter warning about appstream-missing-vcs-browser-url

### DIFF
--- a/dists/ultrastardx.appdata.xml
+++ b/dists/ultrastardx.appdata.xml
@@ -14,6 +14,7 @@
   <url type="homepage">https://usdx.eu/</url>
   <url type="bugtracker">https://github.com/UltraStar-Deluxe/USDX/issues</url>
   <url type="translate">https://www.transifex.com/usdx/usdx</url>
+  <url type="vcs-browser">https://github.com/UltraStar-Deluxe/USDX</url>
   <screenshots>
     <screenshot type="default">
       <image>https://usdx.eu/images/screenshots/song_6_player_projectm.jpg</image>


### PR DESCRIPTION
I was doing release 2026.2.0 and there were some warnings at the bottom of the summary page:
https://github.com/flathub-infra/vorarbeiter/actions/runs/21795387192

screenshotted in case the link stops working:
<img width="598" height="354" alt="2026-02-08-100222_598x354_scrot" src="https://github.com/user-attachments/assets/1af9e410-c638-4e2e-b0b4-4b8455cbd2c3" />

Documentation:
* https://docs.flathub.org/docs/for-app-authors/linter#appstream-missing-vcs-browser-url
* https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#url

I think this is how we're supposed to fix this? I have no idea how flathub works.