### PR TITLE
use full path for song errors

### DIFF
--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -584,7 +584,7 @@ begin
   else if (Length(Str) > 1) and (Str[1] <> 'P') then
   begin
     Log.LogWarn(Format('"%s" in line %d: %s',
-        [FileName.ToNative, FileLineNo, 'character expected but found "' + Str + '"']),
+        [Path.Append(FileName).ToNative, FileLineNo, 'character expected but found "' + Str + '"']),
         'TSong.ParseLyricCharParam');
   end;
 


### PR DESCRIPTION
Use the full song txt path in TSong.ParseLyricCharParam warnings to allow seeing which file causes the problem.

Fixes #759 