### PR TITLE
show how perfect singing scores would split up to normal notes, line bonus, and golden notes in the editor

### DIFF
--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -418,6 +418,7 @@ type
       procedure CopyFromUndo; //undo last lines, mouse position and headers
       procedure DrawPlayerTrack(CurrentTone: Integer; Count: Integer; CurrentNote: Integer);
       procedure DrawInfoBar(X, Y, W, H: Integer; ColR, ColG, ColB, Alpha: real; Track: Integer);
+      procedure DrawMaxScoreInfo(X, Y, W, H: Integer; Track: Integer);
       procedure DrawText(X, Y, W, H: real; Track: Integer; NumLines: Integer = 10);
       //video view
       procedure StartVideoPreview();
@@ -4560,6 +4561,99 @@ begin
   glLineWidth(1);
 end;
 
+procedure TScreenEditSub.DrawMaxScoreInfo(X, Y, W, H: Integer; Track: Integer);
+var
+  LineIndex: Integer;
+  NoteIndex: Integer;
+  NonEmptyLines: Integer;
+  LineWeight: Integer;
+  TotalWeight: Integer;
+  NormalWeight: Integer;
+  GoldenWeight: Integer;
+  MaxSongPoints: Integer;
+  NormalPoints: Integer;
+  GoldenPoints: Integer;
+  LineBonusPoints: Integer;
+  Lines: array[0..2] of UTF8String;
+  OrgFont: TFont;
+begin
+  if (Track < Low(CurrentSong.Tracks)) or (Track > High(CurrentSong.Tracks)) then
+    Exit;
+
+  NonEmptyLines := 0;
+  TotalWeight := 0;
+  NormalWeight := 0;
+  GoldenWeight := 0;
+
+  for LineIndex := 0 to High(CurrentSong.Tracks[Track].Lines) do
+  begin
+    LineWeight := 0;
+
+    for NoteIndex := 0 to High(CurrentSong.Tracks[Track].Lines[LineIndex].Notes) do
+    begin
+      Inc(
+        LineWeight,
+        CurrentSong.Tracks[Track].Lines[LineIndex].Notes[NoteIndex].Duration *
+        ScoreFactor[CurrentSong.Tracks[Track].Lines[LineIndex].Notes[NoteIndex].NoteType]);
+
+      case CurrentSong.Tracks[Track].Lines[LineIndex].Notes[NoteIndex].NoteType of
+        ntNormal, ntRap:
+          Inc(
+            NormalWeight,
+            CurrentSong.Tracks[Track].Lines[LineIndex].Notes[NoteIndex].Duration *
+            ScoreFactor[CurrentSong.Tracks[Track].Lines[LineIndex].Notes[NoteIndex].NoteType]);
+        ntGolden, ntRapGolden:
+          Inc(
+            GoldenWeight,
+            CurrentSong.Tracks[Track].Lines[LineIndex].Notes[NoteIndex].Duration *
+            ScoreFactor[CurrentSong.Tracks[Track].Lines[LineIndex].Notes[NoteIndex].NoteType]);
+      end;
+    end;
+
+    if LineWeight > 0 then
+      Inc(NonEmptyLines);
+
+    Inc(TotalWeight, LineWeight);
+  end;
+
+  if TotalWeight > 0 then
+  begin
+    MaxSongPoints := MAX_SONG_SCORE - MAX_SONG_LINE_BONUS;
+    GoldenPoints := Round(MaxSongPoints * GoldenWeight / TotalWeight);
+    NormalPoints := MaxSongPoints - GoldenPoints;
+  end
+  else
+  begin
+    NormalPoints := 0;
+    GoldenPoints := 0;
+  end;
+
+  if NonEmptyLines > 0 then
+    LineBonusPoints := MAX_SONG_LINE_BONUS
+  else
+    LineBonusPoints := 0;
+
+  Lines[0] := Language.Translate('SING_NOTES') + ': ' + IntToStr(NormalPoints);
+  Lines[1] := Language.Translate('SING_PHRASE_BONUS') + ': ' + IntToStr(LineBonusPoints);
+  Lines[2] := Language.Translate('SING_GOLDEN_NOTES') + ': ' + IntToStr(GoldenPoints);
+
+  OrgFont := CurrentFont;
+  SetFontFamily(0);
+  SetFontStyle(ftBold);
+  SetFontItalic(False);
+  SetFontReflection(False, 0);
+  SetFontSize(14);
+  glColor4f(0, 0, 0, 1);
+
+  for LineIndex := 0 to High(Lines) do
+  begin
+    SetFontPos(X + 10, Y + 12 + LineIndex * 18);
+    glPrint(Lines[LineIndex]);
+  end;
+
+  SetFont(OrgFont);
+end;
+
 procedure TScreenEditSub.DrawText(X, Y, W, H: real; Track: Integer; NumLines: Integer);
 var
   Rec:   TRecR;
