### PR TITLE
Improve picture quality

### DIFF
--- a/src/base/UGraphic.pas
+++ b/src/base/UGraphic.pas
@@ -559,7 +559,7 @@ begin
 
   SDL_SetWindowTitle(Screen, PChar(Title + ' - Initializing texturizer'));
   Texture := TTextureUnit.Create;
-  Texture.Limit :=1920; //currently, Full HD is all we want. switch to 64bit target before going further up
+  Texture.Limit :=4096;
 
   //LoadTextures;
   SDL_SetWindowTitle(Screen, PChar(Title + ' - Initializing video modules'));

--- a/src/base/UGraphic.pas
+++ b/src/base/UGraphic.pas
@@ -323,6 +323,7 @@ implementation
 
 uses
   Classes,
+  Math,
   UDisplay,
   UCommandLine,
   UPathUtils,
@@ -534,6 +535,7 @@ const
 procedure Initialize3D (Title: string);
 var
   Icon: PSDL_Surface;
+  MaxTextureSize: integer;
 begin
   Log.LogStatus('SDL_Init', 'UGraphic.Initialize3D');
   if ( SDL_InitSubSystem(SDL_INIT_VIDEO) = -1 ) then
@@ -559,7 +561,10 @@ begin
 
   SDL_SetWindowTitle(Screen, PChar(Title + ' - Initializing texturizer'));
   Texture := TTextureUnit.Create;
-  Texture.Limit :=4096;
+  glGetIntegerv(GL_MAX_TEXTURE_SIZE, @MaxTextureSize);
+  // beyond 4096 something starts becoming noticeably slow in LoadTexture
+  // memory usage also becomes an issue
+  Texture.Limit := Min(MaxTextureSize, 4096);
 
   //LoadTextures;
   SDL_SetWindowTitle(Screen, PChar(Title + ' - Initializing video modules'));

--- a/src/base/UGraphic.pas
+++ b/src/base/UGraphic.pas
@@ -562,6 +562,8 @@ begin
   SDL_SetWindowTitle(Screen, PChar(Title + ' - Initializing texturizer'));
   Texture := TTextureUnit.Create;
   glGetIntegerv(GL_MAX_TEXTURE_SIZE, @MaxTextureSize);
+  // log it because the actual usable size might be lower than the reported value
+  Log.LogStatus('Graphics reports '+IntToStr(MaxTextureSize)+' max texture size', 'UGraphic.Initialize3D');
   // beyond 4096 something starts becoming noticeably slow in LoadTexture
   // memory usage also becomes an issue
   Texture.Limit := Min(MaxTextureSize, 4096);


### PR DESCRIPTION
draft because one of the removed comments says something about needing 64-bit to do so.

I've been running this for... at least 3 years now on various Linux boxes (not RPi)

there's actually another one for the covers which (for some reason) comes from the ini `Graphics.TextureSize` but that one only accepts 64, 128, 256, 512. Iirc this also controls avatars though it's less relevant there. but perhaps we want to make sure to rip out everything related to the cover database (and maybe also the avatar database) before we touch that one. Also, _why_ is this an option in the first place and _why_ is the default 256.

I also removed the limit entirely at some point to see what would happen, but it did not like my 8000x4500 test png (it _worked_ but the song took about 6 seconds to start). With 4096 it's ~1 second, but 1920 is _also_ ~1 second, probably that's just the png parsing. maybe we could make this dynamic based on actual screen resolution? but the downscaling algorithm is _awful_ so especially for static singing backgrounds, you're going to want this to be _more_ than the screen width (I'd say at least 1.5-2x) and let the renderer sort out the rest, at which point 4096 is about the minimum?

granted, an 8000x4500 png is about the worst thing you can do (jpg is much faster, also in my normal collection I've resized that background to 50% of its size) but unless a theme uses huge textures for some reason, I think it's the editor where you can both the menu background and the song background loaded together.

I don't know if setting this to 4096 has repercussions to what kind of hardware it does and doesn't run on, I just know this works fine on all _my_ hardware (most of which is about 8 years old and has Intel IGPs)