### PR TITLE
Count In for Songs With Low #GAP Values

### DIFF
--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -239,6 +239,8 @@ type
       function GetLength(): real;           virtual; abstract;
       function GetPosition(): real;         virtual; abstract;
       procedure SetPosition(Time: real);    virtual; abstract;
+      function GetStartTime(): real;         virtual; abstract;
+      procedure SetStartTime(Time: real);    virtual; abstract;
       function GetLoop(): boolean;          virtual; abstract;
       procedure SetLoop(Enabled: boolean);  virtual; abstract;
 
@@ -258,6 +260,7 @@ type
 
       property Length: real read GetLength;
       property Position: real read GetPosition write SetPosition;
+      property StartTime: real read GetStartTime write SetStartTime;
       property Loop: boolean read GetLoop write SetLoop;
   end;
 
@@ -268,6 +271,8 @@ type
     protected
       function IsEOF(): boolean;            virtual; abstract;
       function IsError(): boolean;          virtual; abstract;
+      function GetStartTime(): real; override;
+      procedure SetStartTime(Time: real); override;
       procedure SetReplayGain(const GainTag: AnsiString; const PeakTag: AnsiString);
       procedure SetReplayGainR128(const R128Tag: AnsiString);
     public
@@ -304,6 +309,8 @@ type
       function GetStatus(): TStreamStatus;  virtual; abstract;
       function GetVolume(): single;         virtual; abstract;
       procedure SetVolume(Volume: single);  virtual; abstract;
+      function GetStartTime(): real; override;
+      procedure SetStartTime(Time: real); override;
       function Synchronize(BufferSize: integer; FormatInfo: TAudioFormatInfo): integer;
       procedure FillBufferWithFrame(Buffer: PByteArray; BufferSize: integer; Frame: PByteArray; FrameSize: integer);
     public
@@ -481,7 +488,12 @@ type
       procedure SetPosition(Time: real);
       function GetPosition: real;
 
+      procedure SetStartTime(Time: real);
+      function GetStartTime: real;
+
       property Position: real read GetPosition write SetPosition;
+      property StartTime: real read GetStartTime write SetStartTime;
+
 
       // Sounds
       // TODO:
@@ -1151,6 +1163,15 @@ begin
   Result := RG;
 end;
 
+function TAudioSourceStream.GetStartTime(): real;
+begin
+  Result := 0;
+end;
+
+procedure TAudioSourceStream.SetStartTime();
+begin
+end;
+
 { TAudioPlaybackStream }
 
 constructor TAudioPlaybackStream.Create();
@@ -1312,6 +1333,20 @@ end;
 procedure TAudioPlaybackStream.SetReplayGainEnabled(RGEnabled: boolean);
 begin
   self.RGEnabled := RGEnabled;
+end;
+
+function TAudioPlaybackStream.GetStartTime(): real;
+begin
+  if (assigned(SourceStream)) then
+    Result := SourceStream.StartTime
+  else
+    Result := 0;
+end;
+
+procedure TAudioPlaybackStream.SetStartTime(Time: real);
+begin
+  if (assigned(SourceStream)) then
+    SourceStream.StartTime := Time;
 end;
 
 { TAudioVoiceStream }

--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -331,7 +331,10 @@ begin
 
   fAudioStream := PPAVStream(PtrUInt(fFormatCtx.streams) + fAudioStreamIndex * Sizeof(pointer))^;
   fAudioStreamPos := 0;
-  fStartTime := fAudioStream^.start_time;
+  if (fAudioStream^.start_time <> AV_NOPTS_VALUE) then
+    fStartTime := fAudioStream^.start_time
+  else
+    fStartTime := 0;
 
 {$IF LIBAVFORMAT_VERSION < 59000000}
   CodecID := fAudioStream^.codec^.codec_id;

--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -101,6 +101,7 @@ type
       fSeekPos:     double;    // stream position to seek for (in secs) (locked by StateLock)
       fSeekFlush:   boolean;   // true if the buffers should be flushed after seeking (locked by StateLock)
       SeekFinishedCond: PSDL_Cond;
+      fStartTime:   int64; // start time in PTS
 
       fLoop: boolean; // (locked by StateLock)
 
@@ -173,6 +174,8 @@ type
       function GetAudioFormatInfo(): TAudioFormatInfo; override;
       function GetPosition: real;            override;
       procedure SetPosition(Time: real);     override;
