### PR TITLE
prepare projectM cwrapper for 64-bit

### DIFF
--- a/src/lib/projectM/cwrapper/projectM-cwrapper.cpp
+++ b/src/lib/projectM/cwrapper/projectM-cwrapper.cpp
@@ -19,22 +19,23 @@
 // MILKDROP_FILE_EXTENSION, and PROJECTM_MODULE_EXTENSION defined (yuck!)
 // by the projectM headers with __cxa_atexit.
 
-projectM_ptr projectM_create1(char* config_file) 
+projectM_ptr PROJECTM_CWRAPPER_CALL projectM_create1(char* config_file)
 {
     return projectM_ptr(new projectM(config_file));
 }
 
 #if (PROJECTM_VERSION_INT < 1000000)
-projectM_ptr projectM_create2(int gx, int gy, int fps, int texsize, 
-			      int width, int height, char* preset_url, 
+projectM_ptr PROJECTM_CWRAPPER_CALL projectM_create2(int gx, int gy, int fps, int texsize,
+			      int width, int height, char* preset_url,
 			      char* title_fonturl, char* title_menuurl)
 {
-    return projectM_ptr(new projectM(gx, gy, fps, texsize, width, height, 
-    				     preset_url, title_fonturl, title_menuurl));}
+    return projectM_ptr(new projectM(gx, gy, fps, texsize, width, height,
+				     preset_url, title_fonturl, title_menuurl));
+}
 #endif
 
 #if (PROJECTM_VERSION_INT >= 2000000)
