### PR TITLE
Bugfix/Improvement: sustain music across screens

### DIFF
--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -134,6 +134,7 @@ uses
   UMain,
   UMenuButton,
   UPath,
+  UScreenSong,
   USkins,
   USongs,
   UTime,
@@ -353,7 +354,12 @@ begin
           Ini.SaveNames;
           AudioPlayback.PlaySound(SoundLib.Back);
           if GoTo_SingScreen then
+          begin
+            AudioPlayback.SetVolume(1.0);
+            ScreenSong.StopMusicPreview();
+            ScreenSong.StopVideoPreview();
             FadeTo(@ScreenSong)
+          end
           else
             FadeTo(@ScreenMain);
         end;
@@ -420,6 +426,9 @@ begin
           begin
             // if we've been in the player screen, we need to show the warning again
             ScreenSing.CheckPlayerConfigOnNextSong := true;
+            AudioPlayback.SetVolume(1.0);
+            ScreenSong.StopMusicPreview();
+            ScreenSong.StopVideoPreview();
             FadeTo(@ScreenSing);
             GoTo_SingScreen := false;
           end
@@ -875,6 +884,7 @@ var
   I: integer;
 begin
   inherited;
+  AudioPlayback.SetVolume(IPreviewVolumeVals[Ini.PreviewVolume]);
 
   Ini.ReloadNames;
   CountIndex := Ini.Players;
@@ -896,13 +906,6 @@ begin
   AvatarCurrent := AvatarTarget;
 
   RefreshPlayers;
-
-  // list players
-  for I := 1 to PlayersPlay do
-  begin
-    Text[PlayerCurrentText[I - 1]].Text := Ini.Name[I - 1];
-    SetPlayerAvatar(I - 1);
-  end;
 
   PlayerColorButton(Num[PlayerIndex]);
 

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -355,10 +355,9 @@ begin
           AudioPlayback.PlaySound(SoundLib.Back);
           if GoTo_SingScreen then
           begin
-            AudioPlayback.SetVolume(1.0);
-            ScreenSong.StopMusicPreview();
-            ScreenSong.StopVideoPreview();
-            FadeTo(@ScreenSong)
+            ScreenSong.PreservePreviewForReturn;
+            FadeTo(@ScreenSong);
+            GoTo_SingScreen := false;
           end
           else
             FadeTo(@ScreenMain);

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -353,10 +353,9 @@ begin
           AudioPlayback.PlaySound(SoundLib.Back);
           if GoTo_SingScreen then
           begin
-            AudioPlayback.SetVolume(1.0);
-            ScreenSong.StopMusicPreview();
-            ScreenSong.StopVideoPreview();
-            FadeTo(@ScreenSong)
+            ScreenSong.PreservePreviewForReturn;
+            FadeTo(@ScreenSong);
+            GoTo_SingScreen := false;
           end
           else
             FadeTo(@ScreenMain);

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -132,6 +132,7 @@ uses
   UMenuButton,
   UPath,
   URenderer,
+  UScreenSong,
   USkins,
   USongs,
   UTime,
@@ -351,7 +352,12 @@ begin
           Ini.SaveNames;
           AudioPlayback.PlaySound(SoundLib.Back);
           if GoTo_SingScreen then
+          begin
+            AudioPlayback.SetVolume(1.0);
+            ScreenSong.StopMusicPreview();
+            ScreenSong.StopVideoPreview();
             FadeTo(@ScreenSong)
+          end
           else
             FadeTo(@ScreenMain);
         end;
@@ -418,6 +424,9 @@ begin
           begin
             // if we've been in the player screen, we need to show the warning again
             ScreenSing.CheckPlayerConfigOnNextSong := true;
+            AudioPlayback.SetVolume(1.0);
+            ScreenSong.StopMusicPreview();
+            ScreenSong.StopVideoPreview();
             FadeTo(@ScreenSing);
             GoTo_SingScreen := false;
           end
