### PR TITLE
Improvement: Make more elements themeable and configurable

### DIFF
--- a/src/base/UCatCovers.pas
+++ b/src/base/UCatCovers.pas
@@ -63,6 +63,7 @@ uses
   UFilesystem,
   ULog,
   UMain,
+  UThemes,
   UUnicodeUtils,
   UPathUtils;
 
@@ -196,6 +197,12 @@ begin
   //No Cover
   if (Result.IsUnset) then
   begin
+    NoCoverPath := UThemes.ResolveThemeAsset(Path('NoCover.jpg'));
+    if NoCoverPath.IsUnset then
+      NoCoverPath := UThemes.ResolveThemeAsset(Path('covers').Append('NoCover.jpg'));
+    if (NoCoverPath.IsFile) then
+      Exit(NoCoverPath);
+
     for I := 0 to CoverPaths.Count-1 do
     begin
       NoCoverPath := (CoverPaths[I] as IPath).Append('NoCover.jpg');

--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -675,7 +675,8 @@ uses
   UCommon,
   URecord,
   ULog,
-  UPathUtils;
+  UPathUtils,
+  UThemes;
 
 var
   DefaultVideoPlayback : IVideoPlayback;
@@ -684,6 +685,19 @@ var
   DefaultAudioInput    : IAudioInput;
   AudioDecoderList     : TInterfaceList;
   MediaInterfaceList   : TInterfaceList;
+
+function ResolveSoundAsset(const Filename: UTF8String): IPath;
+begin
+  Result := UThemes.ResolveThemeAsset(Path('sounds').Append(Filename));
+  if Result.IsSet then
+    Exit;
+
+  Result := UThemes.ResolveThemeAsset(Path(Filename));
+  if Result.IsSet then
+    Exit;
+
+  Result := SoundPath.Append(Filename);
+end;
 
 
 constructor TAudioFormatInfo.Create(Channels: byte; SampleRate: double; Format: TAudioSampleFormat);
@@ -1018,15 +1032,15 @@ procedure TSoundLibrary.LoadSounds();
 begin
   UnloadSounds();
 
-  Start   := AudioPlayback.OpenSound(SoundPath.Append('Common start.mp3'));
-  Back    := AudioPlayback.OpenSound(SoundPath.Append('Common back.mp3'));
-  Swoosh  := AudioPlayback.OpenSound(SoundPath.Append('menu swoosh.mp3'));
-  Change  := AudioPlayback.OpenSound(SoundPath.Append('select music change music 50.mp3'));
-  Option  := AudioPlayback.OpenSound(SoundPath.Append('option change col.mp3'));
-  Click   := AudioPlayback.OpenSound(SoundPath.Append('rimshot022b.wav'));
-  Applause:= AudioPlayback.OpenSound(SoundPath.Append('Applause.mp3'));
+  Start   := AudioPlayback.OpenSound(ResolveSoundAsset('Common start.mp3'));
+  Back    := AudioPlayback.OpenSound(ResolveSoundAsset('Common back.mp3'));
+  Swoosh  := AudioPlayback.OpenSound(ResolveSoundAsset('menu swoosh.mp3'));
+  Change  := AudioPlayback.OpenSound(ResolveSoundAsset('select music change music 50.mp3'));
+  Option  := AudioPlayback.OpenSound(ResolveSoundAsset('option change col.mp3'));
+  Click   := AudioPlayback.OpenSound(ResolveSoundAsset('rimshot022b.wav'));
+  Applause:= AudioPlayback.OpenSound(ResolveSoundAsset('Applause.mp3'));
 
-  BGMusic := AudioPlayback.OpenSound(SoundPath.Append('background track.mp3'));
+  BGMusic := AudioPlayback.OpenSound(ResolveSoundAsset('background track.mp3'));
 
   if (BGMusic <> nil) then
     BGMusic.Loop := True;

--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -690,7 +690,8 @@ uses
   UCommon,
   URecord,
   ULog,
-  UPathUtils;
+  UPathUtils,
+  UThemes;
 
 var
   DefaultVideoPlayback : IVideoPlayback;
@@ -699,6 +700,19 @@ var
   DefaultAudioInput    : IAudioInput;
   AudioDecoderList     : TInterfaceList;
   MediaInterfaceList   : TInterfaceList;