@@ -5875,6 +5969,13 @@ begin
   else
     EditorLyrics[CurrentTrack].ClearCursor;
   EditorLyrics[CurrentTrack].Draw;
+
+  DrawMaxScoreInfo(
+    Theme.EditSub.BackgroundImage.X,
+    Theme.EditSub.BackgroundImage.Y,
+    Theme.EditSub.BackgroundImage.W,
+    Theme.EditSub.BackgroundImage.H,
+    CurrentTrack);
 
   //video
   if Assigned(fCurrentVideo) then

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -1080,6 +1080,7 @@ procedure TScreenEditSub.HandleVideo(SDL_ModState: word);
 begin
   if (SDL_ModState = 0) or (SDL_ModState = KMOD_LALT) then // play current line/remainder of song with video
   begin
+    Statics[BackgroundImageId].Visible := false;
     StopVideoPreview;
     AudioPlayback.Stop;
     PlayVideo := true;
@@ -1106,6 +1107,9 @@ begin
     AudioPlayback.Play;
     LastClick := -100;
     StartVideoPreview();
+    Statics[BackgroundImageId].Visible :=
+      (not Assigned(fCurrentVideo)) and
+      (Statics[BackgroundImageId].Texture.TexNum > 0);
     Text[TextInfo].Text := Language.Translate('EDIT_INFO_PLAY_SONG');
   end;
 end;
@@ -3068,6 +3072,7 @@ begin
     Statics[BackgroundImageId].Texture.Y := theme.EditSub.BackgroundImage.Y;
     Statics[BackgroundImageId].Texture.W := theme.EditSub.BackgroundImage.W;
     Statics[BackgroundImageId].Texture.H := theme.EditSub.BackgroundImage.H;
+    Statics[BackgroundImageId].Visible := false;
   end;
 
   if ((BackgroundSlideId = Interactions[nBut].Num) and (Action = maRight) and (SelectsS[Interactions[nBut].Num].SelectedOption < Length(SelectsS[Interactions[nBut].Num].TextOptT)-1)) then
@@ -3082,6 +3087,7 @@ begin
     Statics[BackgroundImageId].Texture.Y := theme.EditSub.BackgroundImage.Y;
     Statics[BackgroundImageId].Texture.W := theme.EditSub.BackgroundImage.W;
     Statics[BackgroundImageId].Texture.H := theme.EditSub.BackgroundImage.H;
+    Statics[BackgroundImageId].Visible := false;
   end;
 
   // changed video
@@ -4807,6 +4813,7 @@ end;
 procedure TScreenEditSub.StopVideoPreview;
 begin
   // Stop video preview of previous song
+  Statics[BackgroundImageId].Visible := false;
   if Assigned(fCurrentVideo) then
   begin
     fCurrentVideo.Stop();
@@ -5099,6 +5106,7 @@ begin
 
   // background image & preview
   BackgroundImageId := AddStatic(Theme.EditSub.BackgroundImage);
+  Statics[BackgroundImageId].Visible := false;
 
   // note info
   // start header
@@ -5608,6 +5616,7 @@ begin
       Statics[BackgroundImageId].Texture.Y := Theme.EditSub.BackgroundImage.Y;
       Statics[BackgroundImageId].Texture.W := Theme.EditSub.BackgroundImage.W;
       Statics[BackgroundImageId].Texture.H := Theme.EditSub.BackgroundImage.H;
+      Statics[BackgroundImageId].Visible := false;
     end;
   except
     Log.LogError('Background could not be loaded: ' + CurrentSong.Background.ToNative);

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -421,6 +421,7 @@ type
       procedure CopyFromUndo; //undo last lines, mouse position and headers
       procedure DrawPlayerTrack(CurrentTone: Integer; Count: Integer; CurrentNote: Integer);
       procedure DrawInfoBar(X, Y, W, H: Integer; ColR, ColG, ColB, Alpha: real; Track: Integer);
+      procedure DrawMaxScoreInfo(X, Y, W, H: Integer; Track: Integer);
       procedure DrawText(X, Y, W, H: real; Track: Integer; NumLines: Integer = 10);
       //video view
       procedure StartVideoPreview();
