### PR TITLE
Improvement: refresh audio devices when entering ScreenOptionsRecord, only scan configured ones at startup

### DIFF
--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -107,7 +107,6 @@ uses
 procedure Main;
 var
   WindowTitle: string;
-  BadPlayer: integer;
 begin
   {$IFNDEF Debug}
   try
@@ -243,24 +242,6 @@ begin
       * Start background music
       *}
     SoundLib.StartBgMusic;
-
-    // check microphone settings, goto record options if they are corrupt
-    BadPlayer := AudioInputProcessor.ValidateSettings;
-    if (BadPlayer <> 0) then
-    begin
-      ScreenPopupError.ShowPopup(
-          Format(Language.Translate('ERROR_PLAYER_DEVICE_ASSIGNMENT'),
-          [BadPlayer]));
-      Display.CurrentScreen^.FadeTo( @ScreenOptionsRecord );
-    end;
-    BadPlayer := AudioInputProcessor.CheckPlayersConfig(1);
-    if (BadPlayer <> 0) then
-    begin
-      ScreenPopupError.ShowPopup(
-          Format(Language.Translate('ERROR_PLAYER_NO_DEVICE_ASSIGNMENT'),
-          [BadPlayer]));
-      Display.CurrentScreen^.FadeTo( @ScreenOptionsRecord );
-    end;
 
     //------------------------------
     // Start Mainloop

--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -646,6 +646,7 @@ var
 procedure InitializeSound;
 procedure InitializeVideo;
 procedure FinalizeMedia;
+function RefreshAudioInputDevices(): boolean;
 
 function  Visualization(): IVideoPlayback;
 function  VideoPlayback(): IVideoPlayback;
@@ -758,6 +759,25 @@ end;
 function AudioDecoders(): TInterfaceList;
 begin
   Result := AudioDecoderList;
+end;
+
+function RefreshAudioInputDevices(): boolean;
+var
+  CurrentAudioInput: IAudioInput;
+begin
+  CurrentAudioInput := AudioInput();
+  if not assigned(CurrentAudioInput) then
+  begin
+    Result := false;
+    Exit;
+  end;
+
+  CurrentAudioInput.FinalizeRecord();
+  Result := CurrentAudioInput.InitializeRecord();
+  if not Result then
+    Log.LogError('Failed to refresh input devices for ' + CurrentAudioInput.GetName());
+
+  AudioInputProcessor.UpdateInputDeviceConfig();
 end;
 
 procedure FilterInterfaceList(const IID: TGUID; InList, OutList: TInterfaceList);

--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -42,6 +42,11 @@ uses
   UWebcam;
 
 type
+  TAudioInputScanMode = (
+    aimFast,
+    aimFull
+  );
+
   TNoteType = (ntFreestyle, ntNormal, ntGolden, ntRap, ntRapGolden);
 
   TPos = record // Tracks[track].Lines[line].Notes[note]
@@ -547,7 +552,7 @@ type
   IAudioInput = Interface
   ['{A5C8DA92-2A0C-4AB2-849B-2F7448C6003A}']
       function GetName: String;
-      function InitializeRecord: boolean;
+      function InitializeRecord(ScanMode: TAudioInputScanMode): boolean;
       function FinalizeRecord(): boolean;
 
       procedure CaptureStart;
@@ -646,7 +651,7 @@ var
 procedure InitializeSound;
 procedure InitializeVideo;
 procedure FinalizeMedia;
-function RefreshAudioInputDevices(): boolean;
+function RefreshAudioInputDevices(ScanMode: TAudioInputScanMode): boolean;
 
 function  Visualization(): IVideoPlayback;
 function  VideoPlayback(): IVideoPlayback;
@@ -761,7 +766,7 @@ begin
   Result := AudioDecoderList;
 end;
 
-function RefreshAudioInputDevices(): boolean;
+function RefreshAudioInputDevices(ScanMode: TAudioInputScanMode): boolean;
 var
   CurrentAudioInput: IAudioInput;
 begin
@@ -773,7 +778,7 @@ begin
   end;
 
   CurrentAudioInput.FinalizeRecord();
