### PR TITLE
Improvement: allow to full screen the video preview with V in the song selection

### DIFF
--- a/game/languages/English.ini
+++ b/game/languages/English.ini
@@ -1156,6 +1156,7 @@ P = Open playlist menu
 O = Toggle fixed order for current playlist (playlist view)
 R = Jump to random song
 T = Interpret rap notes as freestyle (toggle on/off)
+V = Toggle fullscreen video preview
 E = Load editor for selected song
 W = Web matching
 ;-------------------------------------------------------;
@@ -1235,6 +1236,7 @@ P = Open playlist menu
 O = Toggle fixed order for current playlist (playlist view)
 R = Jump to random song
 T = Interpret rap notes as freestyle (toggle on/off)
+V = Toggle fullscreen video preview
 W = Web matching
 ;-------------------------------------------------------;
 ;SEC_020  Playback
@@ -1274,6 +1276,7 @@ P = Open playlist menu
 O = Toggle fixed order for current playlist (playlist view)
 R = Jump to random song
 T = Interpret rap notes as freestyle (toggle on/off)
+V = Toggle fullscreen video preview
 W = Web matching
 ;-------------------------------------------------------;
 ;SEC_020  Playback

--- a/game/languages/English.ini
+++ b/game/languages/English.ini
@@ -1164,6 +1164,7 @@ P = Open playlist menu
 O = Toggle fixed order for current playlist (playlist view)
 R = Jump to random song
 T = Interpret rap notes as freestyle (toggle on/off)
+V = Toggle fullscreen video preview
 E = Load editor for selected song
 W = Web matching
 ;-------------------------------------------------------;
@@ -1243,6 +1244,7 @@ P = Open playlist menu
 O = Toggle fixed order for current playlist (playlist view)
 R = Jump to random song
 T = Interpret rap notes as freestyle (toggle on/off)
+V = Toggle fullscreen video preview
 W = Web matching
 ;-------------------------------------------------------;
 ;SEC_020  Playback
@@ -1282,6 +1284,7 @@ P = Open playlist menu
 O = Toggle fixed order for current playlist (playlist view)
 R = Jump to random song
 T = Interpret rap notes as freestyle (toggle on/off)
+V = Toggle fullscreen video preview
 W = Web matching
 ;-------------------------------------------------------;
 ;SEC_020  Playback

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -1065,6 +1065,12 @@ begin
         if CatSongs.Song[Interaction].hasRap then
           RapToFreestyle := not RapToFreestyle;
 
+      SDLK_V:
+        begin
+          CoverFull := not CoverFull;
+          Exit;
+        end;
+
       SDLK_W:
         begin
 
@@ -2950,6 +2956,7 @@ begin
     AudioPlayback.Stop;
 
   PreviewOpened := -1;
+  CoverFull := false;
 
   // reset video playback engine
   fCurrentVideo := nil;
@@ -3063,6 +3070,7 @@ begin
   // stop preview
   StopMusicPreview();
   StopVideoPreview();
+  CoverFull := false;
 end;
 
 procedure TScreenSong.DrawExtensions;
@@ -3297,7 +3305,14 @@ begin
     fCurrentVideo.Alpha := VideoAlpha;
 
     //set up window
-    if (TSongMenuMode(Ini.SongMenu) in [smChessboard, smList]) then
+    if CoverFull then
+    begin
+        fCurrentVideo.SetScreenPosition(0, 0, 1);
+        fCurrentVideo.Width := 800;
+        fCurrentVideo.Height := 600;
+        fCurrentVideo.ReflectionSpacing := 0;
+    end
+    else if (TSongMenuMode(Ini.SongMenu) in [smChessboard, smList]) then
     begin
         fCurrentVideo.SetScreenPosition(Theme.Song.Cover.SelectX, Theme.Song.Cover.SelectY, 1);
         fCurrentVideo.Width := Theme.Song.Cover.SelectW;
@@ -3316,11 +3331,14 @@ begin
       end;
     end;
 
-    fCurrentVideo.AspectCorrection := acoCrop;
+    if CoverFull then
+      fCurrentVideo.AspectCorrection := acoLetterBox
+    else
+      fCurrentVideo.AspectCorrection := acoCrop;
 
     fCurrentVideo.Draw;
 
-    if Button[interaction].Reflection or (Theme.Song.Cover.SelectReflection) then
+    if (not CoverFull) and (Button[interaction].Reflection or (Theme.Song.Cover.SelectReflection)) then
       fCurrentVideo.DrawReflection;
   end;
 
@@ -3339,6 +3357,19 @@ begin
   Equalizer.Draw;
 
   DrawExtensions;