@@ -877,6 +886,7 @@ var
   I: integer;
 begin
   inherited;
+  AudioPlayback.SetVolume(IPreviewVolumeVals[Ini.PreviewVolume]);
 
   Ini.ReloadNames;
   CountIndex := Ini.Players;
@@ -898,13 +908,6 @@ begin
   AvatarCurrent := AvatarTarget;
 
   RefreshPlayers;
-
-  // list players
-  for I := 1 to PlayersPlay do
-  begin
-    Text[PlayerCurrentText[I - 1]].Text := Ini.Name[I - 1];
-    SetPlayerAvatar(I - 1);
-  end;
 
   PlayerColorButton(Num[PlayerIndex]);
 

--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -379,7 +379,10 @@ begin
           if (FinishScreenDraw = true) then
           begin
             if (CurrentSong.isDuet) or (ScreenSong.RapToFreestyle) or (ScreenSong.Mode = smMedley) then
+            begin
+              ScreenSong.PreservePreviewForReturn;
               FadeTo(@ScreenSong)
+            end
             else
               FadeTo(@ScreenTop5);
             Exit;
@@ -403,7 +406,10 @@ begin
            begin
 
              if (CurrentSong.isDuet) or (ScreenSong.RapToFreestyle) or (ScreenSong.Mode = smMedley) then
+             begin
+               ScreenSong.PreservePreviewForReturn;
                FadeTo(@ScreenSong)
+             end
              else
                FadeTo(@ScreenTop5);
 
@@ -1141,6 +1147,7 @@ var
   I: integer;
   V: array[1..UIni.IMaxPlayerCount] of boolean; // visibility array
 begin
+  AudioPlayback.SetVolume(IPreviewVolumeVals[Ini.PreviewVolume]);
   if not Help.SetHelpID(ID) then
     Log.LogWarn('No Entry for Help-ID ' + ID, 'ScreenScore');
 

--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -1813,6 +1813,8 @@ var
   select:   integer;
   changed:  boolean;
 begin
+  if (not AudioPlayback.Finished) then
+    Exit;
   //When Music Preview is activated -> then change music
   if (Ini.PreviewVolume <> 0) then
   begin

--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -1791,6 +1791,8 @@ var
   changed:  boolean;
   PreviewVolume: single;
 begin
+  if (not AudioPlayback.Finished) then
+    Exit;
   //When Music Preview is activated -> then change music
   if (Ini.PreviewVolume <> 0) then
   begin

--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -378,7 +378,10 @@ begin
           if (FinishScreenDraw = true) then
           begin
             if (CurrentSong.isDuet) or (ScreenSong.RapToFreestyle) or (ScreenSong.Mode = smMedley) then
+            begin
+              ScreenSong.PreservePreviewForReturn;
               FadeTo(@ScreenSong)
+            end
             else
               FadeTo(@ScreenTop5);
             Exit;
@@ -402,7 +405,10 @@ begin
            begin
 
              if (CurrentSong.isDuet) or (ScreenSong.RapToFreestyle) or (ScreenSong.Mode = smMedley) then
+             begin
+               ScreenSong.PreservePreviewForReturn;
                FadeTo(@ScreenSong)
+             end
              else
                FadeTo(@ScreenTop5);
 
@@ -1136,6 +1142,7 @@ var
   I: integer;
   V: array[1..UIni.IMaxPlayerCount] of boolean; // visibility array
 begin
+  AudioPlayback.SetVolume(IPreviewVolumeVals[Ini.PreviewVolume]);
   if not Help.SetHelpID(ID) then
     Log.LogWarn('No Entry for Help-ID ' + ID, 'ScreenScore');
 

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -84,6 +84,9 @@ type
       RandomSongOrder: CardinalArray;
       NextRandomSongIdx: cardinal;
       RandomSearchOrder: CardinalArray;
