### PR TITLE
Flush FFmpeg Audio Resampler When Seeking

### DIFF
--- a/src/lib/ffmpeg-4.0/swresample.pas
+++ b/src/lib/ffmpeg-4.0/swresample.pas
@@ -56,6 +56,6 @@ function swr_alloc(): PSwrContext; cdecl; external sw__resample;
 function swr_alloc_set_opts(s: PSwrContext; out_ch_layout: cint64; out_sample_fmt: TAVSampleFormat; out_sample_rate: cint; in_ch_layout: cint64; in_sample_fmt: TAVSampleFormat; in_sample_rate: cint; log_offset: cint; log_ctx: pointer): PSwrContext; cdecl; external sw__resample;
 function swr_init(s: PSwrContext): cint; cdecl; external sw__resample;
 procedure swr_free(s: PPSwrContext); cdecl; external sw__resample;
-function swr_convert(s: PSwrContext; var out: pcuint8; out_count: cint; var in_: pcuint8; in_count: cint): cint; cdecl; external sw__resample;
+function swr_convert(s: PSwrContext; var out: pcuint8; out_count: cint; in_: ppcuint8; in_count: cint): cint; cdecl; external sw__resample;
 implementation
 end.

--- a/src/lib/ffmpeg-5.0/swresample.pas
+++ b/src/lib/ffmpeg-5.0/swresample.pas
@@ -56,6 +56,6 @@ function swr_alloc(): PSwrContext; cdecl; external sw__resample;
 function swr_alloc_set_opts(s: PSwrContext; out_ch_layout: cint64; out_sample_fmt: TAVSampleFormat; out_sample_rate: cint; in_ch_layout: cint64; in_sample_fmt: TAVSampleFormat; in_sample_rate: cint; log_offset: cint; log_ctx: pointer): PSwrContext; cdecl; external sw__resample;
 function swr_init(s: PSwrContext): cint; cdecl; external sw__resample;
 procedure swr_free(s: PPSwrContext); cdecl; external sw__resample;
-function swr_convert(s: PSwrContext; var out: pcuint8; out_count: cint; var in_: pcuint8; in_count: cint): cint; cdecl; external sw__resample;
+function swr_convert(s: PSwrContext; var out: pcuint8; out_count: cint; in_: ppcuint8; in_count: cint): cint; cdecl; external sw__resample;
 implementation
 end.

--- a/src/lib/ffmpeg-6.0/swresample.pas
+++ b/src/lib/ffmpeg-6.0/swresample.pas
@@ -56,6 +56,6 @@ function swr_alloc(): PSwrContext; cdecl; external sw__resample;
 function swr_alloc_set_opts(s: PSwrContext; out_ch_layout: cint64; out_sample_fmt: TAVSampleFormat; out_sample_rate: cint; in_ch_layout: cint64; in_sample_fmt: TAVSampleFormat; in_sample_rate: cint; log_offset: cint; log_ctx: pointer): PSwrContext; cdecl; external sw__resample;
 function swr_init(s: PSwrContext): cint; cdecl; external sw__resample;
 procedure swr_free(s: PPSwrContext); cdecl; external sw__resample;
-function swr_convert(s: PSwrContext; var out: pcuint8; out_count: cint; var in_: pcuint8; in_count: cint): cint; cdecl; external sw__resample;
+function swr_convert(s: PSwrContext; var out: pcuint8; out_count: cint; in_: ppcuint8; in_count: cint): cint; cdecl; external sw__resample;
 implementation
 end.

--- a/src/lib/ffmpeg-7.0/swresample.pas
+++ b/src/lib/ffmpeg-7.0/swresample.pas
@@ -56,6 +56,6 @@ function swr_alloc(): PSwrContext; cdecl; external sw__resample;
 function swr_alloc_set_opts2(s: PPSwrContext; out_ch_layout: PAVChannelLayout; out_sample_fmt: TAVSampleFormat; out_sample_rate: cint; in_ch_layout: PAVChannelLayout; in_sample_fmt: TAVSampleFormat; in_sample_rate: cint; log_offset: cint; log_ctx: pointer): cint; cdecl; external sw__resample;
 function swr_init(s: PSwrContext): cint; cdecl; external sw__resample;
 procedure swr_free(s: PPSwrContext); cdecl; external sw__resample;
-function swr_convert(s: PSwrContext; var out: pcuint8; out_count: cint; var in_: pcuint8; in_count: cint): cint; cdecl; external sw__resample;
+function swr_convert(s: PSwrContext; var out: pcuint8; out_count: cint; in_: ppcuint8; in_count: cint): cint; cdecl; external sw__resample;
 implementation
 end.