+      function GetStartTime: real;           override;
+      procedure SetStartTime(Time: real);    override;
       function GetLoop(): boolean;           override;
       procedure SetLoop(Enabled: boolean);   override;
       function IsEOF(): boolean;             override;
@@ -231,6 +234,7 @@ begin
   fErrorState := false;
   fLoop := false;
   fQuitRequest := false;
+  fStartTime := 0;
 
   fAudioPaketSize := 0;
   fAudioPaketSilence := 0;
@@ -327,6 +331,7 @@ begin
 
   fAudioStream := PPAVStream(PtrUInt(fFormatCtx.streams) + fAudioStreamIndex * Sizeof(pointer))^;
   fAudioStreamPos := 0;
+  fStartTime := fAudioStream^.start_time;
 
 {$IF LIBAVFORMAT_VERSION < 59000000}
   CodecID := fAudioStream^.codec^.codec_id;
@@ -613,6 +618,24 @@ begin
   SDL_UnlockMutex(fStateLock);
 end;
 
+function TFFmpegDecodeStream.GetStartTime: real;
+begin
+  SDL_LockMutex(fStateLock);
+  if (fAudioStream <> nil) then
+    Result := fStartTime * av_q2d(fAudioStream^.time_base)
+  else
+    Result := 0;
+  SDL_UnlockMutex(fStateLock);
+end;
+
+procedure TFFMpegDecodeStream.SetStartTime(Time: real);
+begin
+  SDL_LockMutex(fStateLock);
+  if (fAudioStream <> nil) then
+    fStartTime := Max(fAudioStream^.start_time, Round(Time / av_q2d(fAudioStream^.time_base)));
+  SDL_UnlockMutex(fStateLock);
+end;
+
 function TFFmpegDecodeStream.GetLoopInternal(): boolean;
 begin
   Result := fLoop;
@@ -811,8 +834,11 @@ begin
         // first try: seek on the audio stream
         SeekTarget := Round(fSeekPos / av_q2d(fAudioStream^.time_base));
         StartSilence := 0;
-        if (SeekTarget < fAudioStream^.start_time) then
-          StartSilence := (fAudioStream^.start_time - SeekTarget) * av_q2d(fAudioStream^.time_base);
+        if (SeekTarget < fStartTime) then
+        begin
+          StartSilence := (fStartTime - SeekTarget) * av_q2d(fAudioStream^.time_base);
+          SeekTarget := fStartTime;
+        end;
         ErrorCode := av_seek_frame(fFormatCtx, fAudioStreamIndex, SeekTarget, fSeekFlags);
 
         if (ErrorCode < 0) then
@@ -820,8 +846,11 @@ begin
           // second try: seek on the default stream (necessary for flv-videos and some ogg-files)
           SeekTarget := Round(fSeekPos * AV_TIME_BASE);
           StartSilence := 0;
-          if (SeekTarget < fFormatCtx^.start_time) then
-            StartSilence := (fFormatCtx^.start_time - SeekTarget) / AV_TIME_BASE;
+          if (SeekTarget < fStartTime) then
+          begin
+            StartSilence := (fStartTime - SeekTarget) / AV_TIME_BASE;
+            SeekTarget := fStartTime;
+          end;
           ErrorCode := av_seek_frame(fFormatCtx, -1, SeekTarget, fSeekFlags);
         end;
 

--- a/src/media/UAudioPlaybackBase.pas
+++ b/src/media/UAudioPlaybackBase.pas
@@ -79,6 +79,8 @@ type
 
       procedure SetPosition(Time: real);
       function  GetPosition: real;
+      procedure SetStartTime(Time: real);
+      function GetStartTime: real;
 
       function InitializePlayback: boolean; virtual; abstract;
       function FinalizePlayback: boolean; virtual;
@@ -324,11 +326,7 @@ end;
 function TAudioPlaybackBase.GetPosition: real;
 begin
   if assigned(MusicStream) then
-  begin
-    Result := MusicStream.Position - Ini.AVDelay / 1000;
-    if Result < 0 then
-      Result := 0;
-  end
+    Result := MusicStream.Position - Ini.AVDelay / 1000
   else
     Result := 0;
 end;
@@ -339,6 +337,22 @@ begin
     MusicStream.Position := Time;
   if assigned(KaraokeMusicStream) then
     KaraokeMusicStream.Position := Time;
