### PR TITLE
Bugfix: don't suggest uninstall on reinstall and don't delete avatars unless user wants it

### DIFF
--- a/installer/UltraStar Deluxe.nsi
+++ b/installer/UltraStar Deluxe.nsi
@@ -258,6 +258,8 @@ Function Settings
 
 	Var /GLOBAL CHECKBOX_COVERS
 	Var /GLOBAL CB_COVERS_State
+	Var /GLOBAL CHECKBOX_AVATARS
+	Var /GLOBAL CB_AVATARS_State
 	Var /GLOBAL CHECKBOX_SCORES
 	Var /GLOBAL CB_SCORES_State
 	Var /GLOBAL CHECKBOX_CONFIG
@@ -323,25 +325,29 @@ Function un.AskDelete
 	Pop $CHECKBOX_COVERS
 	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_COVERS $1
 
-	${NSD_CreateCheckbox} 0 -155 100% 8u "$(delete_config)"
+	${NSD_CreateCheckbox} 0 -155 100% 8u "$(delete_avatars)"
+	Pop $CHECKBOX_AVATARS
+	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_AVATARS $2
+
+	${NSD_CreateCheckbox} 0 -135 100% 8u "$(delete_config)"
 	Pop $CHECKBOX_CONFIG
-	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_CONFIG $2
+	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_CONFIG $3
 
-	${NSD_CreateCheckbox} 0 -135 100% 8u "$(delete_highscores)"
+	${NSD_CreateCheckbox} 0 -115 100% 8u "$(delete_highscores)"
 	Pop $CHECKBOX_SCORES 
-	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_SCORES $3
+	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_SCORES $4
 
-	${NSD_CreateCheckbox} 0 -115 100% 8u "$(delete_screenshots)"
+	${NSD_CreateCheckbox} 0 -95 100% 8u "$(delete_screenshots)"
 	Pop $CHECKBOX_SCREENSHOTS 
-	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_SCREENSHOTS $4
+	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_SCREENSHOTS $5
 
-	${NSD_CreateCheckbox} 0 -95 100% 8u "$(delete_playlists)"
+	${NSD_CreateCheckbox} 0 -75 100% 8u "$(delete_playlists)"
 	Pop $CHECKBOX_PLAYLISTS
-	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_PLAYLISTS $5
+	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_PLAYLISTS $6
 
-	${NSD_CreateCheckbox} 0 -65 100% 18u "$(delete_songs)"
+	${NSD_CreateCheckbox} 0 -45 100% 18u "$(delete_songs)"
 	Pop $CHECKBOX_SONGS 
-	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_SONGS $6
+	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_SONGS $7
 
 
 	nsDialogs::Show
@@ -351,16 +357,25 @@ FunctionEnd
 Function un.DeleteAll
 
 	${NSD_GetState} $CHECKBOX_COVERS $CB_COVERS_State
+	${NSD_GetState} $CHECKBOX_AVATARS $CB_AVATARS_State
 	${NSD_GetState} $CHECKBOX_CONFIG $CB_CONFIG_State
 	${NSD_GetState} $CHECKBOX_SCORES $CB_SCORES_State
-	${NSD_GetState} $CHECKBOX_SCORES $CB_SCREENSHOTS_State
-	${NSD_GetState} $CHECKBOX_SCORES $CB_PLAYLISTS_State
+	${NSD_GetState} $CHECKBOX_SCREENSHOTS $CB_SCREENSHOTS_State
+	${NSD_GetState} $CHECKBOX_PLAYLISTS $CB_PLAYLISTS_State
 	${NSD_GetState} $CHECKBOX_SONGS  $CB_SONGS_State
 
 	${If} $CB_COVERS_State == "1" ; Remove covers
 		RMDir /r "$INSTDIR\covers"
 		SetShellVarContext current	
 		RMDir /r "$APPDATA\ultrastardx\covers"
+		SetShellVarContext all
+	${EndIf}
+
+	${If} $CB_AVATARS_State == "1" ; Remove avatars
+		RMDir /r "$INSTDIR\avatars"
+		Delete "$INSTDIR\avatar.db"
+		SetShellVarContext current
+		Delete "$APPDATA\ultrastardx\avatar.db"
 		SetShellVarContext all
 	${EndIf}
 
@@ -379,13 +394,13 @@ Function un.DeleteAll
 	${EndIf}
 
 	${If} $CB_SCREENSHOTS_State == "1" ; Remove screenshots
-		RMDir /r "$INSTDIR\sreenshots"
+		RMDir /r "$INSTDIR\screenshots"
 		SetShellVarContext current
 		RMDir /r "$APPDATA\ultrastardx\screenshots"
 		SetShellVarContext all
 	${EndIf}
 