+
+  // Keep fullscreen preview video above all song-selection overlays/text.
+  if Assigned(fCurrentVideo) and CoverFull then
+  begin
+    fCurrentVideo.SetScreen(ScreenAct);
+    fCurrentVideo.Alpha := 1;
+    fCurrentVideo.SetScreenPosition(0, 0, 1);
+    fCurrentVideo.Width := 800;
+    fCurrentVideo.Height := 600;
+    fCurrentVideo.ReflectionSpacing := 0;
+    fCurrentVideo.AspectCorrection := acoLetterBox;
+    fCurrentVideo.Draw;
+  end;
 
   //if (Mode = smPartyTournament) then
   //  PartyTimeLimit();

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -1082,6 +1082,12 @@ begin
         if CatSongs.Song[Interaction].hasRap then
           RapToFreestyle := not RapToFreestyle;
 
+      SDLK_V:
+        begin
+          CoverFull := not CoverFull;
+          Exit;
+        end;
+
       SDLK_W:
         begin
 
@@ -1444,7 +1450,7 @@ end;
 function TScreenSong.ParseMouse(MouseButton: integer; BtnDown: boolean; X, Y: integer): boolean;
 begin
 
-  // transfer mousecords to the 800x600 raster we use to draw
+  // Convert mouse coordinates to the virtual render coordinate space.
   X := Round((X / (ScreenW / Screens)) * RenderW);
   if (X > RenderW) then
     X := X - RenderW;
@@ -2940,6 +2946,7 @@ begin
     AudioPlayback.Stop;
 
   PreviewOpened := -1;
+  CoverFull := false;
 
   // reset video playback engine
   fCurrentVideo := nil;
@@ -3053,6 +3060,7 @@ begin
   // stop preview
   StopMusicPreview();
   StopVideoPreview();
+  CoverFull := false;
 end;
 
 procedure TScreenSong.DrawExtensions;
@@ -3287,7 +3295,14 @@ begin
     fCurrentVideo.Alpha := VideoAlpha;
 
     //set up window
-    if (TSongMenuMode(Ini.SongMenu) in [smChessboard, smList]) then
+    if CoverFull then
+    begin
+        fCurrentVideo.SetScreenPosition(0, 0, 1);
+        fCurrentVideo.Width := RenderW;
+        fCurrentVideo.Height := RenderH;
+        fCurrentVideo.ReflectionSpacing := 0;
+    end
+    else if (TSongMenuMode(Ini.SongMenu) in [smChessboard, smList]) then
     begin
         fCurrentVideo.SetScreenPosition(Theme.Song.Cover.SelectX, Theme.Song.Cover.SelectY, 1);
         fCurrentVideo.Width := Theme.Song.Cover.SelectW;
@@ -3308,9 +3323,15 @@ begin
     if Button[interaction].Reflection or (Theme.Song.Cover.SelectReflection) then
       fCurrentVideo.Reflection := true;
 
-    fCurrentVideo.AspectCorrection := acoCrop;
+    if CoverFull then
+      fCurrentVideo.AspectCorrection := acoLetterBox
+    else
+      fCurrentVideo.AspectCorrection := acoCrop;
 
-    fCurrentVideo.Draw;
+     fCurrentVideo.Draw;
+
+     if (not CoverFull) and (Button[interaction].Reflection or (Theme.Song.Cover.SelectReflection)) then
+       fCurrentVideo.DrawReflection;
   end;
 
   // duet names
@@ -3328,6 +3349,19 @@ begin
   Equalizer.Draw;
 
   DrawExtensions;
+
+  // Keep fullscreen preview video above all song-selection overlays/text.
+  if Assigned(fCurrentVideo) and CoverFull then
+  begin
+    fCurrentVideo.SetScreen(ScreenAct);
+    fCurrentVideo.Alpha := 1;
+    fCurrentVideo.SetScreenPosition(0, 0, 1);
+    fCurrentVideo.Width := RenderW;
+    fCurrentVideo.Height := RenderH;
+    fCurrentVideo.ReflectionSpacing := 0;
+    fCurrentVideo.AspectCorrection := acoLetterBox;
+    fCurrentVideo.Draw;
+  end;
 
   //if (Mode = smPartyTournament) then
   //  PartyTimeLimit();

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -3320,8 +3320,8 @@ begin
         fCurrentVideo.ReflectionSpacing := Reflectionspacing;
       end;
     end;
-    if Button[interaction].Reflection or (Theme.Song.Cover.SelectReflection) then
-      fCurrentVideo.Reflection := true;
+    fCurrentVideo.Reflection := (not CoverFull) and
+      (Button[interaction].Reflection or Theme.Song.Cover.SelectReflection);
 
     if CoverFull then
       fCurrentVideo.AspectCorrection := acoLetterBox
@@ -3330,8 +3330,6 @@ begin
 
      fCurrentVideo.Draw;
 
-     if (not CoverFull) and (Button[interaction].Reflection or (Theme.Song.Cover.SelectReflection)) then
-       fCurrentVideo.DrawReflection;
   end;
 
   // duet names


### PR DESCRIPTION
Adds a `V` fullscreen toggle for song-selection video preview.

- `V` now toggles preview video between normal cover area and fullscreen
- Toggle is session-local for the screen (`CoverFull` resets on `OnShow`/`OnHide`)
- Fullscreen is aspect-preserving
- Help screen is updated