### PR TITLE
tiny bug fix: P2 note overview was too high

### DIFF
--- a/game/themes/Modern.ini
+++ b/game/themes/Modern.ini
@@ -6073,6 +6073,7 @@ H = 10
 [EditSubP2InfoBarBackground]
 Inherits = EditSubHeaderBackground
 Y = 530
+H = 10
 
 [EditSubTitle]
 X = 30


### PR DESCRIPTION
<img width="1602" height="932" alt="grafik" src="https://github.com/user-attachments/assets/f1774b18-2491-4c87-ae09-05ac1e692aa5" />

a one line fix to get to the correct height:

<img width="1602" height="932" alt="grafik" src="https://github.com/user-attachments/assets/8ef8488c-11bf-4551-9322-73487a580528" />
