### PR TITLE
Bugfix: avoid crash from out-of-bounds access when config.ini has too high player counts

### DIFF
--- a/src/base/UIni.pas
+++ b/src/base/UIni.pas
@@ -1075,6 +1075,7 @@ var
   DeviceIndex:  integer;
   ChannelCount: integer;
   ChannelIndex: integer;
+  PlayerNumber: integer;
   RecordKeys:   TStringList;
   i:            integer;
 begin
@@ -1117,8 +1118,11 @@ begin
       // or set non-configured channels to no player (=0).
       for ChannelIndex := 0 to High(DeviceCfg.ChannelToPlayerMap) do
       begin
-        DeviceCfg.ChannelToPlayerMap[ChannelIndex] :=
+        PlayerNumber :=
           IniFile.ReadInteger('Record', Format('Channel%d[%d]', [ChannelIndex+1, DeviceIndex]), CHANNEL_OFF);
+        if (PlayerNumber < 1) or (PlayerNumber > IMaxPlayerCount) then
+          PlayerNumber := CHANNEL_OFF;
+        DeviceCfg.ChannelToPlayerMap[ChannelIndex] := PlayerNumber;
       end;
     end;
   end;
@@ -1151,7 +1155,7 @@ begin
     for ChannelIndex := 0 to High(InputDeviceConfig[DeviceIndex].ChannelToPlayerMap) do
     begin
       PlayerNumber := InputDeviceConfig[DeviceIndex].ChannelToPlayerMap[ChannelIndex];
-      if PlayerNumber > 0 then
+      if (PlayerNumber >= 1) and (PlayerNumber <= IMaxPlayerCount) then
       begin
         IniFile.WriteInteger('Record',
             Format('Channel%d[%d]', [ChannelIndex+1, DeviceIndex+1]),

--- a/src/base/URecord.pas
+++ b/src/base/URecord.pas
@@ -701,10 +701,13 @@ function TAudioInputProcessor.ValidateSettings: integer;
 var
   I, J: integer;
   PlayerID: integer;
+  MaxPlayerID: integer;
   PlayerMap: array [0 .. UIni.IMaxPlayerCount - 1] of boolean;
   InputDevice: TAudioInputDevice;
   InputDeviceCfg: PInputDeviceConfig;
 begin
+  MaxPlayerID := Length(PlayerMap);
+
   // mark all players as unassigned
   for I := 0 to High(PlayerMap) do
     PlayerMap[I] := false;
@@ -721,6 +724,10 @@ begin
       PlayerID := InputDeviceCfg.ChannelToPlayerMap[J];
       if (PlayerID <> CHANNEL_OFF) then
       begin
+        // avoid out-of-bounds access when switching between game versions with different max player counts
+        if (PlayerID < 1) or (PlayerID > MaxPlayerID) then
+          continue;
+
         // check if player is already assigned to another device/channel
         if (PlayerMap[PlayerID - 1]) then
         begin


### PR DESCRIPTION
After working on #1186 i had mic assignments for 24 players, switching back to other branches would crash the game because the validating the old microphone settings would then go out of bounds (other branches have a max. of 12 set).

Now this is not a bug that should occur under normal usage, but it can occur if:
- someone tries the player count PR #1186 and switches back to an older branch
- manually or with an external tool edits the microphone assignments in `config.ini` and uses a player number beyond 12

Especially for the latter case, it would be nice to not crash the game, even if someone has to do already weird stuff to get there.