### PR TITLE
fix multiple bugs in roulette mode (some also in other modes)

### DIFF
--- a/src/base/UPlaylist.pas
+++ b/src/base/UPlaylist.pas
@@ -370,8 +370,7 @@ begin
       Log.LogError('Playlist entry has invalid SongID after reordering: ' + Playlists[Index].Items[I].Artist + ' - ' + Playlists[Index].Items[I].Title);
   end;
 
-  CatSongs.LastVisChecked := 0;
-  CatSongs.LastVisIndex := 0;
+  CatSongs.ResetVisibleIndexCache;
 
   if ScreenSong.ListMinLine > 0 then
   begin

--- a/src/base/USongs.pas
+++ b/src/base/USongs.pas
@@ -134,6 +134,7 @@ type
     procedure HideCategory(Index: integer);                 // hides all songs in category
     procedure ClickCategoryButton(Index: integer);          // uses ShowCategory and HideCategory when needed
     procedure ShowCategoryList;                             // Hides all Songs And Show the List of all Categorys
+    procedure ResetVisibleIndexCache;
     function FindNextVisible(SearchFrom: integer): integer; // Find Next visible Song
     function FindPreviousVisible(SearchFrom: integer): integer; // Find Previous visible Song
     function VisibleSongs: integer;                         // returns number of visible songs (for tabs)
@@ -718,8 +719,7 @@ begin
     CurSong.Visible := true;
 }
   end;
-  LastVisChecked := 0;
-  LastVisIndex := 0;
+  ResetVisibleIndexCache;
 
   // set CatNumber of last category
   if (Ini.TabsAtStartup = 1) and (High(Song) >= 1) then
@@ -750,8 +750,7 @@ begin
 //  KMS: This should be the same, but who knows :-)
     CatSongs.Song[S].Visible := ((CatSongs.Song[S].OrderNum = Index) and (not CatSongs.Song[S].Main));
   end;
-  LastVisChecked := 0;
-  LastVisIndex := 0;
+  ResetVisibleIndexCache;
 end;
 
 procedure TCatSongs.HideCategory(Index: integer); // hides all songs in category
@@ -763,8 +762,7 @@ begin
     if not CatSongs.Song[S].Main then
       CatSongs.Song[S].Visible := false // hides all at now
   end;
-  LastVisChecked := 0;
-  LastVisIndex := 0;
+  ResetVisibleIndexCache;
 end;
 
 procedure TCatSongs.ClickCategoryButton(Index: integer);
@@ -792,10 +790,18 @@ begin
     CatSongs.Song[S].Visible := CatSongs.Song[S].Main;
   CatSongs.Selected := CatNumShow; //Show last shown Category
   CatNumShow := -1;
-  LastVisChecked := 0;
-  LastVisIndex := 0;
+  ResetVisibleIndexCache;
 end;
 //Hide Categorys when in Category Hack End
+
+procedure TCatSongs.ResetVisibleIndexCache;
+begin
+  LastVisChecked := 0;
+  LastVisIndex := 0;
+
+  if Length(Song) > 0 then
+    Song[0].VisibleIndex := 0;
+end;
 
 // Wrong song selected when tabs on bug
 function TCatSongs.FindNextVisible(SearchFrom:integer): integer;// Find next Visible Song
@@ -951,8 +957,7 @@ begin
     end;
     Result := 0;
   end;
-  LastVisChecked := 0;
-  LastVisIndex := 0;
+  ResetVisibleIndexCache;
 end;
 
 // -----------------------------------------------------------------------------

--- a/src/screens/UScreenOptionsGame.pas
+++ b/src/screens/UScreenOptionsGame.pas
@@ -288,6 +288,7 @@ procedure TScreenOptionsGame.ReloadSongMenu;
 begin
   if (Ini.Sorting <> old_Sorting) or (Ini.Tabs <> old_Tabs) or (old_SongMenu <> Ini.SongMenu) then
   begin
