### PR TITLE
Cleanup: refactor BPM to a single floating point number

### DIFF
--- a/src/base/UFiles.pas
+++ b/src/base/UFiles.pas
@@ -89,7 +89,6 @@ var
   CurrentNote:      integer;
   CurrentTrack:     integer;
   Line:             AnsiString;
-  B:      integer;
   RelativeSubTime: integer;
   NoteState: AnsiString;
   SongFile: TTextFileStream;
@@ -176,7 +175,7 @@ begin
         SongFile.WriteLine('#MEDLEYENDBEAT:' + IntToStr(Song.Medley.EndBeat));
       end;
 
-      SongFile.WriteLine('#BPM:' + FloatToStr(Song.BPM[0].BPM / 4));
+      SongFile.WriteLine('#BPM:' + FloatToStr(Song.BPM / 4));
       SongFile.WriteLine('#GAP:' + FloatToStr(Song.GAP));
 
       if Song.isDuet then
@@ -189,9 +188,6 @@ begin
       WriteCustomTags;
 
       RelativeSubTime := 0;
-      for B := 1 to High(Song.BPM) do
-        SongFile.WriteLine('B ' + FloatToStr(Song.BPM[B].StartBeat) + ' '
-                                + FloatToStr(Song.BPM[B].BPM/4));
 
       for CurrentTrack := 0 to High(Tracks) do
       begin

--- a/src/base/UNote.pas
+++ b/src/base/UNote.pas
@@ -175,130 +175,32 @@ begin
   Result := BPM * msTime / 60;
 end;
 
-procedure GetMidBeatSub(BPMNum: integer; var Time: real; var CurBeat: real);
-var
-  NewTime: real;
-begin
-  if High(CurrentSong.BPM) = BPMNum then
-  begin
-    // last BPM
-    CurBeat := CurrentSong.BPM[BPMNum].StartBeat + GetBeats(CurrentSong.BPM[BPMNum].BPM, Time);
-    Time := 0;
-  end
-  else
-  begin
-    // not last BPM
-    // count how much time is it for start of the new BPM and store it in NewTime
-    NewTime := GetTimeForBeats(CurrentSong.BPM[BPMNum].BPM, CurrentSong.BPM[BPMNum+1].StartBeat - CurrentSong.BPM[BPMNum].StartBeat);
-
-    // compare it to remaining time
-    if (Time - NewTime) > 0 then
-    begin
-      // there is still remaining time
-      CurBeat := CurrentSong.BPM[BPMNum].StartBeat;
-      Time := Time - NewTime;
-    end
-    else
-    begin
-      // there is no remaining time
-      CurBeat := CurrentSong.BPM[BPMNum].StartBeat + GetBeats(CurrentSong.BPM[BPMNum].BPM, Time);
-      Time := 0;
-    end; // if
-  end; // if
-end;
-
 function GetMidBeat(Time: real): real;
-var
-  CurBeat: real;
-  CurBPM:  integer;
 begin
   try
-  // static BPM
-  if Length(CurrentSong.BPM) = 1 then
-  begin
-    Result := Time * CurrentSong.BPM[0].BPM / 60;
-  end
-  // variable BPM
-  else if Length(CurrentSong.BPM) > 1 then
-  begin
-    CurBeat := 0;
-    CurBPM := 0;
-    while (Time > 0) do
-    begin
-      GetMidBeatSub(CurBPM, Time, CurBeat);
-      Inc(CurBPM);
-    end;
-
-    Result := CurBeat;
-  end
-  // invalid BPM
-  else
-  begin
-    Result := 0;
-  end;
+    if CurrentSong.BPM > 0 then
+      Result := Time * CurrentSong.BPM / 60
+    else
+      Result := 0;
   except
     on E : Exception do
-    Result :=0;
+      Result := 0;
   end;
 end;
 
 function GetTimeFromBeat(Beat: integer; SelfSong: TSong = nil): real;
 var
-  CurBPM: integer;
   Song: TSong;
 begin
-
   if (SelfSong <> nil) then
     Song := SelfSong
   else
     Song := CurrentSong;
 