-  Result := CurrentAudioInput.InitializeRecord();
+  Result := CurrentAudioInput.InitializeRecord(ScanMode);
   if not Result then
     Log.LogError('Failed to refresh input devices for ' + CurrentAudioInput.GetName());
 
@@ -848,7 +853,7 @@ begin
   for i := 0 to InterfaceList.Count-1 do
   begin
     CurrentAudioInput := InterfaceList[i] as IAudioInput;
-    if (CurrentAudioInput.InitializeRecord()) then
+    if (CurrentAudioInput.InitializeRecord(aimFast)) then
     begin
       DefaultAudioInput := CurrentAudioInput;
       break;

--- a/src/base/URecord.pas
+++ b/src/base/URecord.pas
@@ -191,10 +191,16 @@ type
     private
       Started: boolean;
     protected
+      ScanMode: TAudioInputScanMode;
+      SeenDeviceNames: array of UTF8String;
+
+      procedure PrepareDeviceScan(AScanMode: TAudioInputScanMode);
+      function IsDeviceAssigned(const name: UTF8String): boolean;
+      function ShouldProbeDevice(const name: UTF8String): boolean;
       function UnifyDeviceName(const name: UTF8String; deviceIndex: integer): UTF8String;
     public
       function GetName: String;           virtual; abstract;
-      function InitializeRecord: boolean; virtual; abstract;
+      function InitializeRecord(ScanMode: TAudioInputScanMode): boolean; virtual; abstract;
       function FinalizeRecord: boolean;   virtual;
 
       procedure CaptureStart;
@@ -875,7 +881,46 @@ begin
   for i := 0 to High(AudioInputProcessor.DeviceList) do
     AudioInputProcessor.DeviceList[i].Free();
   AudioInputProcessor.DeviceList := nil;
+  SeenDeviceNames := nil;
   Result := true;