+    Ini.TabsAtStartup := Ini.Tabs;
     Theme.ThemeSongReload;
     ScreenSong.Free;
     ScreenSong := TScreenSong.Create;

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -360,7 +360,7 @@ var
 begin
   if (CatSongs.VisibleSongs > 0) then
   begin
-    if (Interaction > Low(CatSongs.Song)) and (Interaction <= High(CatSongs.Song)) then
+    if (Interaction >= Low(CatSongs.Song)) and (Interaction <= High(CatSongs.Song)) then
       I2 := CatSongs.VisibleIndex(Interaction)
     else
       I2 := CatSongs.VisibleSongs;
@@ -376,7 +376,7 @@ var
 begin
   if (CatSongs.VisibleSongs > 0) then
   begin
-    if (Interaction > Low(CatSongs.Song)) and (Interaction <= High(CatSongs.Song)) then
+    if (Interaction >= Low(CatSongs.Song)) and (Interaction <= High(CatSongs.Song)) then
       I2 := CatSongs.VisibleIndex(Interaction)
     else
       I2 := CatSongs.VisibleSongs;
@@ -655,6 +655,8 @@ var
     Idx, i: cardinal;
   begin
     Result := nil;
+    if Num <= 0 then
+      Exit;
     SetLength(Ordered, Num);
     SetLength(Result, Num);
     for i := 0 to Num-1 do Ordered[i] := i;
@@ -944,6 +946,9 @@ begin
           if (Songs.SongList.Count > 0) and
              (FreeListMode) then
           begin
+            if CatSongs.VisibleSongs <= 0 then
+              Exit;
+
             if (SDL_ModState = KMOD_LSHIFT) and (Ini.TabsAtStartup = 1) then // random category
             begin
               I2 := 0; // count cats
@@ -1010,7 +1015,8 @@ begin
             begin
               if CatSongs.CatNumShow = -2 then
               begin
-                if NextRandomSearchIdx >= CatSongs.VisibleSongs then
+                if (Length(RandomSearchOrder) <> CatSongs.VisibleSongs) or
+                   (NextRandomSearchIdx >= CatSongs.VisibleSongs) then
                 begin
                   NextRandomSearchIdx := 0;
                   RandomSearchOrder := RandomPermute(CatSongs.VisibleSongs);
@@ -1020,7 +1026,8 @@ begin
               end
               else
               begin
-                if NextRandomSongIdx >= CatSongs.VisibleSongs then
+                if (Length(RandomSongOrder) <> CatSongs.VisibleSongs) or
+                   (NextRandomSongIdx >= CatSongs.VisibleSongs) then
                 begin
                   NextRandomSongIdx := 0;
                   RandomSongOrder := RandomPermute(CatSongs.VisibleSongs);
@@ -1125,7 +1132,13 @@ begin
               //StopMusicPreview();
               OnSongDeSelect;
 
-              CatSongs.ShowCategoryList;
+              if (CatSongs.CatNumShow = -3) then
+              begin
+                CatSongs.SetFilter('', fltAll);
+                PlaylistMan.UnsetPlaylist;
+              end
+              else
+                CatSongs.ShowCategoryList;
 
               //Show Cat in Top Left Mod
               HideCatTL;
@@ -4036,8 +4049,7 @@ begin
       if CatSongs.Song[I].isDuet then
         CatSongs.Song[I].Visible := false;
     // Reset visible-index cache so VisibleIndex() recomputes correctly
-    CatSongs.LastVisChecked := 0;
-    CatSongs.LastVisIndex := 0;
+    CatSongs.ResetVisibleIndexCache;
   end;
 end;
 


### PR DESCRIPTION
fix multiple bugs in roulette mode (some also in other modes) related to not correctly updated bounds for randomness and indices
1. display bug in roulette mode with fixed order playlists
2. when leaving playlists in roulette mode the category cover went missing
3. when switching tabs on->off the song list was empty
4. pressing R in the above case (inccorectly empty song list) the game crashed
5. when leaving playlist mode with tabs=on and then pressing R in a folder crashed the game