+end;
+
+function TAudioPlaybackBase.GetStartTime: real;
+begin
+  if assigned(MusicStream) then
+    Result := MusicStream.StartTime
+  else
+    Result := 0;
+end;
+
+procedure TAudioPlaybackBase.SetStartTime(Time: real);
+begin
+  if assigned(MusicStream) then
+    MusicStream.StartTime := Time;
+  if assigned(KaraokeMusicStream) then
+    KaraokeMusicStream.StartTime := Time;
 end;
 
 procedure TAudioPlaybackBase.SetSyncSource(SyncSource: TSyncSource);

--- a/src/media/UMedia_dummy.pas
+++ b/src/media/UMedia_dummy.pas
@@ -65,6 +65,8 @@ type
 
       procedure SetPosition(Time: real);
       function  GetPosition: real;
+      procedure SetStartTime(Time: real);
+      function  GetStartTime: real;
 
       procedure SetSyncSource(SyncSource: TSyncSource);
 
@@ -224,6 +226,15 @@ begin
 end;
 
 function  TAudio_Dummy.GetPosition: real;
+begin
+  Result := 0;
+end;
+
+procedure TAudio_Dummy.SetStartTime(Time: real);
+begin
+end;
+
+function  TAudio_Dummy.GetStartTime: real;
 begin
   Result := 0;
 end;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -75,11 +75,14 @@ type
   TScreenSingController = class(TMenu)
   private
     StartNote, EndNote:     TPos;
+    fCountIn: boolean;
+    fStartTime, fFirstNote: real;
 
     procedure LoadNextSong();
     procedure SongError();
     procedure ResetLinesAndLyrics();
     procedure ClearLyricEngines();
+    procedure CalculateStartTime;
   public
     CheckPlayerConfigOnNextSong: boolean;
     eSongLoaded: THookableEvent; //< event is called after lyrics of a song are loaded on OnShow
@@ -185,6 +188,8 @@ type
     procedure UpdateMedleyStats(medley_end: boolean);
     procedure OnSentenceEnd(Track: integer; SentenceIndex: cardinal);     // for linebonus + singbar
     procedure OnSentenceChange(Track: integer; SentenceIndex: cardinal);  // for golden notes
+    property CountIn: boolean read fCountIn write fCountIn;
+    property FirstNote: real read fFirstNote;
   end;
 
 var screenSingViewRef: TScreenSingView;
@@ -217,6 +222,7 @@ uses
 
 const
   MAX_MESSAGE = 3;
+  MINIMUM_START_TIME = 3;
 
 // method for input parsing. if false is returned, getnextwindow
 // should be checked to know the next window to load;
@@ -271,7 +277,9 @@ begin
 
           LastSentencePerfect := false;
         end;
-        AudioPlayback.SetPosition(CurrentSong.Start);
+        AudioPlayback.SetPosition(fStartTime);
+        if (fStartTime < CurrentSong.Start) then
+          fCountIn := true;
         if (Assigned(fCurrentVideo)) then
            fCurrentVideo.Position := CurrentSong.VideoGAP + CurrentSong.Start;// + (CurrentSong.gap / 1000.0 - 5.0);
         Scores.KillAllPopUps;
@@ -287,7 +295,7 @@ begin
           Scores.AddPlayer(Tex_ScoreBG[i1], Color);
         end;
 
-        LyricsState.SetCurrentTime(CurrentSong.Start);
+        LyricsState.SetCurrentTime(fStartTime);
         LyricsState.UpdateBeats();
         ClearLyricEngines;
         ResetLinesAndLyrics;
@@ -899,6 +907,8 @@ begin
   else
     AudioPlayback.SetVolume(1.0);
   //AudioPlayback.Position := CurrentSong.Start;
+    if ((fStartTime < CurrentSong.Start) and (fStartTime > 0)) then
+      AudioPlayback.StartTime := CurrentSong.Start;
   AudioPlayback.Position := LyricsState.GetCurrentTime();
 
 
@@ -1093,6 +1103,17 @@ begin
     Exit;
   end;
 
+  CalculateStartTime;
+  if (fStartTime < CurrentSong.Start) then
+  begin
+    fCountIn := true;
+    AudioPlayback.Position := fStartTime;
+    if (fStartTime > 0) then
+      AudioPlayback.StartTime := CurrentSong.Start;
+  end
+  else
+    fCountIn := false;
+
   // Set up Medley timings
   if ScreenSong.Mode = smMedley then
   begin