-  Result := 0;
-
-  // static BPM
-  if Length(Song.BPM) = 1 then
-  begin
-    Result := Song.GAP / 1000 + Beat * 60 / Song.BPM[0].BPM;
-  end
-  // variable BPM
-  else if Length(Song.BPM) > 1 then
-  begin
-    Result := Song.GAP / 1000;
-    CurBPM := 0;
-    while (CurBPM <= High(Song.BPM)) and
-          (Beat > Song.BPM[CurBPM].StartBeat) do
-    begin
-      if (CurBPM < High(Song.BPM)) and
-         (Beat >= Song.BPM[CurBPM+1].StartBeat) then
-      begin
-        // full range
-        Result := Result + (60 / Song.BPM[CurBPM].BPM) *
-                           (Song.BPM[CurBPM+1].StartBeat - Song.BPM[CurBPM].StartBeat);
-      end;
-
-      if (CurBPM = High(Song.BPM)) or
-         (Beat < Song.BPM[CurBPM+1].StartBeat) then
-      begin
-        // in the middle
-        Result := Result + (60 / Song.BPM[CurBPM].BPM) *
-                           (Beat - Song.BPM[CurBPM].StartBeat);
-      end;
-      Inc(CurBPM);
-    end;
-
-    {
-    while (Time > 0) do
-    begin
-      GetMidBeatSub(CurBPM, Time, CurBeat);
-      Inc(CurBPM);
-    end;
-    }
-  end
-  // invalid BPM
+  if Song.BPM > 0 then
+    Result := Song.GAP / 1000 + Beat * 60 / Song.BPM
   else
-  begin
     Result := 0;
-  end;
 end;
 
 procedure Sing(Screen: TScreenSingController);

--- a/src/base/UNote.pas
+++ b/src/base/UNote.pas
@@ -178,7 +178,7 @@ end;
 function GetMidBeat(Time: real): real;
 begin
   try
-    if CurrentSong.BPM > 0 then
+    if CurrentSong.BPM >= MIN_BPM then
       Result := Time * CurrentSong.BPM / 60
     else
       Result := 0;
@@ -197,7 +197,7 @@ begin
   else
     Song := CurrentSong;
 
-  if Song.BPM > 0 then
+  if Song.BPM >= MIN_BPM then
     Result := Song.GAP / 1000 + Beat * 60 / Song.BPM
   else
     Result := 0;

--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -67,6 +67,7 @@ uses
 
 const
   DEFAULT_RESOLUTION = 4; // default #RESOLUTION
+  MIN_BPM = 1.0; // minimum allowed BPM to avoid divide-by-zero
 
 type
 
@@ -81,11 +82,6 @@ type
     EndBeat:      integer;        //end beat of medley
     FadeIn_time:  real;           //FadeIn-Time in seconds
     FadeOut_time: real;           //FadeOut-Time in seconds
-  end;
-
-  TBPM = record
-    BPM:        real;
-    StartBeat:  real;
   end;
 
   TScore = record
@@ -179,7 +175,7 @@ type
     Finish:     integer; // in milliseconds
     Relative:   boolean;
     Resolution: integer;
-    BPM:        array of TBPM;
+    BPM:        real;
     GAP:        real; // in milliseconds
     
     Encoding:   TEncoding;
@@ -208,7 +204,6 @@ type
     Base:       array[0..1] of integer;
     Rel:        array[0..1] of integer;
     Mult:       integer;
-    MultBPM:    integer;
 
     LastError:  AnsiString;
     function    GetErrorLineNo: integer;
@@ -433,7 +428,6 @@ begin
   inherited Create();
 
   Mult    := 1;
-  MultBPM := 4;
 
   LastError := '';
 
@@ -672,7 +666,6 @@ begin
   LastError := '';
   CurrentTrack := 0;
 
-  MultBPM           := 4; // multiply beat-count of note by 4
   Mult              := 1; // accuracy of measurement of note
   Rel[0]            := 0;
   Rel[1]            := 0;
@@ -841,12 +834,8 @@ begin
         end // if
         else if Param0 = 'B' then
         begin
-          SetLength(self.BPM, Length(self.BPM) + 1);
-          self.BPM[High(self.BPM)].StartBeat := ParseLyricFloatParam(CurLine, LinePos);
-          self.BPM[High(self.BPM)].StartBeat := self.BPM[High(self.BPM)].StartBeat + Rel[0];
-
-          self.BPM[High(self.BPM)].BPM := ParseLyricFloatParam(CurLine, LinePos);
-          self.BPM[High(self.BPM)].BPM := self.BPM[High(self.BPM)].BPM * Mult * MultBPM;
+          Log.LogWarn(Format('Ignoring variable BPM line in "%s" (line %d)',
+            [FileNamePath.ToNative, FileLineNo]), 'TSong.LoadSong');
         end;
 
         // Read next line in File
@@ -1022,9 +1011,7 @@ begin
   Result := true;
   Done   := 0;
   MedleyFlags := 0;
-  SetLength(self.BPM, 1);
-  self.BPM[0].BPM := 0;
-  self.BPM[0].StartBeat := 0;
+  self.BPM := 0;
 
   //SetLength(tmpEdition, 0);
 
@@ -1200,18 +1187,19 @@ begin
     if (TagMapTryGetData('BPM', Value)) then
     begin
       RemoveTagsFromTagMap('BPM');
-      SetLength(self.BPM, 1);
-      self.BPM[0].StartBeat := 0;
+      self.BPM := 0;
       StringReplace(Value, ',', '.', [rfReplaceAll]);