--- a/src/lib/ffmpeg-8.0/swresample.pas
+++ b/src/lib/ffmpeg-8.0/swresample.pas
@@ -29,6 +29,6 @@ function swr_alloc(): PSwrContext; cdecl; external sw__resample;
 function swr_alloc_set_opts2(s: PPSwrContext; out_ch_layout: PAVChannelLayout; out_sample_fmt: TAVSampleFormat; out_sample_rate: cint; in_ch_layout: PAVChannelLayout; in_sample_fmt: TAVSampleFormat; in_sample_rate: cint; log_offset: cint; log_ctx: pointer): cint; cdecl; external sw__resample;
 function swr_init(s: PSwrContext): cint; cdecl; external sw__resample;
 procedure swr_free(s: PPSwrContext); cdecl; external sw__resample;
-function swr_convert(s: PSwrContext; var out: pcuint8; out_count: cint; var in_: pcuint8; in_count: cint): cint; cdecl; external sw__resample;
+function swr_convert(s: PSwrContext; var out: pcuint8; out_count: cint; in_: ppcuint8; in_count: cint): cint; cdecl; external sw__resample;
 implementation
 end.

--- a/src/media/UAudioConverter.pas
+++ b/src/media/UAudioConverter.pas
@@ -266,7 +266,7 @@ begin
   InBufPtr := Pcuint8(@InputBuffer[0]);
   OutBufPtr := Pcuint8(@OutputBuffer[0]);
   OutputSampleCount:= swr_convert(SwrContext, OutBufPtr, OutputSampleCount,
-                                  InBufPtr, InputSampleCount);
+                                  @InBufPtr, InputSampleCount);
   if (OutputSampleCount < 0) then
   begin
     Log.LogError('swr_convert failed ' + inttostr(OutputSampleCount), 'TAudioConverter_SWResample.Init');

--- a/src/media/UAudioDecoder_FFmpeg.pas
+++ b/src/media/UAudioDecoder_FFmpeg.pas
@@ -156,6 +156,7 @@ type
 
       function DecodeFrame(): integer;
       procedure FlushCodecBuffers();
+      procedure FlushSwrContext();
       procedure PauseDecoderUnlocked();
       procedure ResumeDecoderUnlocked();
       procedure PauseDecoder();
@@ -849,6 +850,8 @@ begin
               fAudioPaketSize := 0;
               fAudioPaketSilence := 0;
               FlushCodecBuffers();
+              if (fSwrContext <> nil) then
+                FlushSwrContext();
               
               // Set preliminary stream position. The position will be set to
               // the correct value as soon as the first packet is decoded.
@@ -1077,6 +1080,19 @@ begin
   end;
 end;
 
+procedure TFFmpegDecodeStream.FlushSwrContext();
+var
+  I, NumSamples: integer;
+  Buffer: array[0..1023] of Byte;
+  BufferPtr: PByte;
+begin
+  BufferPtr := @Buffer[0];
+  NumSamples := SizeOf(Buffer) div fBytesPerSample;
+  repeat
+    I := swr_convert(fSwrContext, BufferPtr, NumSamples, nil, 0);
+  until I <= 0;
+end;
+
 function TFFmpegDecodeStream.DecodeFrame(): integer;
 var
   Packet: PAVPacket;
@@ -1279,7 +1295,7 @@ begin
     begin
       BufferPtr := @Buffer[0];
       BufferPos := swr_convert(fSwrContext, BufferPtr, BufferSize div fBytesPerSample,
-                               fAudioBufferFrame.extended_data^, 0);
+                               fAudioBufferFrame.extended_data, 0);
       if (BufferPos < 0) then // might happen if out of memory
         Exit;
       BufferPos := BufferPos * fBytesPerSample;
@@ -1323,7 +1339,7 @@ begin
       begin
         BufferPtr := @Buffer[BufferPos];
         CopyByteCount := swr_convert(fSwrContext, BufferPtr, RemainByteCount div fBytesPerSample,
-                                     fAudioBufferFrame.extended_data^, fAudioBufferFrame.nb_samples);
+                                     fAudioBufferFrame.extended_data, fAudioBufferFrame.nb_samples);
         if (CopyByteCount < 0) then
           Exit;
         CopyByteCount := CopyByteCount * fBytesPerSample;


### PR DESCRIPTION
When seeking audio, the audio decoder needs to flush out any old audio samples that may be buffered. It currently does this for the decoder context. However, the resampler context is not flushed and usually has old samples buffered. This can cause a brief audio glitch when seeking while an audio stream is continuously playing.

This PR adds a function to flush the resampler context during a seek operation. I had to change the bindings for the `swr_convert` function to accept a pointer instead of reference to allow for the passing of `nil`. The calling code was adapted to the updated binding.

In most cases, whatever brief audio glitch that may occur while seeking is not noticeable in current `master`. My motivation for this is that in #1203, when pressing `R` to restart on the sing screen, the glitch usually *is* noticeable. I figured it would be best to split this into a separate PR to make it easier to review.