@@ -1217,7 +1238,7 @@ begin
   end
   else
   begin
-    LyricsState.SetCurrentTime(CurrentSong.Start);
+    LyricsState.SetCurrentTime(fStartTime);
     LyricsState.StartTime := CurrentSong.Gap;
     if CurrentSong.Finish > 0 then
       LyricsState.TotalTime := CurrentSong.Finish / 1000
@@ -1310,6 +1331,20 @@ begin
   Lyrics.Clear(CurrentSong.BPM);
   LyricsDuetP1.Clear(CurrentSong.BPM);
   LyricsDuetP2.Clear(CurrentSong.BPM);
+end;
+
+procedure TScreenSingController.CalculateStartTime;
+var
+  I, StartBeat: integer;
+begin
+  StartBeat := MaxInt;
+  for I := Low(CurrentSong.Tracks) to High(CurrentSong.Tracks) do
+    StartBeat := Min(StartBeat, CurrentSong.Tracks[I].Lines[0].Notes[0].StartBeat);
+  fFirstNote := CurrentSong.GAP / 1000 + StartBeat * (CurrentSong.BPM / 60);
+  if ((fFirstNote - CurrentSong.Start) < MINIMUM_START_TIME) then
+    fStartTime := fFirstNote - MINIMUM_START_TIME
+  else
+    fStartTime := CurrentSong.Start;
 end;
 
 procedure TScreenSingController.ClearSettings;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -1340,7 +1340,7 @@ begin
   StartBeat := MaxInt;
   for I := Low(CurrentSong.Tracks) to High(CurrentSong.Tracks) do
     StartBeat := Min(StartBeat, CurrentSong.Tracks[I].Lines[0].Notes[0].StartBeat);
-  fFirstNote := CurrentSong.GAP / 1000 + StartBeat * (CurrentSong.BPM / 60);
+  fFirstNote := (CurrentSong.GAP / 1000) + ((StartBeat * 60) / CurrentSong.BPM);
   if ((fFirstNote - CurrentSong.Start) < MINIMUM_START_TIME) then
     fStartTime := fFirstNote - MINIMUM_START_TIME
   else

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -196,6 +196,8 @@ type
     destructor Destroy; override;
 
     procedure DrawMedleyCountdown();
+    procedure DrawCountIn();
+    procedure DrawCountdown(timeDiff: real);
     function Draw: boolean;
 
     procedure SwapToScreen(Screen: integer);
@@ -891,7 +893,7 @@ begin
   // retrieve time for timebar text
   case (ScreenSing.fTimebarMode) of
     tbmRemaining: begin
-      DisplayTime := TotalTime - CurLyricsTime;
+      DisplayTime := TotalTime - Max(CurLyricsTime, CurrentSong.Start);
       DisplayPrefix := '-';
     end;
     tbmTotal: begin
@@ -899,7 +901,7 @@ begin
       DisplayPrefix := '#';
     end;
     else begin       // current time
-      DisplayTime := CurLyricsTime;
+      DisplayTime := Max(CurLyricsTime, CurrentSong.Start);
       DisplayPrefix := '';
     end;
   end;
@@ -969,13 +971,13 @@ begin
       if (ScreenSing.ShowFinish) then
       begin
         // everything is setup, determine the current position
-        VideoFrameTime := CurrentSong.VideoGAP + LyricsState.GetCurrentTime();
+        VideoFrameTime := CurrentSong.VideoGAP + Max(LyricsState.GetCurrentTime(), CurrentSong.Start);
       end
       else
       begin
         // Important: do not yet start the triggered timer by a call to
         // LyricsState.GetCurrentTime()
-        VideoFrameTime := CurrentSong.VideoGAP;
+        VideoFrameTime := CurrentSong.VideoGAP + CurrentSong.Start;
       end;
       try
         ScreenSing.fCurrentVideo.GetFrame(VideoFrameTime);
@@ -993,6 +995,8 @@ begin
   //Medley Countdown
   if ScreenSong.Mode = smMedley then
     DrawMedleyCountdown;
+  if ScreenSing.CountIn then
+    DrawCountIn;
 
   // check for music finish
   //Log.LogError('Check for music finish: ' + BoolToStr(Music.Finished) + ' ' + FloatToStr(LyricsState.CurrentTime*1000) + ' ' + IntToStr(CurrentSong.Finish));
@@ -1059,11 +1063,6 @@ begin
 end;
 
 procedure TScreenSingView.DrawMedleyCountdown();