-      self.BPM[0].BPM := StrToFloatI18n(Value ) * Mult * MultBPM;
+      self.BPM := StrToFloatI18n(Value) * Mult * 4;
 
-      if self.BPM[0].BPM <> 0 then
+      if self.BPM <= 0 then
       begin
-        //Add BPM Flag to Done
-        Done := Done or 8
-      end
-      else
-          Log.LogError('Was not able to convert String ' + FullFileName + '"' + Value + '" to number.');
+        Log.LogWarn('Invalid BPM value "' + Value + '" in ' + FullFileName + ' -> clamped to minimum',
+          'TSong.ReadTXTHeader');
+        self.BPM := MIN_BPM;
+      end;
+
+      //Add BPM Flag to Done
+      Done := Done or 8;
     end;
 
     //---------
@@ -1844,7 +1832,7 @@ begin
 
   //Required Information
   Audio    := PATH_NONE;
-  SetLength(BPM, 0);
+  BPM := 0;
 
   GAP    := 0;
   Start  := 0;

--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -67,6 +67,7 @@ uses
 
 const
   DEFAULT_RESOLUTION = 4; // default #RESOLUTION
+  MIN_BPM = 1.0; // minimum allowed BPM to avoid divide-by-zero
 type
 
   TSingMode = ( smNormal, smPartyClassic, smPartyFree, smPartyTournament, smJukebox, smPlaylistRandom , smMedley );
@@ -1189,7 +1190,7 @@ begin
       StringReplace(Value, ',', '.', [rfReplaceAll]);
       self.BPM := StrToFloatI18n(Value) * Mult * 4;
 
-      if self.BPM <= 0 then
+      if self.BPM < MIN_BPM then
       begin
         Log.LogError('Invalid BPM value "' + Value + '" in ' + FullFileName + '"',
           'TSong.ReadTXTHeader');

--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -67,8 +67,6 @@ uses
 
 const
   DEFAULT_RESOLUTION = 4; // default #RESOLUTION
-  MIN_BPM = 1.0; // minimum allowed BPM to avoid divide-by-zero
-
 type
 
   TSingMode = ( smNormal, smPartyClassic, smPartyFree, smPartyTournament, smJukebox, smPlaylistRandom , smMedley );
@@ -1193,13 +1191,15 @@ begin
 
       if self.BPM <= 0 then
       begin
-        Log.LogWarn('Invalid BPM value "' + Value + '" in ' + FullFileName + ' -> clamped to minimum',
+        Log.LogError('Invalid BPM value "' + Value + '" in ' + FullFileName + '"',
           'TSong.ReadTXTHeader');
-        self.BPM := MIN_BPM;
+        self.BPM := 0;
+      end
+      else
+      begin
+        //Add BPM Flag to Done
+        Done := Done or 8;
       end;
-
-      //Add BPM Flag to Done
-      Done := Done or 8;
     end;
 
     //---------
@@ -1933,4 +1933,3 @@ begin
 end;
 
 end.
-

--- a/src/base/USongs.pas
+++ b/src/base/USongs.pas
@@ -77,11 +77,6 @@ type
     fltTags
   );
 
-  TBPM = record
-    BPM:       real;
-    StartBeat: real;
-  end;
-
   TScore = record
     Name:   UTF8String;
     Score:  integer;

--- a/src/lua/ULuaScreenSing.pas
+++ b/src/lua/ULuaScreenSing.pas
@@ -190,15 +190,10 @@ begin
   lua_ClearStack(L);
   Result := 1;
 
-  if (CurrentSong = nil) or (Length(CurrentSong.BPM) = 0) or (Display.CurrentScreen <> @ScreenSing) then
+  if (CurrentSong = nil) or (CurrentSong.BPM = 0) or (Display.CurrentScreen <> @ScreenSing) then
     lua_PushNumber(L, 0) // in case of error
-  else if (Length(CurrentSong.BPM) = 1) then
-    lua_PushNumber(L, CurrentSong.BPM[0].BPM)
   else
