### PR TITLE
Bugfix: fix off by one in database interface

### DIFF
--- a/src/lib/SQLite/SQLiteTable3.pas
+++ b/src/lib/SQLite/SQLiteTable3.pas
@@ -393,7 +393,9 @@ begin
           vtString: begin // ShortString
             AnsiStr := Bindings[I].VString^;
             DataPtr := PAnsiChar(AnsiStr);
-            DataSize := Length(AnsiStr)+1;
+            // MODIFIED, original line was: DataSize := Length(AnsiStr)+1;
+            // reason: don't insert null byte at the end of a string
+            DataSize := Length(AnsiStr);
           end;
           vtPChar: begin
             DataPtr := Bindings[I].VPChar;
@@ -402,7 +404,9 @@ begin
           vtAnsiString: begin
             AnsiStrPtr := PAnsiString(@Bindings[I].VAnsiString);
             DataPtr := PAnsiChar(AnsiStrPtr^);
-            DataSize := Length(AnsiStrPtr^)+1;
+            // MODIFIED, original line was: DataSize := Length(AnsiStrPtr^)+1;
+            // reason: don't insert null byte at the end of a string
+            DataSize := Length(AnsiStrPtr^);
           end;
           vtPWideChar: begin
             AnsiStr := UTF8Encode(WideString(Bindings[I].VPWideChar));
@@ -417,7 +421,9 @@ begin
           vtChar: begin
             AnsiStr := AnsiString(Bindings[I].VChar);
             DataPtr := PAnsiChar(AnsiStr);
-            DataSize := 2;
+            // MODIFIED, original line was: DataSize := 2;
+            // reason: don't insert null byte at the end of a string
+            DataSize := Length(AnsiStr);
           end;
           vtWideChar: begin
             AnsiStr := UTF8Encode(WideString(Bindings[I].VWideChar));
@@ -427,7 +433,9 @@ begin
           else
             raise ESqliteException.Create('Unknown string-type');
         end;
-        if (sqlite3_bind_text(Stmt, I+1, DataPtr, DataSize, SQLITE_STATIC) <> SQLITE_OK) then
+        // MODIFIED, original line was: if (sqlite3_bind_text(Stmt, I+1, DataPtr, DataSize, SQLITE_STATIC) <> SQLITE_OK) then
+        // reason: use SQLITE_TRANSIENT for proper memory management
+        if (sqlite3_bind_text(Stmt, I+1, DataPtr, DataSize, SQLITE_TRANSIENT) <> SQLITE_OK) then
           RaiseError('Could not bind text', 'BindData');
       end;
       vtInteger:
@@ -1500,4 +1508,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
The database interface had an off by one error, leading to null bytes being added into the strings in the database. this fixes it and removes the null byte as a transition step