+      KeepPreviewMusicOnHide: boolean;
+      PreviewRestorePosition: real;
+      PreviewRestoreValid: boolean;
 
       procedure StartMusicPreview();
       procedure StartVideoPreview();
@@ -191,6 +194,8 @@ type
       PlayMidi: boolean;
       MidiFadeIn: boolean;
       FadeTime: cardinal;
+
+      KeepPreviewPositionOnShow: boolean;
 
       InfoMessageBG: cardinal;
       InfoMessageText: cardinal;
@@ -320,6 +325,8 @@ type
       procedure ParseInputPrevVertical(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean);
 
       procedure ResetScrollList;
+
+      procedure PreservePreviewForReturn;
   end;
 
 implementation
@@ -653,6 +660,7 @@ var
   VerifySong, WebList: string;
   Fix: boolean;
   VS: integer;
+  NeedPlayersScreen: boolean;
 
   function RandomPermute(Num: integer): CardinalArray;
   var
@@ -1255,8 +1263,10 @@ begin
                 Exit;
               end;
 
+              NeedPlayersScreen := (Mode = smNormal) and (Ini.OnSongClick = 1);
               StopVideoPreview;
-              StopMusicPreview;
+              if not NeedPlayersScreen then
+                StopMusicPreview;
 
               if (Mode = smNormal) then //Normal Mode -> Start Song
               begin
@@ -1932,6 +1942,10 @@ begin
   NextRandomSongIdx := High(cardinal);
   NextRandomSearchIdx := High(cardinal);
 
+  KeepPreviewMusicOnHide := false;
+  KeepPreviewPositionOnShow := false;
+  PreviewRestorePosition := 0;
+  PreviewRestoreValid := false;
 end;
 
 procedure TScreenSong.ColorDuetNameSingers();
@@ -2855,8 +2869,11 @@ end;
 procedure TScreenSong.OnShow;
 var
   I: integer;
+  KeepPreview: boolean;
 begin
   inherited;
+
+  KeepPreviewMusicOnHide := false;
 
   CloseMessage();
 
@@ -2946,13 +2963,38 @@ begin
    *}
   SoundLib.PauseBgMusic;
 
-  if SongIndex <> Interaction then
+  KeepPreview := KeepPreviewPositionOnShow;
+  if (SongIndex <> Interaction) and not KeepPreview then
     AudioPlayback.Stop;
-
-  PreviewOpened := -1;
+  if KeepPreview then
+    PreviewOpened := Interaction
+  else
+    PreviewOpened := -1;
+  KeepPreviewPositionOnShow := false;
 
   // reset video playback engine
   fCurrentVideo := nil;
+  if KeepPreview then
+  begin
+    if PreviewRestoreValid then
+    begin
+      if (AudioPlayback.Length <= 0) then
+      begin
+        if AudioPlayback.Open(CatSongs.Song[Interaction].Path.Append(CatSongs.Song[Interaction].Audio), nil) then
+          AudioPlayback.Position := PreviewRestorePosition;
+        AudioPlayback.Play();
+      end
+      else if AudioPlayback.Finished then
+      begin
+        AudioPlayback.Position := PreviewRestorePosition;
+        AudioPlayback.Play();
+      end;
+
+      PreviewRestoreValid := false;
+    end;
+
+    StartVideoPreview();
+  end;
 
   // reset Medley-Playlist
   SetLength(PlaylistMedley.Song, 0);
@@ -3056,13 +3098,21 @@ end;
 
 procedure TScreenSong.OnHide;
 begin
+  if not KeepPreviewMusicOnHide then
+  begin
+    // turn music volume to 100%
+    AudioPlayback.SetVolume(1.0);
 
-  // turn music volume to 100%
-  AudioPlayback.SetVolume(1.0);
-
-  // stop preview
-  StopMusicPreview();
-  StopVideoPreview();
+    // stop preview
+    StopMusicPreview();
+    StopVideoPreview();
+  end
+  else
+  begin
+    // keep music preview running (e.g., player select), but stop video preview
+    StopVideoPreview();
+    KeepPreviewMusicOnHide := false;
+  end;
 end;
 
 procedure TScreenSong.DrawExtensions;
