### PR TITLE
Fix Memory Leaks in Sing Screen and Score Screen

### DIFF
--- a/src/base/UTexture.pas
+++ b/src/base/UTexture.pas
@@ -88,6 +88,7 @@ function TextureTypeToStr(TexType: TTextureType): string;
 function ParseTextureType(const TypeStr: string; Default: TTextureType): TTextureType;
 
 procedure AdjustPixelFormat(var TexSurface: PSDL_Surface; Typ: TTextureType);
+procedure FreeTexture(var Texture: TTexture);
 
 type
   PTextureEntry = ^TTextureEntry;
@@ -170,6 +171,15 @@ begin
     TempSurface := TexSurface;
     TexSurface := SDL_ConvertSurfaceFormat(TempSurface, NeededPixFmt, 0);
     SDL_FreeSurface(TempSurface);
+  end;
+end;
+
+procedure FreeTexture(var Texture: TTexture);
+begin
+  if (Texture.TexNum <> 0) then
+  begin
+    glDeleteTextures(1, @Texture.TexNum);
+    Texture.TexNum := 0;
   end;
 end;
 

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -407,8 +407,8 @@ begin
 
           // Reload ScreenSing and ScreenScore because of player colors
           // TODO: do this better  REALLY NECESSARY?
-          //ScreenScore.Free;
-          //ScreenSing.Free;
+          ScreenScore.Free;
+          ScreenSing.Free;
 
           ScreenScore := TScreenScore.Create;
           ScreenSing  := TScreenSingController.Create;

--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -205,6 +205,7 @@ type
       procedure SwapToScreen(Screen: integer);
     public
       constructor Create; override;
+      destructor Destroy; override;
       function ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean; override;
       function ParseMouse(MouseButton: Integer; BtnDown: Boolean; X, Y: integer): boolean; override;
       procedure OnShow; override;
@@ -1001,6 +1002,22 @@ begin
   for I := 1 to 3 do
     ButtonSend[I] := AddButton(Theme.Score.ButtonSend[I]);
 
+end;
+
+destructor TScreenScore.Destroy;
+var
+  I: integer;
+begin
+  for I := 1 to UIni.IMaxPlayerCount do
+  begin
+    FreeTexture(Tex_Score_NoteBarLevel_Dark[I]);
+    FreeTexture(Tex_Score_NoteBarRound_Dark[I]);
+    FreeTexture(Tex_Score_NoteBarLevel_Light[I]);
+    FreeTexture(Tex_Score_NoteBarRound_Light[I]);
+    FreeTexture(Tex_Score_NoteBarLevel_Lightest[I]);
+    FreeTexture(Tex_Score_NoteBarRound_Lightest[I]);
+  end;
+  inherited;
 end;
 
 //TODO: adapt for players 7 to 12

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -166,6 +166,7 @@ type
     procedure EndSong;
 
     constructor Create; override;
+    destructor Destroy; override;
     procedure OnShow; override;
     procedure OnShowFinish; override;
     procedure OnHide; override;
@@ -678,6 +679,19 @@ begin
   BackgroundAspectCorrection := acoLetterBox;
 
   ClearSettings;
+end;
+
+destructor TScreenSingController.Destroy;
+begin
+  FreeAndNil(screenSingViewRef);
+  Lyrics.Free;
+  LyricsDuetP1.Free;
+  LyricsDuetP2.Free;
+  fLyricsSync.Free;
+  fMusicSync.Free;
+  eSongLoaded.Free;
+  Scores.Free;
+  inherited;
 end;
 
 procedure TScreenSingController.OnShow;
@@ -1339,11 +1353,7 @@ begin
   fCurrentVideo := nil;
 
   // background texture
-  if Tex_Background.TexNum > 0 then
-  begin
-    glDeleteTextures(1, PGLuint(@Tex_Background.TexNum));
-    Tex_Background.TexNum := 0;
-  end;
+  FreeTexture(Tex_Background);
   if fShowWebcam then
         begin
           Webcam.Release;

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -193,6 +193,7 @@ type
 
 
     constructor Create;
+    destructor Destroy; override;
 
     procedure DrawMedleyCountdown();
     function Draw: boolean;
@@ -710,6 +711,41 @@ begin
   assignAvatarStatic(Theme.Sing.Duet3PP1, StaticDuetP1ThreePAvatar[1], AvatarPlayerTextures[4]);
   assignAvatarStatic(Theme.Sing.Duet3PP2, StaticDuetP2MAvatar[1]     , AvatarPlayerTextures[5]);
   assignAvatarStatic(Theme.Sing.Duet3PP3, StaticDuetP3RAvatar[1]     , AvatarPlayerTextures[6]);
+end;
+
+destructor TScreenSingView.Destroy;
+var
+  I: integer;
+begin
+  for I := 1 to UIni.IMaxPlayerCount do
+  begin
+    FreeTexture(Tex_Left[I]);
+    FreeTexture(Tex_Mid[I]);
+    FreeTexture(Tex_Right[I]);
+    FreeTexture(Tex_plain_Left[I]);
+    FreeTexture(Tex_plain_Mid[I]);
+    FreeTexture(Tex_plain_Right[I]);
+    FreeTexture(Tex_BG_Left[I]);
+    FreeTexture(Tex_BG_Mid[I]);
+    FreeTexture(Tex_BG_Right[I]);
+    FreeTexture(Tex_Left_Rap[I]);
+    FreeTexture(Tex_Mid_Rap[I]);
+    FreeTexture(Tex_Right_Rap[I]);
+    FreeTexture(Tex_plain_Left_Rap[I]);
+    FreeTexture(Tex_plain_Mid_Rap[I]);
+    FreeTexture(Tex_plain_Right_Rap[I]);
+    FreeTexture(Tex_BG_Left_Rap[I]);
+    FreeTexture(Tex_BG_Mid_Rap[I]);
+    FreeTexture(Tex_BG_Right_Rap[I]);
+    FreeTexture(Tex_ScoreBG[I - 1]);
+  end;
+  FreeTexture(Tex_Left_Inv);
+  FreeTexture(Tex_Mid_Inv);
+  FreeTexture(Tex_Right_Inv);
+  FreeTexture(Tex_Left_Rap_Inv);
+  FreeTexture(Tex_Mid_Rap_Inv);
+  FreeTexture(Tex_Right_Rap_Inv);
+  inherited;
 end;
 
 function TScreenSingView.Draw: boolean;


### PR DESCRIPTION
The sing screen and score screen are not loaded in the usual `LoadScreens` function, because they depend on player colors. Due to this, they don't get loaded until the user confirms the player selection on the player selection screen (`ScreenName`).

Every time the player selection changes, the sing screen and score screen are created again, but the old ones are not freed. If you're having a party/event where the player selection is changing frequently, this will leak a lot of memory over time.

Both screen classes lack destructors, so in addition to the `SingScreen` and `ScoreScreen` objects, *all* of the memory that they dynamically allocated is also leaked.

This PR makes the following changes:
- Free both `ScreenSing` and `ScreenScore` when reloading after a new player selection
- Add destructors to `TSingScreenController`, `TScreenSingView`, and `TScreenScore`. Free all dynamically allocated memory in the destructor.
- Add a function `FreeTexture` for freeing the `TTexture` record in a consistent manner (checking first if it contains a valid OpenGL texture)

Most of the underlying graphics classes also have memory leaks (`TStatic`, `TButton`, `TSelectSlide`, etc). So, there is still a lot of memory leaking when screens are reloaded, but I plan to submit separate PRs for those classes.