-	${If} $CB_SCREENSHOTS_State == "1" ; Remove playlists
+	${If} $CB_PLAYLISTS_State == "1" ; Remove playlists
 		RMDir /r "$INSTDIR\playlists"
 		SetShellVarContext current
 		RMDir /r "$APPDATA\ultrastardx\playlists"
@@ -638,10 +653,6 @@ Function .onInit
 
 
 continue:
-	ReadRegStr $R2 "${PRODUCT_UNINST_ROOT_KEY}" "${PRODUCT_UNINST_KEY}" 'UninstallString'
-	MessageBox MB_YESNO|MB_ICONEXCLAMATION "$(oninit_uninstall)" IDNO done
-	ExecWait '"$R2" _?=$INSTDIR'
-
 done:
 	!insertmacro MUI_LANGDLL_DISPLAY
 

--- a/installer/UltraStar Deluxe.nsi
+++ b/installer/UltraStar Deluxe.nsi
@@ -258,6 +258,8 @@ Function Settings
 
 	Var /GLOBAL CHECKBOX_COVERS
 	Var /GLOBAL CB_COVERS_State
+	Var /GLOBAL CHECKBOX_AVATARS
+	Var /GLOBAL CB_AVATARS_State
 	Var /GLOBAL CHECKBOX_SCORES
 	Var /GLOBAL CB_SCORES_State
 	Var /GLOBAL CHECKBOX_CONFIG
@@ -323,25 +325,29 @@ Function un.AskDelete
 	Pop $CHECKBOX_COVERS
 	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_COVERS $1
 
-	${NSD_CreateCheckbox} 0 -155 100% 8u "$(delete_config)"
+	${NSD_CreateCheckbox} 0 -155 100% 8u "$(delete_avatars)"
+	Pop $CHECKBOX_AVATARS
+	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_AVATARS $2
+
+	${NSD_CreateCheckbox} 0 -135 100% 8u "$(delete_config)"
 	Pop $CHECKBOX_CONFIG
-	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_CONFIG $2
+	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_CONFIG $3
 
-	${NSD_CreateCheckbox} 0 -135 100% 8u "$(delete_highscores)"
+	${NSD_CreateCheckbox} 0 -115 100% 8u "$(delete_highscores)"
 	Pop $CHECKBOX_SCORES 
-	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_SCORES $3
+	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_SCORES $4
 
-	${NSD_CreateCheckbox} 0 -115 100% 8u "$(delete_screenshots)"
+	${NSD_CreateCheckbox} 0 -95 100% 8u "$(delete_screenshots)"
 	Pop $CHECKBOX_SCREENSHOTS 
-	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_SCREENSHOTS $4
+	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_SCREENSHOTS $5
 
-	${NSD_CreateCheckbox} 0 -95 100% 8u "$(delete_playlists)"
+	${NSD_CreateCheckbox} 0 -75 100% 8u "$(delete_playlists)"
 	Pop $CHECKBOX_PLAYLISTS
-	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_PLAYLISTS $5
+	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_PLAYLISTS $6
 
-	${NSD_CreateCheckbox} 0 -65 100% 18u "$(delete_songs)"
+	${NSD_CreateCheckbox} 0 -45 100% 18u "$(delete_songs)"
 	Pop $CHECKBOX_SONGS 
-	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_SONGS $6
+	nsDialogs::OnClick /NOUNLOAD $CHECKBOX_SONGS $7
 
 
 	nsDialogs::Show
@@ -351,6 +357,7 @@ FunctionEnd
 Function un.DeleteAll
 
 	${NSD_GetState} $CHECKBOX_COVERS $CB_COVERS_State
+	${NSD_GetState} $CHECKBOX_AVATARS $CB_AVATARS_State
 	${NSD_GetState} $CHECKBOX_CONFIG $CB_CONFIG_State
 	${NSD_GetState} $CHECKBOX_SCORES $CB_SCORES_State
 	${NSD_GetState} $CHECKBOX_SCREENSHOTS $CB_SCREENSHOTS_State
@@ -361,6 +368,14 @@ Function un.DeleteAll
 		RMDir /r "$INSTDIR\covers"
 		SetShellVarContext current	
 		RMDir /r "$APPDATA\ultrastardx\covers"
+		SetShellVarContext all
+	${EndIf}
+
+	${If} $CB_AVATARS_State == "1" ; Remove avatars
+		RMDir /r "$INSTDIR\avatars"
+		Delete "$INSTDIR\avatar.db"
+		SetShellVarContext current
+		Delete "$APPDATA\ultrastardx\avatar.db"
 		SetShellVarContext all
 	${EndIf}
 