+
+function ResolveSoundAsset(const Filename: UTF8String): IPath;
+begin
+  Result := UThemes.ResolveThemeAsset(Path('sounds').Append(Filename));
+  if Result.IsSet then
+    Exit;
+
+  Result := UThemes.ResolveThemeAsset(Path(Filename));
+  if Result.IsSet then
+    Exit;
+
+  Result := SoundPath.Append(Filename);
+end;
 
 
 constructor TAudioFormatInfo.Create(Channels: byte; SampleRate: double; Format: TAudioSampleFormat);
@@ -1118,15 +1132,15 @@ procedure TSoundLibrary.LoadSounds();
 begin
   UnloadSounds();
 
-  Start   := AudioPlayback.OpenSound(SoundPath.Append('Common start.mp3'));
-  Back    := AudioPlayback.OpenSound(SoundPath.Append('Common back.mp3'));
-  Swoosh  := AudioPlayback.OpenSound(SoundPath.Append('menu swoosh.mp3'));
-  Change  := AudioPlayback.OpenSound(SoundPath.Append('select music change music 50.mp3'));
-  Option  := AudioPlayback.OpenSound(SoundPath.Append('option change col.mp3'));
-  Click   := AudioPlayback.OpenSound(SoundPath.Append('rimshot022b.wav'));
-  Applause:= AudioPlayback.OpenSound(SoundPath.Append('Applause.mp3'));
+  Start   := AudioPlayback.OpenSound(ResolveSoundAsset('Common start.mp3'));
+  Back    := AudioPlayback.OpenSound(ResolveSoundAsset('Common back.mp3'));
+  Swoosh  := AudioPlayback.OpenSound(ResolveSoundAsset('menu swoosh.mp3'));
+  Change  := AudioPlayback.OpenSound(ResolveSoundAsset('select music change music 50.mp3'));
+  Option  := AudioPlayback.OpenSound(ResolveSoundAsset('option change col.mp3'));
+  Click   := AudioPlayback.OpenSound(ResolveSoundAsset('rimshot022b.wav'));
+  Applause:= AudioPlayback.OpenSound(ResolveSoundAsset('Applause.mp3'));
 
-  BGMusic := AudioPlayback.OpenSound(SoundPath.Append('background track.mp3'));
+  BGMusic := AudioPlayback.OpenSound(ResolveSoundAsset('background track.mp3'));
 
   if (BGMusic <> nil) then
   begin

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -1251,6 +1251,7 @@ function GetPlayerColor(Color: integer): TRGB;
 function GetPlayerLightColor(Color: integer): TRGB;
 procedure LoadPlayersColors;
 procedure LoadTeamsColors;
+function ResolveThemeAsset(const RelativePath: IPath; IncludeBaseTheme: boolean = true): IPath;
 
 var
   //Skin:         TSkin;
@@ -1272,6 +1273,60 @@ uses
 
 const
   MAX_INHERITANCE = 10;
+var
+  CurrentThemeIndex: integer = -1;
+  CurrentBaseThemeIndex: integer = -1;
+
+function GetThemeFolder(ThemeIndex: integer): IPath;
+begin
+  Result := PATH_NONE;
+  if not Assigned(Theme) then
+    Exit;
+
+  if (ThemeIndex < Low(Theme.Themes)) or (ThemeIndex > High(Theme.Themes)) then
+    Exit;
+
+  Result := Theme.Themes[ThemeIndex].FileName.SetExtension('');
+  if not Result.IsDirectory then
+    Result := ThemePath.Append(Theme.Themes[ThemeIndex].Name);
+
+  if not Result.IsDirectory then
+    Result := PATH_NONE;
+end;
+
+function ResolveThemeAsset(const RelativePath: IPath; IncludeBaseTheme: boolean = true): IPath;
+var
+  ThemeDir, Candidate: IPath;
+begin
+  Result := PATH_NONE;
+
+  if not Assigned(Theme) then
+    Exit;
+  if (CurrentThemeIndex < Low(Theme.Themes)) or (CurrentThemeIndex > High(Theme.Themes)) then
+    Exit;
+
+  ThemeDir := GetThemeFolder(CurrentThemeIndex);
+  if ThemeDir.IsSet then
+  begin
+    Candidate := ThemeDir.Append(RelativePath);
+    if Candidate.IsFile then
+      Exit(Candidate);
+  end;
+
+  if not IncludeBaseTheme then
+    Exit;
+
+  if (CurrentBaseThemeIndex < Low(Theme.Themes)) or (CurrentBaseThemeIndex > High(Theme.Themes)) then
+    Exit;
+
+  ThemeDir := GetThemeFolder(CurrentBaseThemeIndex);
+  if ThemeDir.IsSet then
+  begin
+    Candidate := ThemeDir.Append(RelativePath);
+    if Candidate.IsFile then
+      Result := Candidate;
+  end;
+end;
 
 //-----------
 //Helper procs to use TRGB in Opengl ...maybe this should be somewhere else
