### PR TITLE
Fix: SkipTo should expect 0..N not 1..N

### DIFF
--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -3679,7 +3679,6 @@ begin
   end
   else
   begin
-    // it's still off by one in certain cases, will select the first or last overall song
     if TargetInteraction = -1 then
     begin
       i := 0;
@@ -3687,9 +3686,9 @@ begin
       begin
         if CatSongs.Song[TargetInteraction].Visible then
         begin
-          Inc(i);
           if Target = i then
             break;
+          Inc(i);
         end;
       end;
     end;


### PR DESCRIPTION
This is an issue that previously caused problems with playlists in general, and now still remained for ordered playlists and was already indirectly covered in some other patch, where songs outside of the playlist were selected. the reason was that SkipTo started counting at i=1 effectively but 0 could be passed to it. this led to different corner case behavior then where either a song outside of the playlist was selected or always the first.

the correct approach is to compare first, then increase if it did not match == starting counting at i = 0