--- a/installer/UltraStar Deluxe.nsi
+++ b/installer/UltraStar Deluxe.nsi
@@ -353,8 +353,8 @@ Function un.DeleteAll
 	${NSD_GetState} $CHECKBOX_COVERS $CB_COVERS_State
 	${NSD_GetState} $CHECKBOX_CONFIG $CB_CONFIG_State
 	${NSD_GetState} $CHECKBOX_SCORES $CB_SCORES_State
-	${NSD_GetState} $CHECKBOX_SCORES $CB_SCREENSHOTS_State
-	${NSD_GetState} $CHECKBOX_SCORES $CB_PLAYLISTS_State
+	${NSD_GetState} $CHECKBOX_SCREENSHOTS $CB_SCREENSHOTS_State
+	${NSD_GetState} $CHECKBOX_PLAYLISTS $CB_PLAYLISTS_State
 	${NSD_GetState} $CHECKBOX_SONGS  $CB_SONGS_State
 
 	${If} $CB_COVERS_State == "1" ; Remove covers
@@ -379,13 +379,13 @@ Function un.DeleteAll
 	${EndIf}
 
 	${If} $CB_SCREENSHOTS_State == "1" ; Remove screenshots
-		RMDir /r "$INSTDIR\sreenshots"
+		RMDir /r "$INSTDIR\screenshots"
 		SetShellVarContext current
 		RMDir /r "$APPDATA\ultrastardx\screenshots"
 		SetShellVarContext all
 	${EndIf}
 
-	${If} $CB_SCREENSHOTS_State == "1" ; Remove playlists
+	${If} $CB_PLAYLISTS_State == "1" ; Remove playlists
 		RMDir /r "$INSTDIR\playlists"
 		SetShellVarContext current
 		RMDir /r "$APPDATA\ultrastardx\playlists"

--- a/installer/UltraStar Deluxe.nsi
+++ b/installer/UltraStar Deluxe.nsi
@@ -653,10 +653,6 @@ Function .onInit
 
 
 continue:
-	ReadRegStr $R2 "${PRODUCT_UNINST_ROOT_KEY}" "${PRODUCT_UNINST_KEY}" 'UninstallString'
-	MessageBox MB_YESNO|MB_ICONEXCLAMATION "$(oninit_uninstall)" IDNO done
-	ExecWait '"$R2" _?=$INSTDIR'
-
 done:
 	!insertmacro MUI_LANGDLL_DISPLAY
 

--- a/installer/languages/English.nsh
+++ b/installer/languages/English.nsh
@@ -30,6 +30,7 @@ ${LangFileString} button_close "Close"
 
 ${LangFileString} delete_components "Also delete the following components:"
 ${LangFileString} delete_covers "Cover"
+${LangFileString} delete_avatars "Avatars"
 ${LangFileString} delete_highscores "Highscores"
 ${LangFileString} delete_config "Config"
 ${LangFileString} delete_screenshots "Screenshots"

--- a/installer/languages/German.nsh
+++ b/installer/languages/German.nsh
@@ -30,6 +30,7 @@ ${LangFileString} button_close "Beenden"
 
 ${LangFileString} delete_components "Folgende Komponenten ebenfalls entfernen:"
 ${LangFileString} delete_covers "Cover"
+${LangFileString} delete_avatars "Avatare"
 ${LangFileString} delete_highscores "Statistiken"
 ${LangFileString} delete_config "Konfiguration"
 ${LangFileString} delete_screenshots "Screenshots"

--- a/installer/languages/Hungarian.nsh
+++ b/installer/languages/Hungarian.nsh
@@ -33,6 +33,7 @@ ${LangFileString} update_information "Ellenõrizheti, hogy van-e új '${name}'-v
 
 ${LangFileString} delete_components "Also delete the following components:"
 ${LangFileString} delete_covers "Töröljük a borítókat?"
+${LangFileString} delete_avatars "Avatars?"
 ${LangFileString} delete_highscores "Töröljük a pontszámokat?"
 ${LangFileString} delete_config "Config?"
 ${LangFileString} delete_screenshots "Screenshots?"

--- a/installer/languages/Polish.nsh
+++ b/installer/languages/Polish.nsh
@@ -32,6 +32,7 @@ ${LangFileString} button_check_update "Sprawdź"
 
 ${LangFileString} delete_components "Usuń również następujące składniki:"
 ${LangFileString} delete_covers "Okładka"