-  begin
-    // to-do: do this for songs w/ BPM changes
-    //        or drop support for BPM changes?!
-  end;
+    lua_PushNumber(L, CurrentSong.BPM);
 end;
 
 { ScreenSing.BeatsToSeconds(Beats: float)
@@ -207,15 +202,10 @@ function ULuaScreenSing_BeatsToSeconds(L: Plua_State): Integer; cdecl;
 begin
   Result := 1;
 
-  if (CurrentSong = nil) or (Length(CurrentSong.BPM) = 0) or (Display.CurrentScreen <> @ScreenSing) then
+  if (CurrentSong = nil) or (CurrentSong.BPM = 0) or (Display.CurrentScreen <> @ScreenSing) then
     lua_PushNumber(L, 0) // in case of error
-  else if (Length(CurrentSong.BPM) = 1) then
-    lua_PushNumber(L, luaL_CheckNumber(L, 1) * 60 / CurrentSong.BPM[0].BPM)
   else
-  begin
-    // to-do: do this for songs w/ BPM changes
-    //        or drop support for BPM changes?!
-  end;
+    lua_PushNumber(L, luaL_CheckNumber(L, 1) * 60 / CurrentSong.BPM);
 end;
 
 { ScreenSing.BeatsToSeconds(Seconds: float)
@@ -224,15 +214,10 @@ function ULuaScreenSing_SecondsToBeats(L: Plua_State): Integer; cdecl;
 begin
   Result := 1;
 
-  if (CurrentSong = nil) or (Length(CurrentSong.BPM) = 0) or (Display.CurrentScreen <> @ScreenSing) then
+  if (CurrentSong = nil) or (CurrentSong.BPM = 0) or (Display.CurrentScreen <> @ScreenSing) then
     lua_PushNumber(L, 0)
-  else if (Length(CurrentSong.BPM) = 1) then
-    lua_PushNumber(L, luaL_CheckNumber(L, 1) * CurrentSong.BPM[0].BPM / 60)
   else
-  begin
-    // to-do: do this for songs w/ BPM changes
-    //        or drop support for BPM changes?!
-  end;
+    lua_PushNumber(L, luaL_CheckNumber(L, 1) * CurrentSong.BPM / 60);
 end;
 
 { ScreenSing.GetBeat() - returns current beat of lyricstate (in quarts) }

--- a/src/lua/ULuaScreenSing.pas
+++ b/src/lua/ULuaScreenSing.pas
@@ -119,6 +119,7 @@ uses
   math,
   UScreenSingController,
   UNote,
+  USong,
   UDisplay,
   UGraphic,
   UMusic,
@@ -190,7 +191,7 @@ begin
   lua_ClearStack(L);
   Result := 1;
 
-  if (CurrentSong = nil) or (CurrentSong.BPM = 0) or (Display.CurrentScreen <> @ScreenSing) then
+  if (CurrentSong = nil) or (CurrentSong.BPM < MIN_BPM) or (Display.CurrentScreen <> @ScreenSing) then
     lua_PushNumber(L, 0) // in case of error
   else
     lua_PushNumber(L, CurrentSong.BPM);
@@ -202,7 +203,7 @@ function ULuaScreenSing_BeatsToSeconds(L: Plua_State): Integer; cdecl;
 begin
   Result := 1;
 
-  if (CurrentSong = nil) or (CurrentSong.BPM = 0) or (Display.CurrentScreen <> @ScreenSing) then
+  if (CurrentSong = nil) or (CurrentSong.BPM < MIN_BPM) or (Display.CurrentScreen <> @ScreenSing) then
     lua_PushNumber(L, 0) // in case of error
   else
     lua_PushNumber(L, luaL_CheckNumber(L, 1) * 60 / CurrentSong.BPM);
@@ -214,7 +215,7 @@ function ULuaScreenSing_SecondsToBeats(L: Plua_State): Integer; cdecl;
 begin
   Result := 1;
 
-  if (CurrentSong = nil) or (CurrentSong.BPM = 0) or (Display.CurrentScreen <> @ScreenSing) then
+  if (CurrentSong = nil) or (CurrentSong.BPM < MIN_BPM) or (Display.CurrentScreen <> @ScreenSing) then
     lua_PushNumber(L, 0)
   else
     lua_PushNumber(L, luaL_CheckNumber(L, 1) * CurrentSong.BPM / 60);

--- a/src/screens/UScreenEditConvert.pas
+++ b/src/screens/UScreenEditConvert.pas
@@ -580,8 +580,7 @@ begin
   Song := TSong.Create();
   Song.Clear();
   Song.Resolution := 4;
-  SetLength(Song.BPM, 1);
-  Song.BPM[0].BPM := BPM*4;
+  Song.BPM := BPM*4;
   SetLength(Notes, 0);
 
   // extract notes

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -91,7 +91,7 @@ type
     Video:        IPath;
     VideoId:      Integer;
     VideoGAP:     Real;
-    BPM:          array of TBPM;
+    BPM:          Real;
     GAP:          Real;
     StartTag:     Real;
     EndTag:       longint;
@@ -1324,17 +1324,17 @@ begin
   CopyToUndo;
   if SDL_ModState = 0 then
   begin
-    CurrentSong.BPM[0].BPM := Round((CurrentSong.BPM[0].BPM * 5) + 1) / 5; // (1/20)
+    CurrentSong.BPM := Round((CurrentSong.BPM * 5) + 1) / 5; // (1/20)
     Text[TextInfo].Text := Language.Translate('EDIT_INFO_BPM_INCREASED_BY') + ' 0.05';
   end;
   if SDL_ModState = KMOD_LSHIFT then
   begin
-    CurrentSong.BPM[0].BPM := CurrentSong.BPM[0].BPM + 4; // (1/1)
+    CurrentSong.BPM := CurrentSong.BPM + 4; // (1/1)
     Text[TextInfo].Text := Language.Translate('EDIT_INFO_BPM_INCREASED_BY') + ' 1.0';
   end;
   if SDL_ModState = KMOD_LCTRL then
   begin
-    CurrentSong.BPM[0].BPM := Round((CurrentSong.BPM[0].BPM * 25) + 1) / 25; // (1/100)
+    CurrentSong.BPM := Round((CurrentSong.BPM * 25) + 1) / 25; // (1/100)
     Text[TextInfo].Text := Language.Translate('EDIT_INFO_BPM_INCREASED_BY') + ' 0.01';
   end;
 end;
@@ -1346,17 +1346,17 @@ begin
   CopyToUndo;
   if SDL_ModState = 0 then
   begin
-    CurrentSong.BPM[0].BPM := Round((CurrentSong.BPM[0].BPM * 5) - 1) / 5;
+    CurrentSong.BPM := Round((CurrentSong.BPM * 5) - 1) / 5;
     Text[TextInfo].Text := Language.Translate('EDIT_INFO_BPM_DECREASED_BY') + ' 0.05';
   end;
   if SDL_ModState = KMOD_LSHIFT then
   begin
-    CurrentSong.BPM[0].BPM := CurrentSong.BPM[0].BPM - 4;
+    CurrentSong.BPM := CurrentSong.BPM - 4;
     Text[TextInfo].Text := Language.Translate('EDIT_INFO_BPM_DECREASED_BY') + ' 1.0';
   end;
   if SDL_ModState = KMOD_LCTRL then
   begin
-    CurrentSong.BPM[0].BPM := Round((CurrentSong.BPM[0].BPM * 25) - 1) / 25;
+    CurrentSong.BPM := Round((CurrentSong.BPM * 25) - 1) / 25;
     Text[TextInfo].Text := Language.Translate('EDIT_INFO_BPM_DECREASED_BY') + ' 0.01';
   end;
 end;
@@ -1593,7 +1593,7 @@ end;
 procedure TScreenEditSub.EnterBPMEditMode(SDL_ModState: word);
 begin
   // Enter BPM Edit Mode
-  BackupEditText := FloatToStr(CurrentSong.BPM[0].BPM / 4);
+  BackupEditText := FloatToStr(CurrentSong.BPM / 4);
   CurrentEditText := BackupEditText;
   CurrentSlideId := BPMSlideId;
   TextPosition := LengthUTF8(BackupEditText);
@@ -1744,7 +1744,7 @@ begin
 
     if Interaction = BPMSlideId then
     begin
-      BackupEditText := FloatToStr(CurrentSong.BPM[0].BPM / 4);
+      BackupEditText := FloatToStr(CurrentSong.BPM / 4);
       CurrentEditText := ifthen(BackupEditText <> NOT_SET, BackupEditText, '');
       editLengthText := LengthUTF8(BackupEditText);
       CurrentSlideId := BPMSlideId;
@@ -2644,7 +2644,7 @@ begin
       SDLK_ESCAPE:
         begin
           // exit BPM edit mode, restore previous BPM value
-          SelectsS[CurrentSlideId].TextOpt[0].Text := FloatToStr(CurrentSong.BPM[0].BPM / 4);
+          SelectsS[CurrentSlideId].TextOpt[0].Text := FloatToStr(CurrentSong.BPM / 4);
           BPMEditMode := false;
           StopTextInput;
           editLengthText := 0;
@@ -2665,7 +2665,6 @@ begin
           end
           else
           begin
-            CurrentSong.BPM[0].BPM := 0;
             SelectsS[CurrentSlideId].TextOpt[0].Text := BackupEditText;
           end;
 
@@ -3158,8 +3157,14 @@ var
   factor:     real;
 
 begin
-  factor := newBPM / CurrentSong.BPM[0].BPM;    // e.g. new/old => 1/2 = 0.5 => * 0.5
-  CurrentSong.BPM[0].BPM := newBPM;
+  if CurrentSong.BPM <= 0 then
+    CurrentSong.BPM := USong.MIN_BPM;
+
+  if newBPM <= 0 then
+    newBPM := USong.MIN_BPM;
+
+  factor := newBPM / CurrentSong.BPM;    // e.g. new/old => 1/2 = 0.5 => * 0.5
+  CurrentSong.BPM := newBPM;
 
   for TrackIndex := 0 to High(CurrentSong.Tracks) do
   begin
@@ -3185,12 +3190,12 @@ end;
 
 procedure TScreenEditSub.DivideBPM;
 begin
-  ChangeBPM(CurrentSong.BPM[0].BPM / 2);
+  ChangeBPM(CurrentSong.BPM / 2);
 end;
 
 procedure TScreenEditSub.MultiplyBPM;
 begin
-  ChangeBPM(CurrentSong.BPM[0].BPM * 2);
+  ChangeBPM(CurrentSong.BPM * 2);
 end;
 
 procedure TScreenEditSub.LyricsCapitalize;
@@ -3297,7 +3302,7 @@ begin
       end;
 
     // adjust GAP accordingly, round to nearest integer value (fractional GAPs make no sense)
-    CurrentSong.GAP := round((CurrentSong.GAP + (FirstBeat * 15000) / (CurrentSong.BPM[0].BPM / 4)));
+    CurrentSong.GAP := round((CurrentSong.GAP + (FirstBeat * 15000) / (CurrentSong.BPM / 4)));
 
     // adjust medley tags accordingly
     if (MedleyNotes.isStart) then
@@ -3321,9 +3326,9 @@ begin
         GapSeconds := GetTimeFromBeat(FirstBeat) - GetTimeFromBeat(EndBeat);
 
         if GapSeconds >= 4.0 then
-          LineStart := EndBeat + Trunc(2.0 * CurrentSong.BPM[0].BPM / 60.0)
+          LineStart := EndBeat + Trunc(2.0 * CurrentSong.BPM / 60.0)
         else if GapSeconds >= 2.0 then
-          LineStart := EndBeat + Trunc(1.0 * CurrentSong.BPM[0].BPM / 60.0)
+          LineStart := EndBeat + Trunc(1.0 * CurrentSong.BPM / 60.0)
         else if (GapBeats >= 0) and (GapBeats <= 1) then
           LineStart := EndBeat
         else if (GapBeats >= 2) and (GapBeats <= 8) then
@@ -4113,7 +4118,6 @@ end;
 
 procedure TScreenEditSub.CopyToUndo;
 var
-  BPMIndex:   Integer;
   TrackIndex: Integer;
   LineIndex:  Integer;
   NoteIndex:  Integer;
@@ -4139,12 +4143,7 @@ begin
   UndoHeader[CurrentUndoLines].Video := CurrentSong.Video;
   UndoHeader[CurrentUndoLines].VideoId := SelectsS[VideoSlideId].SelectedOption;
   UndoHeader[CurrentUndoLines].VideoGAP := CurrentSong.VideoGAP;
-  SetLength(UndoHeader[CurrentUndoLines].BPM, length(CurrentSong.BPM));
-  for BPMIndex := 0 to High(CurrentSong.BPM) do
-  begin
-    UndoHeader[CurrentUndoLines].BPM[BPMIndex].BPM := CurrentSong.BPM[BPMIndex].BPM;
-    UndoHeader[CurrentUndoLines].BPM[BPMIndex].StartBeat := CurrentSong.BPM[BPMIndex].StartBeat;
-  end;
+  UndoHeader[CurrentUndoLines].BPM := CurrentSong.BPM;
   UndoHeader[CurrentUndoLines].GAP  := CurrentSong.GAP;
   UndoHeader[CurrentUndoLines].StartTag := CurrentSong.Start;
   UndoHeader[CurrentUndoLines].EndTag := CurrentSong.Finish;
@@ -4271,7 +4270,6 @@ end;
 
 procedure TScreenEditSub.CopyFromUndo;
 var
-  BPMIndex:   Integer;
   TrackIndex: Integer;
   LineIndex:  Integer;
   NoteIndex:  Integer;
@@ -4297,12 +4295,7 @@ begin
   CurrentSong.Video        := Undoheader[CurrentUndoLines].Video;
   SelectsS[VideoSlideId].SelectedOption := Undoheader[CurrentUndoLines].VideoId;
   CurrentSong.VideoGAP     := Undoheader[CurrentUndoLines].VideoGAP;
-  SetLength(CurrentSong.BPM, length(Undoheader[CurrentUndoLines].BPM));
-  for BPMIndex := 0 to High(Undoheader[CurrentUndoLines].BPM) do
-  begin
-    CurrentSong.BPM[BPMIndex].BPM := Undoheader[CurrentUndoLines].BPM[BPMIndex].BPM;
-    CurrentSong.BPM[BPMIndex].StartBeat := Undoheader[CurrentUndoLines].BPM[BPMIndex].StartBeat;
-  end;
+  CurrentSong.BPM := Undoheader[CurrentUndoLines].BPM;
   CurrentSong.GAP          := Undoheader[CurrentUndoLines].GAP;
   CurrentSong.Start        := Undoheader[CurrentUndoLines].StartTag;
   CurrentSong.Finish       := Undoheader[CurrentUndoLines].EndTag;
@@ -5649,7 +5642,7 @@ begin
     // click
     if (Click) and (PlaySentence) then
     begin
-      //CurrentBeat := Floor(CurrentSong.BPM[0].BPM * (Music.Position - CurrentSong.GAP / 1000) / 60);
+      //CurrentBeat := Floor(CurrentSong.BPM * (Music.Position - CurrentSong.GAP / 1000) / 60);
       CurrentBeat := Floor(GetMidBeat(AudioPlayback.Position - CurrentSong.GAP / 1000));
       Text[TextInfo].Text := Language.Translate('EDIT_INFO_CURRENT_BEAT') + ' ' + IntToStr(CurrentBeat);
       if CurrentBeat <> LastClick then
@@ -5714,7 +5707,7 @@ begin
   // BPM
   if not BPMEditMode then
   begin
-    BPMVal[0] := FloatToStr(CurrentSong.BPM[0].BPM / 4);
+    BPMVal[0] := FloatToStr(CurrentSong.BPM / 4);
     SelectsS[BPMSlideId].TextOpt[0].Text := BPMVal[0];
   end;
   // GAP

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -468,6 +468,7 @@ uses
 const
   DEFAULT_FADE_IN_TIME  = 8;    //TODO in INI
   DEFAULT_FADE_OUT_TIME = 2;
+  MIN_EDITOR_BPM = 1.0;
   NOT_SET = '-';
   NotesSkipX:  Integer = 20;
   LineSpacing: Integer = 15;
@@ -1359,6 +1360,9 @@ begin
     CurrentSong.BPM := Round((CurrentSong.BPM * 25) - 1) / 25;
     Text[TextInfo].Text := Language.Translate('EDIT_INFO_BPM_DECREASED_BY') + ' 0.01';
   end;
+
+  if CurrentSong.BPM <= 0 then
+    CurrentSong.BPM := MIN_EDITOR_BPM;
 end;
 
       // SDLK_2, SDLK_3, SDLK_4, SDLK_5, SDLK_6: HandleExtendedCopyPaste;
@@ -2620,6 +2624,7 @@ function TScreenEditSub.ParseInputEditBPM(PressedKey: cardinal; CharCode: UCS4Ch
 var
   SDL_ModState:  word;
   qBPM:          real;
+  NewBPM:        real;
 begin
   // used when in Text Edit Mode
   Result := true;
@@ -2656,9 +2661,13 @@ begin
           //CopyToUndo;
           if (TryStrToFloat(UTF8Copy(CurrentEditText, 1, TextPosition) + UTF8Copy(CurrentEditText, TextPosition+1, LengthUTF8(CurrentEditText)-TextPosition), qBPM)) then
           begin
-            BPMVal[0] := FloatToStr(qBPM * 4);
-            ChangeBPM(qBPM * 4);
-            SelectsS[CurrentSlideId].TextOpt[0].Text := CurrentEditText;
+            NewBPM := qBPM * 4;
+            if NewBPM <= 0 then
+              NewBPM := MIN_EDITOR_BPM;
+
+            BPMVal[0] := FloatToStr(NewBPM / 4);
+            ChangeBPM(NewBPM);
+            SelectsS[CurrentSlideId].TextOpt[0].Text := BPMVal[0];
             UpdateSelectSlideOptions(BPMSlideId,BPMVal,SlideBPMIndex);
             SelectsS[BPMSlideId].TextOpt[0].Align := 0;
             SelectsS[BPMSlideId].TextOpt[0].X := SelectsS[BPMSlideId].TextureSBG.X + 5;
@@ -3158,10 +3167,10 @@ var
 
 begin
   if CurrentSong.BPM <= 0 then
-    CurrentSong.BPM := USong.MIN_BPM;
+    CurrentSong.BPM := MIN_EDITOR_BPM;
 
   if newBPM <= 0 then
-    newBPM := USong.MIN_BPM;
+    newBPM := MIN_EDITOR_BPM;
 
   factor := newBPM / CurrentSong.BPM;    // e.g. new/old => 1/2 = 0.5 => * 0.5
   CurrentSong.BPM := newBPM;

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -468,7 +468,6 @@ uses
 const
   DEFAULT_FADE_IN_TIME  = 8;    //TODO in INI
   DEFAULT_FADE_OUT_TIME = 2;
-  MIN_EDITOR_BPM = 1.0;
   NOT_SET = '-';
   NotesSkipX:  Integer = 20;
   LineSpacing: Integer = 15;
@@ -1361,8 +1360,8 @@ begin
     Text[TextInfo].Text := Language.Translate('EDIT_INFO_BPM_DECREASED_BY') + ' 0.01';
   end;
 
-  if CurrentSong.BPM <= 0 then
-    CurrentSong.BPM := MIN_EDITOR_BPM;
+  if CurrentSong.BPM < MIN_BPM then
+    CurrentSong.BPM := MIN_BPM;
 end;
 
       // SDLK_2, SDLK_3, SDLK_4, SDLK_5, SDLK_6: HandleExtendedCopyPaste;
@@ -2662,8 +2661,8 @@ begin
           if (TryStrToFloat(UTF8Copy(CurrentEditText, 1, TextPosition) + UTF8Copy(CurrentEditText, TextPosition+1, LengthUTF8(CurrentEditText)-TextPosition), qBPM)) then
           begin
             NewBPM := qBPM * 4;
-            if NewBPM <= 0 then
-              NewBPM := MIN_EDITOR_BPM;
+            if NewBPM < MIN_BPM then
+              NewBPM := MIN_BPM;
 
             BPMVal[0] := FloatToStr(NewBPM / 4);
             ChangeBPM(NewBPM);
@@ -3166,11 +3165,11 @@ var
   factor:     real;
 
 begin
-  if CurrentSong.BPM <= 0 then
-    CurrentSong.BPM := MIN_EDITOR_BPM;
+  if CurrentSong.BPM < MIN_BPM then
+    CurrentSong.BPM := MIN_BPM;
 
-  if newBPM <= 0 then
-    newBPM := MIN_EDITOR_BPM;
+  if newBPM < MIN_BPM then
+    newBPM := MIN_BPM;
 
   factor := newBPM / CurrentSong.BPM;    // e.g. new/old => 1/2 = 0.5 => * 0.5
   CurrentSong.BPM := newBPM;

--- a/src/screens/UScreenJukebox.pas
+++ b/src/screens/UScreenJukebox.pas
@@ -2670,7 +2670,7 @@ begin
   LyricsState.UpdateBeats();
 
   // main text
-  Lyrics.Clear(CurrentSong.BPM[0].BPM, CurrentSong.Resolution);
+  Lyrics.Clear(CurrentSong.BPM, CurrentSong.Resolution);
 
   // initialize lyrics by filling its queue
   while (not Lyrics.IsQueueFull) and

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -1106,7 +1106,7 @@ begin
       Text[screenSingViewRef.SongNameText].Text := CurrentSong.Artist + ' - ' + CurrentSong.Title;
 
     //medley start and end timestamps
-    StartNote := FindNote(CurrentSong.Medley.StartBeat - round(CurrentSong.BPM[0].BPM*CurrentSong.Medley.FadeIn_time/60));
+    StartNote := FindNote(CurrentSong.Medley.StartBeat - round(CurrentSong.BPM*CurrentSong.Medley.FadeIn_time/60));
     MedleyStart := GetTimeFromBeat(CurrentSong.Tracks[0].Lines[StartNote.line].Notes[0].StartBeat);
 
     //check Medley-Start
@@ -1307,9 +1307,9 @@ end;
 
 procedure TScreenSingController.ClearLyricEngines();
 begin
-    Lyrics.Clear(CurrentSong.BPM[0].BPM, CurrentSong.Resolution);
-    LyricsDuetP1.Clear(CurrentSong.BPM[0].BPM, CurrentSong.Resolution);
-    LyricsDuetP2.Clear(CurrentSong.BPM[0].BPM, CurrentSong.Resolution);
+  Lyrics.Clear(CurrentSong.BPM, CurrentSong.Resolution);
+  LyricsDuetP1.Clear(CurrentSong.BPM, CurrentSong.Resolution);
+  LyricsDuetP2.Clear(CurrentSong.BPM, CurrentSong.Resolution);
 end;
 
 procedure TScreenSingController.ClearSettings;

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -1295,16 +1295,16 @@ begin
   //calculate total singing beats of song
   if ScreenSong.Mode = smMedley then
   begin
-    SongStart := ScreenSing.MedleyStart * CurrentSong.BPM[0].BPM / 60;
-    SongEnd := ScreenSing.MedleyEnd * CurrentSong.BPM[0].BPM / 60;
+    SongStart := ScreenSing.MedleyStart * CurrentSong.BPM / 60;
+    SongEnd := ScreenSing.MedleyEnd * CurrentSong.BPM / 60;
   end
   else
   begin
-    SongStart := CurrentSong.BPM[0].BPM*CurrentSong.Start/60;
-    SongEnd := CurrentSong.BPM[0].BPM*TotalTime/60;
+    SongStart := CurrentSong.BPM*CurrentSong.Start/60;
+    SongEnd := CurrentSong.BPM*TotalTime/60;
   end;
   SongDuration := SongEnd - SongStart;
-  gapInBeats := CurrentSong.BPM[0].BPM*CurrentSong.GAP/1000/60;
+  gapInBeats := CurrentSong.BPM*CurrentSong.GAP/1000/60;
   // draw sentence boxes
   for CurrentTrack := 0 to High(CurrentSong.Tracks) do //for P1 of duet or solo lyrics, P2 of duet,..
   begin


### PR DESCRIPTION
Historically, the BPM was represented as a multi-entry array with optional per-beat changes, but the engine effectively only used the first entry. This cleans that up by collapsing BPM to a single value, removing the unused variable-BPM scaffolding, and clamping invalid BPM values to a safe minimum to avoid divide-by-zero behavior.

as proposed by @barbeque-squared in #686 