@@ -1356,6 +1411,9 @@ procedure TTheme.OpenFile(ThemeNum: integer);
 var
   I: integer;
 begin
+  CurrentThemeIndex := ThemeNum;
+  CurrentBaseThemeIndex := -1;
+
   ThemeIni := TMemIniFile.Create(Themes[ThemeNum].FileName.ToNative);
 
   // Load base theme if declared
@@ -1368,6 +1426,7 @@ begin
         if (Themes[I].BaseTheme <> '') then
           Log.LogError('Multiple base themes not allowed', 'TTheme.LoadTheme');
         BaseThemeIni := TMemIniFile.Create(Themes[I].FileName.ToNative);
+        CurrentBaseThemeIndex := I;
         Break;
       end;
     end;
@@ -1378,6 +1437,8 @@ procedure TTheme.CloseFile;
 begin
   freeandnil(ThemeIni);
   freeandnil(BaseThemeIni);
+  CurrentThemeIndex := -1;
+  CurrentBaseThemeIndex := -1;
 end;
 
 procedure TTheme.LoadHeader(FileName: IPath);

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -1250,6 +1250,7 @@ function GetPlayerColor(Color: integer): TRGB;
 function GetPlayerLightColor(Color: integer): TRGB;
 procedure LoadPlayersColors;
 procedure LoadTeamsColors;
+function ResolveThemeAsset(const RelativePath: IPath; IncludeBaseTheme: boolean = true): IPath;
 
 var
   //Skin:         TSkin;
@@ -1271,6 +1272,60 @@ uses
 
 const
   MAX_INHERITANCE = 10;
+var
+  CurrentThemeIndex: integer = -1;
+  CurrentBaseThemeIndex: integer = -1;
+
+function GetThemeFolder(ThemeIndex: integer): IPath;
+begin
+  Result := PATH_NONE;
+  if not Assigned(Theme) then
+    Exit;
+
+  if (ThemeIndex < Low(Theme.Themes)) or (ThemeIndex > High(Theme.Themes)) then
+    Exit;
+
+  Result := Theme.Themes[ThemeIndex].FileName.SetExtension('');
+  if not Result.IsDirectory then
+    Result := ThemePath.Append(Theme.Themes[ThemeIndex].Name);
+
+  if not Result.IsDirectory then
+    Result := PATH_NONE;
+end;
+
+function ResolveThemeAsset(const RelativePath: IPath; IncludeBaseTheme: boolean = true): IPath;
+var
+  ThemeDir, Candidate: IPath;
+begin
+  Result := PATH_NONE;
+
+  if not Assigned(Theme) then
+    Exit;
+  if (CurrentThemeIndex < Low(Theme.Themes)) or (CurrentThemeIndex > High(Theme.Themes)) then
+    Exit;
+
+  ThemeDir := GetThemeFolder(CurrentThemeIndex);
+  if ThemeDir.IsSet then
+  begin
+    Candidate := ThemeDir.Append(RelativePath);
+    if Candidate.IsFile then
+      Exit(Candidate);
+  end;
+
+  if not IncludeBaseTheme then
+    Exit;
+
+  if (CurrentBaseThemeIndex < Low(Theme.Themes)) or (CurrentBaseThemeIndex > High(Theme.Themes)) then
+    Exit;
+
+  ThemeDir := GetThemeFolder(CurrentBaseThemeIndex);
+  if ThemeDir.IsSet then
+  begin
+    Candidate := ThemeDir.Append(RelativePath);
+    if Candidate.IsFile then
+      Result := Candidate;
+  end;
+end;
 
 constructor TTheme.Create;
 begin