@@ -4792,6 +4793,99 @@ begin
   Renderer.DrawQuads(QuadList);
 end;
 
+procedure TScreenEditSub.DrawMaxScoreInfo(X, Y, W, H: Integer; Track: Integer);
+var
+  LineIndex: Integer;
+  NoteIndex: Integer;
+  NonEmptyLines: Integer;
+  LineWeight: Integer;
+  TotalWeight: Integer;
+  NormalWeight: Integer;
+  GoldenWeight: Integer;
+  MaxSongPoints: Integer;
+  NormalPoints: Integer;
+  GoldenPoints: Integer;
+  LineBonusPoints: Integer;
+  Lines: array[0..2] of UTF8String;
+  OrgFont: TFont;
+begin
+  if (Track < Low(CurrentSong.Tracks)) or (Track > High(CurrentSong.Tracks)) then
+    Exit;
+
+  NonEmptyLines := 0;
+  TotalWeight := 0;
+  NormalWeight := 0;
+  GoldenWeight := 0;
+
+  for LineIndex := 0 to High(CurrentSong.Tracks[Track].Lines) do
+  begin
+    LineWeight := 0;
+
+    for NoteIndex := 0 to High(CurrentSong.Tracks[Track].Lines[LineIndex].Notes) do
+    begin
+      Inc(
+        LineWeight,
+        CurrentSong.Tracks[Track].Lines[LineIndex].Notes[NoteIndex].Duration *
+        ScoreFactor[CurrentSong.Tracks[Track].Lines[LineIndex].Notes[NoteIndex].NoteType]);
+
+      case CurrentSong.Tracks[Track].Lines[LineIndex].Notes[NoteIndex].NoteType of
+        ntNormal, ntRap:
+          Inc(
+            NormalWeight,
+            CurrentSong.Tracks[Track].Lines[LineIndex].Notes[NoteIndex].Duration *
+            ScoreFactor[CurrentSong.Tracks[Track].Lines[LineIndex].Notes[NoteIndex].NoteType]);
+        ntGolden, ntRapGolden:
+          Inc(
+            GoldenWeight,
+            CurrentSong.Tracks[Track].Lines[LineIndex].Notes[NoteIndex].Duration *
+            ScoreFactor[CurrentSong.Tracks[Track].Lines[LineIndex].Notes[NoteIndex].NoteType]);
+      end;
+    end;
+
+    if LineWeight > 0 then
+      Inc(NonEmptyLines);
+
+    Inc(TotalWeight, LineWeight);
+  end;
+
+  if TotalWeight > 0 then
+  begin
+    MaxSongPoints := MAX_SONG_SCORE - MAX_SONG_LINE_BONUS;
+    GoldenPoints := Round(MaxSongPoints * GoldenWeight / TotalWeight);
+    NormalPoints := MaxSongPoints - GoldenPoints;
+  end
+  else
+  begin
+    NormalPoints := 0;
+    GoldenPoints := 0;
+  end;
+
+  if NonEmptyLines > 0 then
+    LineBonusPoints := MAX_SONG_LINE_BONUS
+  else
+    LineBonusPoints := 0;
+
+  Lines[0] := Language.Translate('SING_NOTES') + ': ' + IntToStr(NormalPoints);
+  Lines[1] := Language.Translate('SING_PHRASE_BONUS') + ': ' + IntToStr(LineBonusPoints);
+  Lines[2] := Language.Translate('SING_GOLDEN_NOTES') + ': ' + IntToStr(GoldenPoints);
+
+  OrgFont := CurrentFont;
+  SetFontFamily(0);
+  SetFontStyle(ftBold);
+  SetFontItalic(False);
+  SetFontReflection(False, 0);
+  SetFontSize(14);
+  glColor4f(0, 0, 0, 1);
+
+  for LineIndex := 0 to High(Lines) do
+  begin
+    SetFontPos(X + 10, Y + 12 + LineIndex * 18);
+    glPrint(Lines[LineIndex]);
+  end;
+
+  SetFont(OrgFont);
+end;
+
 procedure TScreenEditSub.DrawText(X, Y, W, H: real; Track: Integer; NumLines: Integer);
 var
   Rec:   TRecR;
@@ -6195,6 +6289,13 @@ begin
   else
     EditorLyrics[CurrentTrack].ClearCursor;
   EditorLyrics[CurrentTrack].Draw;