@@ -3712,6 +3762,13 @@ begin
   end;
 end;
 
+procedure TScreenSong.PreservePreviewForReturn;
+begin
+  KeepPreviewPositionOnShow := true;
+  PreviewRestorePosition := AudioPlayback.Position;
+  PreviewRestoreValid := true;
+end;
+
 // Changes previewed song
 procedure TScreenSong.ChangeMusic;
 begin
@@ -4139,8 +4196,8 @@ end;
 procedure TScreenSong.SelectPlayers;
 begin
   CatSongs.Selected := Interaction;
-  StopMusicPreview();
 
+  KeepPreviewMusicOnHide := true;
   ScreenName.Goto_SingScreen := true;
   FadeTo(@ScreenName);
 end;
@@ -4298,7 +4355,8 @@ begin
   begin
     Mode := smMedley;
 
-    StopMusicPreview();
+    if (Ini.OnSongClick <> 1) then
+      StopMusicPreview();
 
     //TODO: how about case 2? menu for medley mode?
     case Ini.OnSongClick of
@@ -4318,7 +4376,8 @@ begin
     if PlaylistMedley.NumMedleySongs = NumSongs then
     begin
       Mode := smMedley;
-      StopMusicPreview();
+      if (Ini.OnSongClick <> 1) then
+        StopMusicPreview();
 
       //TODO: how about case 2? menu for medley mode?
       case Ini.OnSongClick of

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -82,6 +82,9 @@ type
       RandomSongOrder: CardinalArray;
       NextRandomSongIdx: cardinal;
       RandomSearchOrder: CardinalArray;
+      KeepPreviewMusicOnHide: boolean;
+      PreviewRestorePosition: real;
+      PreviewRestoreValid: boolean;
 
       procedure StartMusicPreview();
       procedure StartVideoPreview();
@@ -189,6 +192,8 @@ type
       PlayMidi: boolean;
       MidiFadeIn: boolean;
       FadeTime: cardinal;
+
+      KeepPreviewPositionOnShow: boolean;
 
       InfoMessageBG: cardinal;
       InfoMessageText: cardinal;
@@ -320,6 +325,8 @@ type
 
         procedure ResetRandomSongState;
       procedure ResetScrollList;
+
+      procedure PreservePreviewForReturn;
   end;
 
 implementation
@@ -683,6 +690,28 @@ var
   VerifySong, WebList: string;
   Fix: boolean;
   VS: integer;
+  NeedPlayersScreen: boolean;
+
+  function RandomPermute(Num: integer): CardinalArray;
+  var
+    Ordered: array of cardinal;
+    Idx, i: cardinal;
+  begin
+    Result := nil;
+    if Num <= 0 then
+      Exit;
+    SetLength(Ordered, Num);
+    SetLength(Result, Num);
+    for i := 0 to Num-1 do Ordered[i] := i;
+    for i := 0 to Num-1 do
+    begin
+      Idx := Random(Num);
+      Result[i] := Ordered[Idx];
+      Delete(Ordered, Idx, 1);
+      Dec(Num);
+    end;
+  end;
+
 begin
   Result := true;
 
@@ -1281,8 +1310,10 @@ begin
                 Exit;
               end;
 
+              NeedPlayersScreen := (Mode = smNormal) and (Ini.OnSongClick = 1);
               StopVideoPreview;
-              StopMusicPreview;
+              if not NeedPlayersScreen then
+                StopMusicPreview;
 
               if (Mode = smNormal) then //Normal Mode -> Start Song
               begin
@@ -1958,6 +1989,10 @@ begin
   NextRandomSongIdx := High(cardinal);
   NextRandomSearchIdx := High(cardinal);
 