@@ -1332,6 +1387,9 @@ procedure TTheme.OpenFile(ThemeNum: integer);
 var
   I: integer;
 begin
+  CurrentThemeIndex := ThemeNum;
+  CurrentBaseThemeIndex := -1;
+
   ThemeIni := TMemIniFile.Create(Themes[ThemeNum].FileName.ToNative);
 
   // Load base theme if declared
@@ -1344,6 +1402,7 @@ begin
         if (Themes[I].BaseTheme <> '') then
           Log.LogError('Multiple base themes not allowed', 'TTheme.LoadTheme');
         BaseThemeIni := TMemIniFile.Create(Themes[I].FileName.ToNative);
+        CurrentBaseThemeIndex := I;
         Break;
       end;
     end;
@@ -1354,6 +1413,8 @@ procedure TTheme.CloseFile;
 begin
   freeandnil(ThemeIni);
   freeandnil(BaseThemeIni);
+  CurrentThemeIndex := -1;
+  CurrentBaseThemeIndex := -1;
 end;
 
 procedure TTheme.LoadHeader(FileName: IPath);

--- a/src/screens/UScreenMain.pas
+++ b/src/screens/UScreenMain.pas
@@ -114,6 +114,8 @@ begin
       SDLK_R: begin
         UGraphic.UnLoadScreens();
         Theme.LoadTheme(Ini.Theme, Ini.Color);
+        SoundLib.LoadSounds();
+        SoundLib.StartBgMusic();
         UGraphic.LoadScreens(USDXVersionStr);
       end;
 

--- a/src/screens/UScreenMain.pas
+++ b/src/screens/UScreenMain.pas
@@ -113,6 +113,8 @@ begin
       SDLK_R: begin
         UGraphic.UnLoadScreens();
         Theme.LoadTheme(Ini.Theme, Ini.Color);
+        SoundLib.LoadSounds();
+        SoundLib.StartBgMusic();
         UGraphic.LoadScreens(USDXVersionStr);
       end;
 

--- a/src/screens/UScreenOptionsThemes.pas
+++ b/src/screens/UScreenOptionsThemes.pas
@@ -236,6 +236,8 @@ end;
 procedure TScreenOptionsThemes.ReloadTheme;
 begin
   Theme.LoadTheme(Ini.Theme, Ini.Color);
+  SoundLib.LoadSounds();
+  SoundLib.StartBgMusic();
 
   ScreenOptionsThemes := TScreenOptionsThemes.create();
   ScreenOptionsThemes.onshow;

--- a/src/screens/UScreenOptionsThemes.pas
+++ b/src/screens/UScreenOptionsThemes.pas
@@ -237,6 +237,8 @@ end;
 procedure TScreenOptionsThemes.ReloadTheme;
 begin
   Theme.LoadTheme(Ini.Theme, Ini.Color);
+  SoundLib.LoadSounds();
+  SoundLib.StartBgMusic();
 
   ScreenOptionsThemes := TScreenOptionsThemes.create();
   ScreenOptionsThemes.onshow;


### PR DESCRIPTION
This PR adds shared theme asset resolution and uses it for:
- menu/common sounds (`Common start/back`, option/change/click, applause, background track)
- category fallback cover (`NoCover.jpg`)
- screen transition zoom and duration

**Lookup order for Covers and Sounds**
- Covers:  
  1) active theme  
  2) base theme (if configured)  
  3) existing global fallback paths  

**Behavior changes**
- `SoundLib` is reloaded on theme reload so audio overrides apply immediately.
- The unused `menu swoosh.mp3` entry was removed.
- Screen transitions are now theme-controlled:
  - `ScreenTransitionZoomIn`
  - `ScreenTransitionZoomOut`
  - `ScreenTransitionDurationMs`

**Theme defaults updated**
- Modern.ini (now uses a simple and short fade without zoom effect)
- Deluxe.ini (uses the existing zoom effect)

Fixes #1070.
Fixes #411.