+
+  DrawMaxScoreInfo(
+    Theme.EditSub.BackgroundImage.X,
+    Theme.EditSub.BackgroundImage.Y,
+    Theme.EditSub.BackgroundImage.W,
+    Theme.EditSub.BackgroundImage.H,
+    CurrentTrack);
 
   //video
   if Assigned(fCurrentVideo) then

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -1127,6 +1127,7 @@ procedure TScreenEditSub.HandleVideo(SDL_ModState: word);
 begin
   if (SDL_ModState = 0) or (SDL_ModState = KMOD_LALT) then // play current line/remainder of song with video
   begin
+    Statics[BackgroundImageId].Visible := false;
     StopVideoPreview;
     AudioPlayback.Stop;
     PlayVideo := true;
@@ -1157,6 +1158,9 @@ begin
     AudioPlayback.Play;
     LastClick := -100;
     StartVideoPreview();
+    Statics[BackgroundImageId].Visible :=
+      (not Assigned(fCurrentVideo)) and
+      (Statics[BackgroundImageId].Texture.TexNum > 0);
     Text[TextInfo].Text := Language.Translate('EDIT_INFO_PLAY_SONG');
   end;
 end;
@@ -3131,6 +3135,7 @@ begin
     Statics[BackgroundImageId].Texture.Y := theme.EditSub.BackgroundImage.Y;
     Statics[BackgroundImageId].Texture.W := theme.EditSub.BackgroundImage.W;
     Statics[BackgroundImageId].Texture.H := theme.EditSub.BackgroundImage.H;
+    Statics[BackgroundImageId].Visible := false;
   end;
 
   if ((BackgroundSlideId = Interactions[nBut].Num) and (Action = maRight) and (SelectsS[Interactions[nBut].Num].SelectedOption < Length(SelectsS[Interactions[nBut].Num].TextOptT)-1)) then
@@ -3146,6 +3151,7 @@ begin
     Statics[BackgroundImageId].Texture.Y := theme.EditSub.BackgroundImage.Y;
     Statics[BackgroundImageId].Texture.W := theme.EditSub.BackgroundImage.W;
     Statics[BackgroundImageId].Texture.H := theme.EditSub.BackgroundImage.H;
+    Statics[BackgroundImageId].Visible := false;
   end;
 
   // changed video
@@ -5033,6 +5039,7 @@ end;
 procedure TScreenEditSub.StopVideoPreview;
 begin
   // Stop video preview of previous song
+  Statics[BackgroundImageId].Visible := false;
   if Assigned(fCurrentVideo) then
   begin
     fCurrentVideo.Stop();
@@ -5385,6 +5392,7 @@ begin
 
   // background image & preview
   BackgroundImageId := AddStatic(Theme.EditSub.BackgroundImage);
+  Statics[BackgroundImageId].Visible := false;
 
   // note info
   // start header
@@ -5902,6 +5910,7 @@ begin
       Statics[BackgroundImageId].Texture.Y := Theme.EditSub.BackgroundImage.Y;
       Statics[BackgroundImageId].Texture.W := Theme.EditSub.BackgroundImage.W;
       Statics[BackgroundImageId].Texture.H := Theme.EditSub.BackgroundImage.H;
+      Statics[BackgroundImageId].Visible := false;
     end;
   except
     Log.LogError('Background could not be loaded: ' + CurrentSong.Background.ToNative);

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -1160,7 +1160,7 @@ begin
     StartVideoPreview();
     Statics[BackgroundImageId].Visible :=
       (not Assigned(fCurrentVideo)) and
-      (Statics[BackgroundImageId].Texture.TexNum > 0);
+      (not Statics[BackgroundImageId].Texture.IsEmpty);
     Text[TextInfo].Text := Language.Translate('EDIT_INFO_PLAY_SONG');
   end;
 end;
@@ -4881,12 +4881,12 @@ begin
   SetFontItalic(False);
   SetFontReflection(False, 0);
   SetFontSize(14);
-  glColor4f(0, 0, 0, 1);
+  SetFontColor(0, 0, 0, 1);
 
   for LineIndex := 0 to High(Lines) do
   begin
     SetFontPos(X + 10, Y + 12 + LineIndex * 18);
-    glPrint(Lines[LineIndex]);
+    PrintText(Lines[LineIndex]);
   end;
 
   SetFont(OrgFont);


### PR DESCRIPTION
Adds a small score breakdown overlay to the Editor showing how a perfect run would split into normal note points, line bonus, and golden note points.

The values are calculated directly from the current note data in the editor, so they update immediately when notes are edited. The text is drawn in the video preview area and active video playback still overlays it as before.

Fixes #398.