### PR TITLE
throw parser error for stray track markers (P1/P2)

### DIFF
--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -739,6 +739,16 @@ begin
 
         if (Param0 = 'P') then
         begin
+          if (not Self.isDuet) then
+          begin
+            Log.LogError(
+              'Invalid track marker in solo song: "' + CurLine + '" in file "' + FileNamePath.ToNative +
+              '" at line ' + IntToStr(FileLineNo) + '. Track markers (P1/P2) are only allowed if the first note-section line after headers is a P-line.',
+              'TSong.LoadSong'
+            );
+            Result := false;
+            Exit;
+          end;
 
           if (CurLine[2] = ' ') then
             Param1 := StrToInt(CurLine[3])


### PR DESCRIPTION
addresses #1158 by throwing errors for stray track markers / no lines in a track

tested cases that now report an error:
- P1 but no P2
- P2 but no P1
- no lines in P1 track
- no lines in P2 track

tested cases that throw no error:
- P1 (first line) before P2 (later)
- P2 (first line) before P1 (later)
- multiple P1 and P2 sections (as long as it is none of the above error cases)