+  KeepPreviewMusicOnHide := false;
+  KeepPreviewPositionOnShow := false;
+  PreviewRestorePosition := 0;
+  PreviewRestoreValid := false;
 end;
 
 procedure TScreenSong.ColorDuetNameSingers();
@@ -2845,8 +2880,11 @@ end;
 procedure TScreenSong.OnShow;
 var
   I: integer;
+  KeepPreview: boolean;
 begin
   inherited;
+
+  KeepPreviewMusicOnHide := false;
 
   CloseMessage();
 
@@ -2936,13 +2974,38 @@ begin
    *}
   SoundLib.PauseBgMusic;
 
-  if SongIndex <> Interaction then
+  KeepPreview := KeepPreviewPositionOnShow;
+  if (SongIndex <> Interaction) and not KeepPreview then
     AudioPlayback.Stop;
-
-  PreviewOpened := -1;
+  if KeepPreview then
+    PreviewOpened := Interaction
+  else
+    PreviewOpened := -1;
+  KeepPreviewPositionOnShow := false;
 
   // reset video playback engine
   fCurrentVideo := nil;
+  if KeepPreview then
+  begin
+    if PreviewRestoreValid then
+    begin
+      if (AudioPlayback.Length <= 0) then
+      begin
+        if AudioPlayback.Open(CatSongs.Song[Interaction].Path.Append(CatSongs.Song[Interaction].Audio), nil) then
+          AudioPlayback.Position := PreviewRestorePosition;
+        AudioPlayback.Play();
+      end
+      else if AudioPlayback.Finished then
+      begin
+        AudioPlayback.Position := PreviewRestorePosition;
+        AudioPlayback.Play();
+      end;
+
+      PreviewRestoreValid := false;
+    end;
+
+    StartVideoPreview();
+  end;
 
   // reset Medley-Playlist
   SetLength(PlaylistMedley.Song, 0);
@@ -3046,13 +3109,21 @@ end;
 
 procedure TScreenSong.OnHide;
 begin
+  if not KeepPreviewMusicOnHide then
+  begin
+    // turn music volume to 100%
+    AudioPlayback.SetVolume(1.0);
 
-  // turn music volume to 100%
-  AudioPlayback.SetVolume(1.0);
-
-  // stop preview
-  StopMusicPreview();
-  StopVideoPreview();
+    // stop preview
+    StopMusicPreview();
+    StopVideoPreview();
+  end
+  else
+  begin
+    // keep music preview running (e.g., player select), but stop video preview
+    StopVideoPreview();
+    KeepPreviewMusicOnHide := false;
+  end;
 end;
 
 procedure TScreenSong.DrawExtensions;
@@ -3703,6 +3774,13 @@ begin
   end;
 end;
 
+procedure TScreenSong.PreservePreviewForReturn;
+begin
+  KeepPreviewPositionOnShow := true;
+  PreviewRestorePosition := AudioPlayback.Position;
+  PreviewRestoreValid := true;
+end;
+
 // Changes previewed song
 procedure TScreenSong.ChangeMusic;
 begin
@@ -4145,8 +4223,8 @@ end;
 procedure TScreenSong.SelectPlayers;
 begin
   CatSongs.Selected := Interaction;
-  StopMusicPreview();
 
+  KeepPreviewMusicOnHide := true;
   ScreenName.Goto_SingScreen := true;
   FadeTo(@ScreenName);
 end;
@@ -4327,7 +4405,8 @@ begin
   begin
     Mode := smMedley;
 
-    StopMusicPreview();
+    if (Ini.OnSongClick <> 1) then
+      StopMusicPreview();
 
     //TODO: how about case 2? menu for medley mode?
     case Ini.OnSongClick of
@@ -4347,7 +4426,8 @@ begin
     if PlaylistMedley.NumMedleySongs = NumSongs then
     begin
       Mode := smMedley;
