### PR TITLE
link release page

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,7 +17,7 @@
     If any of them fail, retry the job.
 6. Add `+dev` to the version in the first two files and swap the comments in `variables.nsh` again, commit, push.
     This is just to set the dev version again.
-7. Attach the artifacts to the release page and publish it.\
+7. Attach the artifacts to the [release page](https://github.com/UltraStar-Deluxe/USDX/releases) and publish it.\
     You need to extract all the zips _except_ the portable: `for i in UltraStarDeluxe-*{linux,mac,installer}*; do unzip $i; rm $i; done`
 8. Create a PR in [the FlatHub repository](https://github.com/flathub/eu.usdx.UltraStarDeluxe) that updates the tag and commit values.
     See this PR for an example: https://github.com/flathub/eu.usdx.UltraStarDeluxe/pull/7/files


### PR DESCRIPTION
This just adds a link in RELEASING.md because at some point during the release process I always find myself doing:
* Open `Code` in a new tab
* Go to releases
* Draft new release

With this PR that becomes:
* Ctrl-Click to open the releases in a new tab
* Draft new release

Yes, earlier in the process I also need the Code tab (to get at the artifacts) but that is all at least at the top of the page (also earlier in the process, and with like 4-5 release-related tabs open already, I don't want to keep it open until I need it). Releases are somewhere towards the right and hunting for it does take you out of the flow a little bit.