+end;
+
+procedure TAudioInputBase.PrepareDeviceScan(AScanMode: TAudioInputScanMode);
+begin
+  ScanMode := AScanMode;
+  SeenDeviceNames := nil;
+end;
+
+function TAudioInputBase.IsDeviceAssigned(const name: UTF8String): boolean;
+var
+  DeviceIniIndex: integer;
+  ChannelIndex: integer;
+  DeviceCfg: PInputDeviceConfig;
+begin
+  Result := false;
+
+  for DeviceIniIndex := 0 to High(Ini.InputDeviceConfig) do
+  begin
+    DeviceCfg := @Ini.InputDeviceConfig[DeviceIniIndex];
+    if (DeviceCfg.Name <> Trim(name)) then
+      continue;
+
+    for ChannelIndex := 0 to High(DeviceCfg.ChannelToPlayerMap) do
+    begin
+      if (DeviceCfg.ChannelToPlayerMap[ChannelIndex] <> CHANNEL_OFF) then
+      begin
+        Result := true;
+        Exit;
+      end;
+    end;
+
+    Exit;
+  end;
+end;
+
+function TAudioInputBase.ShouldProbeDevice(const name: UTF8String): boolean;
+begin
+  Result := (ScanMode = aimFull) or IsDeviceAssigned(name);
 end;
 
 {*
@@ -972,16 +1017,13 @@ var
     i: integer;
   begin
     Result := false;
-    // search devices with same description
-    for i := 0 to deviceIndex-1 do
+    // search already seen devices with same description
+    for i := 0 to High(SeenDeviceNames) do
     begin
-      if (AudioInputProcessor.DeviceList[i] <> nil) then
+      if (SeenDeviceNames[i] = name) then
       begin
-        if (AudioInputProcessor.DeviceList[i].Name = name) then
-        begin
-          Result := true;
-          Break;
-        end;
+        Result := true;
+        Break;
       end;
     end;
   end;
@@ -997,6 +1039,9 @@ begin
     // set description
     result := name + ' ('+IntToStr(count)+')';
   end;
+
+  SetLength(SeenDeviceNames, Length(SeenDeviceNames) + 1);
+  SeenDeviceNames[High(SeenDeviceNames)] := result;
 end;
 
 end.

--- a/src/media/UAudioInput_Bass.pas
+++ b/src/media/UAudioInput_Bass.pas
@@ -59,7 +59,7 @@ type
       function EnumDevices(): boolean;
     public
       function GetName: String; override;
-      function InitializeRecord: boolean; override;
+      function InitializeRecord(ScanMode: TAudioInputScanMode): boolean; override;
       function FinalizeRecord: boolean; override;
   end;
 
@@ -363,7 +363,7 @@ var
   SourceIndex:  integer;
   RecordInfo: BASS_RECORDINFO;
   NumberOfSupportedChannels: byte;
-  SelectedSourceIndex: integer;
+  DeviceName: UTF8String;
 begin
   result := false;
 
@@ -377,13 +377,30 @@ begin
     if (not BASS_RecordGetDeviceInfo(BassDeviceID, DeviceInfo)) then
       break;
 
+    if ((DeviceInfo.flags and BASS_DEVICE_TYPE_MASK) = BASS_DEVICE_TYPE_SPEAKERS) then
+    begin
+      Inc(BassDeviceID);
+      continue;
+    end;
+
+    // BASS device names seem to be encoded with local encoding
+    // TODO: works for windows, check Linux + Mac OS X
+    Descr := DecodeStringUTF8(DeviceInfo.name, encAuto);
+    DeviceName := UnifyDeviceName(Descr, BassDeviceID);
+
+    if not ShouldProbeDevice(DeviceName) then
+    begin
+      Inc(BassDeviceID);
+      continue;
+    end;
+
     // try to initialize the device
     if not BASS_RecordInit(BassDeviceID) then
     begin
       Log.LogStatus('Failed to initialize BASS Capture-Device['+inttostr(BassDeviceID)+']',
                     'TAudioInput_Bass.InitializeRecord');
     end
-    else if ((DeviceInfo.flags and BASS_DEVICE_TYPE_MASK) <> BASS_DEVICE_TYPE_SPEAKERS) then
+    else
     begin
       SetLength(AudioInputProcessor.DeviceList, DeviceIndex+1);
 
@@ -509,7 +526,7 @@ begin
   result := true;
 end;
 
-function TAudioInput_Bass.InitializeRecord(): boolean;
+function TAudioInput_Bass.InitializeRecord(ScanMode: TAudioInputScanMode): boolean;
 begin
   BassCore := TAudioCore_Bass.GetInstance();
   if not BassCore.CheckVersion then
@@ -517,6 +534,7 @@ begin
     Result := false;
     Exit;
   end;
+  PrepareDeviceScan(ScanMode);
   Result := EnumDevices();
 end;
 

--- a/src/media/UAudioInput_Portaudio.pas
+++ b/src/media/UAudioInput_Portaudio.pas
@@ -61,7 +61,7 @@ type
       function EnumDevices(): boolean;
     public
       function GetName: string; override;
-      function InitializeRecord: boolean; override;
+      function InitializeRecord(ScanMode: TAudioInputScanMode): boolean; override;
       function FinalizeRecord: boolean; override;
   end;
 
@@ -332,6 +332,7 @@ var
   streamInfo:   PPaStreamInfo;
   sampleRate:   double;
   latency:      TPaTime;
+  unifiedDeviceName: UTF8String;
   {$IFDEF UsePortmixer}
   mixer:        PPxMixer;
   sourceCnt:    integer;
@@ -376,12 +377,16 @@ begin
       continue;
     end;
 
+    // retrieve device-name before running expensive tests
+    deviceName := ConvertPaStringToUTF8(paDeviceInfo^.name);
+    unifiedDeviceName := UnifyDeviceName(deviceName, i);
+    if not ShouldProbeDevice(unifiedDeviceName) then
+      continue;
+
     paDevice := TPortaudioInputDevice.Create();
     AudioInputProcessor.DeviceList[deviceIndex] := paDevice;
 
-    // retrieve device-name
-    deviceName := ConvertPaStringToUTF8(paDeviceInfo^.name);
-    paDevice.Name := UnifyDeviceName(deviceName, deviceIndex);
+    paDevice.Name := unifiedDeviceName;
     Log.LogStatus('Attempting to configure InputDevice "' + paDevice.Name + '"', 'Portaudio.EnumDevices');
     paDevice.PaDeviceIndex := paDeviceIndex;
 
@@ -493,7 +498,7 @@ begin
   Result := true;
 end;
 
-function TAudioInput_Portaudio.InitializeRecord(): boolean;
+function TAudioInput_Portaudio.InitializeRecord(ScanMode: TAudioInputScanMode): boolean;
 begin
   Result := false;
   AudioCore := TAudioCore_Portaudio.GetInstance();
@@ -501,6 +506,7 @@ begin
   // initialize portaudio
   if (not AudioCore.Initialize()) then
      Exit;
+  PrepareDeviceScan(ScanMode);
   Result := EnumDevices();
 end;
 

--- a/src/media/UMedia_dummy.pas
+++ b/src/media/UMedia_dummy.pas
@@ -71,7 +71,7 @@ type
       procedure SetSyncSource(SyncSource: TSyncSource);
 
       // IAudioInput
-      function InitializeRecord: boolean;
+      function InitializeRecord(ScanMode: TAudioInputScanMode): boolean;
       function FinalizeRecord: boolean;
       procedure CaptureStart;
       procedure CaptureStop;
@@ -244,7 +244,7 @@ begin
 end;
 
 // IAudioInput
-function TAudio_Dummy.InitializeRecord: boolean;
+function TAudio_Dummy.InitializeRecord(ScanMode: TAudioInputScanMode): boolean;
 begin
   Result := true;
 end;

--- a/src/screens/UScreenOptions.pas
+++ b/src/screens/UScreenOptions.pas
@@ -91,7 +91,7 @@ uses
 
 procedure TScreenOptions.OpenRecordOptions;
 begin
-  RefreshAudioInputDevices();
+  RefreshAudioInputDevices(aimFull);
   FreeAndNil(ScreenOptionsRecord);
   ScreenOptionsRecord := TScreenOptionsRecord.Create;
   FadeTo(@ScreenOptionsRecord, SoundLib.Start);

--- a/src/screens/UScreenOptions.pas
+++ b/src/screens/UScreenOptions.pas
@@ -63,6 +63,7 @@ type
       MapIIDtoDescID: array of integer;
 
       procedure UpdateTextDescriptionFor(IID: integer); virtual;
+      procedure OpenRecordOptions;
 
     public
       TextDescription:    integer;
@@ -84,8 +85,17 @@ uses
   UHelp,
   ULanguage,
   ULog,
+  UScreenOptionsRecord,
   UWebcam,
   UUnicodeUtils;
+
+procedure TScreenOptions.OpenRecordOptions;
+begin
+  RefreshAudioInputDevices();
+  FreeAndNil(ScreenOptionsRecord);
+  ScreenOptionsRecord := TScreenOptionsRecord.Create;
+  FadeTo(@ScreenOptionsRecord, SoundLib.Start);
+end;
 
 function TScreenOptions.ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean;
 begin
@@ -132,7 +142,7 @@ begin
 
       SDLK_R:
         begin
-          FadeTo(@ScreenOptionsRecord, SoundLib.Start);
+          OpenRecordOptions;
           Exit;
         end;
 
@@ -228,8 +238,7 @@ begin
 
           if Interaction = ButtonRecordIID then
           begin
-            AudioPlayback.PlaySound(SoundLib.Start);
-            FadeTo(@ScreenOptionsRecord);
+            OpenRecordOptions;
           end;
 
           if Interaction = ButtonAdvancedIID then

--- a/src/screens/UScreenOptionsRecord.pas
+++ b/src/screens/UScreenOptionsRecord.pas
@@ -654,6 +654,7 @@ begin
   // create preview sound-buffer
   PreviewChannel := TCaptureBuffer.Create();
 
+  ValidateSettings();
   UpdateInputDevice();
 end;
 


### PR DESCRIPTION
So far, when the game was loaded and a USB microphone / audio input device connection was lost, or forgot to be connected, the game couldn't use it anymore.

Now, entering the options -> record screen refreshes the audio input devices, so it is kind of hot-pluggable in the sense of issue #501 

also, @barbeque-squared mentioned that it can lead to slow start times, so this PR also moves the full audio input device detection to the options screen, on startup we only do a quick check for previously configured devices.
at the same time, some warnings are now in different places:
- 2 mics 1 player -> in the options screen only
- 1 player 0 mics -> when starting a song as a warning