-      StopMusicPreview();
+      if (Ini.OnSongClick <> 1) then
+        StopMusicPreview();
 
       //TODO: how about case 2? menu for medley mode?
       case Ini.OnSongClick of

--- a/src/screens/UScreenTop5.pas
+++ b/src/screens/UScreenTop5.pas
@@ -102,6 +102,7 @@ begin
         begin
           if (not Fadeout) then
           begin
+            ScreenSong.PreservePreviewForReturn;
             FadeTo(@ScreenSong);
             Fadeout := true;
           end;
@@ -181,6 +182,7 @@ var
   Report: string;
 begin
   inherited;
+  AudioPlayback.SetVolume(IPreviewVolumeVals[Ini.PreviewVolume]);
 
   if not Help.SetHelpID(ID) then
     Log.LogWarn('No Entry for Help-ID ' + ID, 'ScreenTop5');
@@ -242,7 +244,10 @@ begin
   end;
 
   If Length(CurrentSong.Score[Player[0].Level])=0 then
+  begin
+    ScreenSong.PreservePreviewForReturn;
     FadeTo(@ScreenSong); //if there are no scores to show, go to next screen
+  end;
   for I := Length(CurrentSong.Score[Player[0].Level]) + 1 to 5 do
   begin
     Statics[StaticNumber[I]].Visible := false;

--- a/src/screens/UScreenTop5.pas
+++ b/src/screens/UScreenTop5.pas
@@ -102,6 +102,7 @@ begin
         begin
           if (not Fadeout) then
           begin
+            ScreenSong.PreservePreviewForReturn;
             FadeTo(@ScreenSong);
             Fadeout := true;
           end;
@@ -180,6 +181,7 @@ var
   Report: string;
 begin
   inherited;
+  AudioPlayback.SetVolume(IPreviewVolumeVals[Ini.PreviewVolume]);
 
   if not Help.SetHelpID(ID) then
     Log.LogWarn('No Entry for Help-ID ' + ID, 'ScreenTop5');
@@ -225,7 +227,10 @@ begin
   end;
 
   If Length(CurrentSong.Score[Player[0].Level])=0 then
+  begin
+    ScreenSong.PreservePreviewForReturn;
     FadeTo(@ScreenSong); //if there are no scores to show, go to next screen
+  end;
   for I := Length(CurrentSong.Score[Player[0].Level]) + 1 to 5 do
   begin
     Statics[StaticNumber[I]].Visible := false;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -1601,7 +1601,6 @@ var
 
 begin
   AudioInput.CaptureStop;
-  AudioPlayback.Stop;
   AudioPlayback.SetSyncSource(nil);
 
   if (ScreenSong.Mode = smNormal) and (SungPaused = false) and (SungToEnd) and (Length(DllMan.Websites) > 0) then

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -1592,7 +1592,6 @@ var
 begin
   Log.LogStatus('TScreenSingController.Finish', 'TScreenSingController.Finish');
   AudioInput.CaptureStop;
-  AudioPlayback.Stop;
   AudioPlayback.SetSyncSource(nil);
 
   if (ScreenSong.Mode = smNormal) and SungToEnd then


### PR DESCRIPTION
When you finish a song and bounce between player select, score, and Top5:
- the song preview cuts out or restarts when you return to song selection,
- video previews sometimes stop or come back late,
- volume is inconsistent: some screens suddenly jump to full volume, even though they’re just previews.

So instead of a smooth loop of "finish -> view results -> browse songs," the audio/video flow feels broken with sharp cuts.

This PR makes the entire audio playing behave more consistent with only the actual singing screen running at full volume and no sharp cuts between the other screens:
1. Song preview audio is preserved when returning from score/Top5. The playback position is remembered, so it doesn't restart or jump. Video preview is re‑attached when going back to the song selection
2. Player select, Score, and Top5 now force preview volume. Only the sing screen switches to full volume.
3. Player screen now keeps preview running if it was triggered from song selection. It stops previews only when you actually start singing.

So overall, this is much better for players now.