-projectM_ptr projectM_create2(int gx, int gy, int fps, int texsize,
+projectM_ptr PROJECTM_CWRAPPER_CALL projectM_create2(int gx, int gy, int fps, int texsize,
 			      int width, int height, char* preset_url,
 			      char* title_fonturl, char* title_menuurl)
 {
@@ -59,58 +60,58 @@ projectM_ptr projectM_create2(int gx, int gy, int fps, int texsize,
 }
 #endif
 
-void projectM_resetGL(projectM_ptr pm, int width, int height)
+void PROJECTM_CWRAPPER_CALL projectM_resetGL(projectM_ptr pm, int width, int height)
 {
     PM_CLASS(pm)->projectM_resetGL(width, height);
 }
 
-void projectM_setTitle(projectM_ptr pm, char* title)
+void PROJECTM_CWRAPPER_CALL projectM_setTitle(projectM_ptr pm, char* title)
 {
     PM_CLASS(pm)->projectM_setTitle(title);
 }
 
-void projectM_renderFrame(projectM_ptr pm)
+void PROJECTM_CWRAPPER_CALL projectM_renderFrame(projectM_ptr pm)
 {
     PM_CLASS(pm)->renderFrame();
 }
 
-unsigned projectM_initRenderToTexture(projectM_ptr pm)
+unsigned PROJECTM_CWRAPPER_CALL projectM_initRenderToTexture(projectM_ptr pm)
 {
     return PM_CLASS(pm)->initRenderToTexture();
 }
 
-void projectM_key_handler(projectM_ptr pm, projectMEvent event, 
+void PROJECTM_CWRAPPER_CALL projectM_key_handler(projectM_ptr pm, projectMEvent event,
 		projectMKeycode keycode, projectMModifier modifier)
 {
     PM_CLASS(pm)->key_handler(event, keycode, modifier);
 }
-	    
-void projectM_free(projectM_ptr pm)
+
+void PROJECTM_CWRAPPER_CALL projectM_free(projectM_ptr pm)
 {
     delete PM_CLASS(pm);
 }
 
-void PCM_addPCMfloat(projectM_ptr pm, float *PCMdata, int samples)
+void PROJECTM_CWRAPPER_CALL PCM_addPCMfloat(projectM_ptr pm, float *PCMdata, int samples)
 {
     PM_PCM(pm)->addPCMfloat(PCMdata, samples);
 }
 
-void PCM_addPCM16(projectM_ptr pm, short pcm_data[2][512])
+void PROJECTM_CWRAPPER_CALL PCM_addPCM16(projectM_ptr pm, short pcm_data[2][512])
 {
     PM_PCM(pm)->addPCM16(pcm_data);
 }
 
-void PCM_addPCM16Data(projectM_ptr pm, const short* pcm_data, short samples)
+void PROJECTM_CWRAPPER_CALL PCM_addPCM16Data(projectM_ptr pm, const short* pcm_data, short samples)
 {
     PM_PCM(pm)->addPCM16Data(pcm_data, samples);
 }
 
-void PCM_addPCM8(projectM_ptr pm, unsigned char pcm_data[2][1024])
+void PROJECTM_CWRAPPER_CALL PCM_addPCM8(projectM_ptr pm, unsigned char pcm_data[2][1024])
 {
     PM_PCM(pm)->addPCM8(pcm_data);
 }
 
-void PCM_addPCM8_512(projectM_ptr pm, const unsigned char pcm_data[2][512])
+void PROJECTM_CWRAPPER_CALL PCM_addPCM8_512(projectM_ptr pm, const unsigned char pcm_data[2][512])
 {
     PM_PCM(pm)->addPCM8_512(pcm_data);
 }
@@ -118,7 +119,7 @@ void PCM_addPCM8_512(projectM_ptr pm, const unsigned char pcm_data[2][512])
 #define COPY_FIELD(c_ptr, s, fld) (c_ptr->fld = s.fld)
 
 #if (PROJECTM_VERSION_INT > 1000000)
-void projectM_settings(projectM_ptr pm, Settings* settings)
+void PROJECTM_CWRAPPER_CALL projectM_settings(projectM_ptr pm, Settings* settings)
 {
     const projectM::Settings& pmSettings = PM_CLASS(pm)->settings();
 

--- a/src/lib/projectM/cwrapper/projectM-cwrapper.h
+++ b/src/lib/projectM/cwrapper/projectM-cwrapper.h
@@ -14,6 +14,17 @@
 #define PROJECTM_VERSION_INT PROJECTM_VERSION_2_0_0
 #endif
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+#define PROJECTM_CWRAPPER_CALL __cdecl
+#define PROJECTM_CWRAPPER_API __declspec(dllexport)
+#elif defined(__GNUC__) && __GNUC__ >= 4
+#define PROJECTM_CWRAPPER_CALL
+#define PROJECTM_CWRAPPER_API __attribute__((visibility("default")))
+#else
+#define PROJECTM_CWRAPPER_CALL
+#define PROJECTM_CWRAPPER_API
+#endif
+
 extern "C" {
 
     #if (PROJECTM_VERSION_INT > 1000000)
@@ -38,30 +49,30 @@ extern "C" {
 
     typedef void* projectM_ptr;
 
-    DLLEXPORT projectM_ptr projectM_create1(char* config_file);
+    PROJECTM_CWRAPPER_API projectM_ptr PROJECTM_CWRAPPER_CALL projectM_create1(char* config_file);
     #if (PROJECTM_VERSION_INT < 1000000 || PROJECTM_VERSION_INT >= 2000000)
-    DLLEXPORT projectM_ptr projectM_create2(int gx, int gy, int fps, int texsize, 
-					    int width, int height, char* preset_url, 
+    PROJECTM_CWRAPPER_API projectM_ptr PROJECTM_CWRAPPER_CALL projectM_create2(int gx, int gy, int fps, int texsize,
+					    int width, int height, char* preset_url,
 					    char* title_fonturl, char* title_menuurl);
     #endif
 
-    DLLEXPORT void projectM_resetGL(projectM_ptr pm, int width, int height);
-    DLLEXPORT void projectM_setTitle(projectM_ptr pm, char* title);
-    DLLEXPORT void projectM_renderFrame(projectM_ptr pm);
-    DLLEXPORT unsigned projectM_initRenderToTexture(projectM_ptr pm); 
-    DLLEXPORT void projectM_key_handler(projectM_ptr pm, projectMEvent event, 
+    PROJECTM_CWRAPPER_API void PROJECTM_CWRAPPER_CALL projectM_resetGL(projectM_ptr pm, int width, int height);
+    PROJECTM_CWRAPPER_API void PROJECTM_CWRAPPER_CALL projectM_setTitle(projectM_ptr pm, char* title);
+    PROJECTM_CWRAPPER_API void PROJECTM_CWRAPPER_CALL projectM_renderFrame(projectM_ptr pm);
+    PROJECTM_CWRAPPER_API unsigned PROJECTM_CWRAPPER_CALL projectM_initRenderToTexture(projectM_ptr pm);
+    PROJECTM_CWRAPPER_API void PROJECTM_CWRAPPER_CALL projectM_key_handler(projectM_ptr pm, projectMEvent event,
 					projectMKeycode keycode, projectMModifier modifier);
-    
-    DLLEXPORT void projectM_free(projectM_ptr pm);
 
-    DLLEXPORT void PCM_addPCMfloat(projectM_ptr pm, float *PCMdata, int samples);
-    DLLEXPORT void PCM_addPCM16(projectM_ptr pm, short [2][512]);
-    DLLEXPORT void PCM_addPCM16Data(projectM_ptr pm, const short* pcm_data, short samples);
-    DLLEXPORT void PCM_addPCM8(projectM_ptr pm, unsigned char [2][1024]);
-    DLLEXPORT void PCM_addPCM8_512(projectM_ptr pm, const unsigned char [2][512]);
+    PROJECTM_CWRAPPER_API void PROJECTM_CWRAPPER_CALL projectM_free(projectM_ptr pm);
+
+    PROJECTM_CWRAPPER_API void PROJECTM_CWRAPPER_CALL PCM_addPCMfloat(projectM_ptr pm, float *PCMdata, int samples);
+    PROJECTM_CWRAPPER_API void PROJECTM_CWRAPPER_CALL PCM_addPCM16(projectM_ptr pm, short [2][512]);
+    PROJECTM_CWRAPPER_API void PROJECTM_CWRAPPER_CALL PCM_addPCM16Data(projectM_ptr pm, const short* pcm_data, short samples);
+    PROJECTM_CWRAPPER_API void PROJECTM_CWRAPPER_CALL PCM_addPCM8(projectM_ptr pm, unsigned char [2][1024]);
+    PROJECTM_CWRAPPER_API void PROJECTM_CWRAPPER_CALL PCM_addPCM8_512(projectM_ptr pm, const unsigned char [2][512]);
 
     #if (PROJECTM_VERSION_INT > 1000000)
-    DLLEXPORT void projectM_settings(projectM_ptr pm, Settings* settings);
+    PROJECTM_CWRAPPER_API void PROJECTM_CWRAPPER_CALL projectM_settings(projectM_ptr pm, Settings* settings);
     #endif
 }
 


### PR DESCRIPTION
https://github.com/UltraStar-Deluxe/mxe/pull/2 requires some updates to the projectM cwrapper to be able to build 64-bit compatible dlls for windows:

The issue was that the wrapper did not define its own ABI explicitly: it relied on an external `DLLEXPORT` macro for symbol export, and its function definitions relied on the compiler’s default calling convention instead of stating `cdecl` explicitly. On Windows, where calling convention is part of the ABI, that can lead to compatibility problems for Pascal callers.

The change was to define the wrapper ABI locally via `PROJECTM_CWRAPPER_API` and `PROJECTM_CWRAPPER_CALL`, and apply those macros to all exported declarations and definitions so symbol export and calling convention are explicit and work on every platform.