### PR TITLE
UVideo: workaround for bug in libswscale on pre ssse3 systems

### DIFF
--- a/src/media/UVideo.pas
+++ b/src/media/UVideo.pas
@@ -1033,6 +1033,18 @@ begin
     ;
   end;
 
+  {$IF LIBSWSCALE_VERSION < 8003000}
+  {$IF DEFINED(CPUX86_64) or DEFINED(CPUX86)}
+  // Unscaled conversion with libswscale lacked the emms instruction.
+  // With FFmpeg 7.1 these mmx(ext) implementations have been removed.
+  // I assume you won't run this game on an x86 system that does not yet support mmx.
+  asm
+    emms
+  end ['st(0)','st(1)','st(2)','st(3)','st(4)','st(5)','st(6)','st(7)',
+       'mm0','mm1','mm2','mm3','mm4','mm5','mm6','mm7'];
+  {$ENDIF}
+  {$ENDIF}
+
   if (errnum < 0) then
   begin
     Log.LogError('Image conversion failed', 'TVideoPlayback_ffmpeg.GetFrame');


### PR DESCRIPTION
Without ssse3 libswscale uses mmx but forgets to reset the fpu with the emms instruction when performing unscaled conversions. Our conversions are unscaled as long as a texture that big can be created. The bug was not really fixed in libswscale 8.3 (FFmpeg 7.1). It just stopped using mmx for unscaled conversions.

It affects us when x87 instructions are later used, e.g. to calculate logarithms (GetMipmapLevel) or trigonometric functions (position of preview video in roulette mode).

https://code.ffmpeg.org/FFmpeg/FFmpeg/issues/22333

The list of affected registers is mainly for documentation. With the surrounding code Free Pascal has no reason to hold a value in an fpu register.

If I remember correctly, the fastest x86 without mmx is a 200 MHz Pentium 1.

Fixes #1156