-var
-  w, h:           real;
-  timeDiff:       real;
-  t:              real;
-  CountDownText:  UTF8String;
 begin
   if AudioPlayback.Position < GetTimeFromBeat(CurrentSong.Medley.StartBeat) then
   begin
@@ -1074,22 +1073,7 @@ begin
 
     ScreenSing.Statics[SongNameStatic].Visible := true;
     ScreenSing.Text[SongNameText].Visible := true;
-
-    timeDiff := GetTimeFromBeat(CurrentSong.Medley.StartBeat) - AudioPlayback.Position + 1;
-    t := frac(timeDiff);
-
-    glColor4f(0.15, 0.30, 0.6, t);
-
-    h := 300*t*ScreenH/RenderH;
-    SetFontFamily(0);
-    SetFontStyle(ftBoldHighRes);
-    SetFontItalic(false);
-    SetFontSize(h);
-    CountDownText := IntToStr(round(timeDiff-t));
-    w := glTextWidth(PChar(CountDownText));
-
-    SetFontPos (RenderW/2-w/2, RenderH/2-h/2);
-    glPrint(PChar(CountDownText));
+    DrawCountdown(GetTimeFromBeat(CurrentSong.Medley.StartBeat) - AudioPlayback.Position);
   end else
   begin
     if (ScreenSing.TextMedleyFadeOut = false) then
@@ -1100,6 +1084,41 @@ begin
 
     MedleyTitleFadeOut;
   end;
+end;
+
+procedure TScreenSingView.DrawCountIn;
+var
+  Pos: real;
+begin
+  Pos := AudioPlayback.Position;
+  if (Pos > ScreenSing.FirstNote) then
+    ScreenSing.CountIn := false
+  else
+    DrawCountdown(ScreenSing.FirstNote - Pos);
+
+end;
+
+procedure TScreenSingView.DrawCountdown(timeDiff: real);
+var
+  t: real;
+  w, h: real;
+  CountDownText:  UTF8String;
+begin
+  t := frac(timeDiff);
+
+  glColor4f(0.15, 0.30, 0.6, t);
+
+  h := 300*t*ScreenH/RenderH;
+  SetFontFamily(0);
+  SetFontStyle(ftBoldHighRes);
+  SetFontItalic(false);
+  SetFontSize(h);
+  CountDownText := IntToStr(round(timeDiff - t + 1));
+  w := glTextWidth(PChar(CountDownText));
+
+  SetFontPos (RenderW/2-w/2, RenderH/2-h/2);
+  glPrint(PChar(CountDownText));
+
 end;
 
 procedure TScreenSingView.WriteMessage(msg: UTF8String);
@@ -1335,7 +1354,7 @@ begin
   end;
 
   // draw progress indicator
-  br := (gapInBeats + LyricsState.CurrentBeat - SongStart) / SongDuration*w;
+  br := Max((gapInBeats + LyricsState.CurrentBeat - SongStart) / SongDuration*w, 0);
   glColor4f(Theme.Sing.StaticTimeProgress.ColR,
              Theme.Sing.StaticTimeProgress.ColG,
              Theme.Sing.StaticTimeProgress.ColB, 1); //Set Color


### PR DESCRIPTION
When playing songs with a low `#GAP` value, singers often don't have enough time to react to sing the first note. This PR adds a "count in" feature. If the first note is within 3 seconds of `#START`, it delays the start of the song and displays a 3...2...1 count in to provide extra visual feedback to singers to ensure they have a fair chance to hit the first note.

During the count in, if the song has a video, the background will display the first frame of the video.

The 3...2...1 display is the same as what is currently used for the medley countdown. I refactored that code, generalizing it so that it can be used for both purposes.

Internally, this works by seeking the audio stream to a position before `#START`. The audio decoder currently has a attribute "start time", before which it will pad the audio stream with silence. I expanded that concept by making it externally settable via the `IAudioPlayback` interface, so that you can request a *higher* start time than what the audio file requires.

As an example, suppose a text has a `#START` of 7 seconds and a `#GAP` of 8 seconds. The code would set  `AudioPlayback.Position := 5` and `AudioPlayback.StartTime := 7`. Between 5 and 7 seconds, the audio stream would return silence while the count in occurs.

A few parts of the code had to be adapted to handle the case where `AudioPlayback.Position` is less than `#START`.

I will post a demo video in the Discord.

Fixes #417 