### PR TITLE
Bugfix: fix Alt+Key shortcut if folders are used and sorting is also by folder

### DIFF
--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -739,7 +739,15 @@ begin
           begin
             if (CatSongs.Song[(I + Interaction) mod I2].Visible) then
             begin
-              TempStr := CatSongs.Song[(I + Interaction) mod I2].Artist;
+              if (TSortingType(Ini.Sorting) = sFolder) then
+              begin
+                if CatSongs.Song[(I + Interaction) mod I2].Main then
+                  TempStr := CatSongs.Song[(I + Interaction) mod I2].Artist
+                else
+                  TempStr := CatSongs.Song[(I + Interaction) mod I2].Folder;
+              end
+              else
+                TempStr := CatSongs.Song[(I + Interaction) mod I2].Artist;
               if Length(TempStr) > 0 then TempLetter := UCS4UpperCase(UTF8ToUCS4String(TempStr)[0])
               else                        TempLetter := 0;
               //in case of tabs, the artist string may be enclosed in brackets so we check the first charactere is a bracket then go to next

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -763,7 +763,15 @@ begin
           begin
             if (CatSongs.Song[(I + Interaction) mod I2].Visible) then
             begin
-              TempStr := CatSongs.Song[(I + Interaction) mod I2].Artist;
+              if (TSortingType(Ini.Sorting) = sFolder) then
+              begin
+                if CatSongs.Song[(I + Interaction) mod I2].Main then
+                  TempStr := CatSongs.Song[(I + Interaction) mod I2].Artist
+                else
+                  TempStr := CatSongs.Song[(I + Interaction) mod I2].Folder;
+              end
+              else
+                TempStr := CatSongs.Song[(I + Interaction) mod I2].Artist;
               if Length(TempStr) > 0 then TempLetter := UCS4UpperCase(UTF8ToUCS4String(TempStr)[0])
               else                        TempLetter := 0;
               //in case of tabs, the artist string may be enclosed in brackets so we check the first charactere is a bracket then go to next


### PR DESCRIPTION
The Alt+Key shortcut at some point stopped working, as reported in #757. This small commit fixes it.