+${LangFileString} delete_avatars "Awatary"
 ${LangFileString} delete_highscores "Wyniki"
 ${LangFileString} delete_config "Koniguracja"
 ${LangFileString} delete_screenshots "Zrzuty ekranów"

--- a/installer/languages/Portuguese.nsh
+++ b/installer/languages/Portuguese.nsh
@@ -32,6 +32,7 @@ ${LangFileString} update_information "Você pode verificar se uma nova versão d
 
 ${LangFileString} delete_components "Além disso, exclua os seguintes componentes:"
 ${LangFileString} delete_covers "Capas?"
+${LangFileString} delete_avatars "Avatares?"
 ${LangFileString} delete_highscores "Pontuações?"
 ${LangFileString} delete_config "Configurações?"
 ${LangFileString} delete_screenshots "Screenshots?"

--- a/installer/languages/Spanish.nsh
+++ b/installer/languages/Spanish.nsh
@@ -32,6 +32,7 @@ ${LangFileString} update_information "Puedes comprobar si existe una nueva versi
 
 ${LangFileString} delete_components "Además eliminar los siguientes componentes:"
 ${LangFileString} delete_covers "¿Carátulas?"
+${LangFileString} delete_avatars "¿Avatares?"
 ${LangFileString} delete_highscores "¿Puntuaciones?"
 ${LangFileString} delete_config "¿Configuración?"
 ${LangFileString} delete_screenshots "¿Capturas de pantalla?"

--- a/installer/settings/files_main_install.nsh
+++ b/installer/settings/files_main_install.nsh
@@ -105,8 +105,6 @@ RMDir /r "$INSTDIR\Skins"
 RMDir /r "$INSTDIR\Plugins"
 RMDir /r "$INSTDIR\Languages"
 RMDir /r "$INSTDIR\Webs"
-RMDir /r "$INSTDIR\Avatars"
-
 ; Create Directories:
 
 CreateDirectory $INSTDIR\plugins

--- a/installer/settings/files_main_install.nsh
+++ b/installer/settings/files_main_install.nsh
@@ -105,7 +105,6 @@ RMDir /r "$INSTDIR\Skins"
 RMDir /r "$INSTDIR\Plugins"
 RMDir /r "$INSTDIR\Languages"
 RMDir /r "$INSTDIR\Webs"
-RMDir /r "$INSTDIR\Avatars"
 
 ; Create Directories:
 

--- a/installer/settings/files_main_uninstall.nsh
+++ b/installer/settings/files_main_uninstall.nsh
@@ -13,8 +13,6 @@
  RMDir /r "$INSTDIR\sounds"
  RMDir /r "$INSTDIR\webs"
  RMDir /r "$INSTDIR\soundfonts"
- RMDir /r "$INSTDIR\avatars"
-
 ; Delete remaining files
  Delete "$INSTDIR\${exe}.exe"
  Delete "$INSTDIR\${exeupdate}.exe"
@@ -121,8 +119,6 @@
  Delete "$APPDATA\ultrastardx\Error.log"
  Delete "$APPDATA\ultrastardx\Benchmark.log"
  Delete "$APPDATA\ultrastardx\cover.db"
- Delete "$APPDATA\ultrastardx\avatar.db"
- 
  StrCpy $0 "$APPDATA\ultrastardx\covers"
  Call un.DeleteIfEmpty
 

--- a/installer/settings/files_main_uninstall.nsh
+++ b/installer/settings/files_main_uninstall.nsh
@@ -13,7 +13,6 @@
  RMDir /r "$INSTDIR\sounds"
  RMDir /r "$INSTDIR\webs"
  RMDir /r "$INSTDIR\soundfonts"
- RMDir /r "$INSTDIR\avatars"
 
 ; Delete remaining files
  Delete "$INSTDIR\${exe}.exe"
@@ -121,7 +120,6 @@
  Delete "$APPDATA\ultrastardx\Error.log"
  Delete "$APPDATA\ultrastardx\Benchmark.log"
  Delete "$APPDATA\ultrastardx\cover.db"
- Delete "$APPDATA\ultrastardx\avatar.db"
  
  StrCpy $0 "$APPDATA\ultrastardx\covers"
  Call un.DeleteIfEmpty


### PR DESCRIPTION
the installer so far suggested to uninstall first, which is neither necessary nor useful as it may delete installed data the user does not want to delete

the installer itself also deletes data (probably it should only overwrite) - this is changed now for avatars to address the avatar deletion issue, so it fixes #1176. (at least that part)

also fixes a typo "sreenshots" -> "screenshots"