### PR TITLE
feat: Add song loading progress bar and statistics

### DIFF
--- a/src/base/UGraphic.pas
+++ b/src/base/UGraphic.pas
@@ -42,6 +42,7 @@ uses
   UCommon,
   ULog,
   UIni,
+  UPlatform,
   SysUtils,
   UImage,
   UCatCovers,
@@ -469,6 +470,9 @@ end;
 const
   WINDOW_ICON = 'icons/ultrastardx-icon.png';
 
+{* Progress callback for song loading - updates loading screen *}
+procedure OnSongLoadingProgress(const Stats: TSongLoadingStats); forward;
+
 procedure Initialize3D (Title: string);
 var
   Icon: PSDL_Surface;
@@ -532,9 +536,16 @@ begin
   Log.LogStatus('Creating Avatars Cache', 'Initialization');
   Avatars := TAvatarDatabase.Create;
 
-  // Songs
+  // Songs - set up progress callback before loading
   Log.LogStatus('Creating Song Array', 'Initialization');
+  SongLoadingProgressCallback := @OnSongLoadingProgress;
   Songs := TSongs.Create;
+  SongLoadingProgressCallback := nil;  // Clear callback after loading
+
+  // Log song loading statistics
+  Log.LogStatus(Format('Song loading complete: %d loaded, %d failed in %.3f seconds',
+    [Songs.LoadingStats.SongsLoaded, Songs.LoadingStats.SongsFailed,
+     Songs.LoadingStats.LoadTimeMs / 1000]), 'Initialization');
 
   Log.LogStatus('Creating 2nd Song Array', 'Initialization');
   CatSongs := TCatSongs.Create;
@@ -916,6 +927,17 @@ begin
   if assigned(Display) then
   begin
     Display.OnWindowResized(); // notify display window has changed
+  end;
+end;
+
+{* Progress callback for song loading - updates loading screen progress bar *}
+procedure OnSongLoadingProgress(const Stats: TSongLoadingStats);
+begin
+  // Only update every 20 songs to avoid slowdown, plus first and last
+  if Assigned(ScreenLoading) and (Stats.FilesFound > 0) and
+     ((Stats.CurrentFile mod 20 = 0) or (Stats.CurrentFile = 1) or (Stats.CurrentFile = Stats.FilesFound)) then
+  begin
+    ScreenLoading.SetProgress(Stats.CurrentFile, Stats.FilesFound);
   end;
 end;
 

--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -122,6 +122,10 @@ begin
     // Commandline Parameter Parser
     Params := TCMDParams.Create;
 
+    // Enable verbose logging if -debug flag is passed
+    if Params.Debug then
+      Log.SetLogLevel(50);  // LOG_LEVEL_DEBUG - shows all messages including STATUS
+
     if Platform.TerminateIfAlreadyRunning(WindowTitle) then
       Exit;
 

--- a/src/base/USongs.pas
+++ b/src/base/USongs.pas
@@ -85,6 +85,21 @@ type
 
   TPathDynArray = array of IPath;
 
+  // Song loading statistics
+  TSongLoadingStats = record
+    FilesFound:     Integer;
+    SongsLoaded:    Integer;
+    SongsFailed:    Integer;
+    CurrentFile:    Integer;
+    CurrentPath:    UTF8String;
+    StartTime:      TDateTime;
+    EndTime:        TDateTime;
+    LoadTimeMs:     Double;
+  end;
+
+  // Progress callback for loading screen updates
+  TSongLoadingProgressCallback = procedure(const Stats: TSongLoadingStats);
+
   {$IFDEF USE_PSEUDO_THREAD}
   TSongs = class(TPseudoThread)
   {$ELSE}
@@ -99,6 +114,7 @@ type
     procedure Execute; override;
   public
     SongList: TList;            // array of songs
+    LoadingStats: TSongLoadingStats;  // Statistics from last load
 
     Selected: integer;        // selected song index
     constructor Create();
@@ -141,6 +157,7 @@ type
 var
   Songs:    TSongs;    // all songs
   CatSongs: TCatSongs; // categorized songs
+  SongLoadingProgressCallback: TSongLoadingProgressCallback; // Progress callback for loading screen
 
 const
   IN_ACCESS        = $00000001; //* File was accessed */
@@ -160,6 +177,7 @@ implementation
 
 uses
   StrUtils,
+  sdl2,
   UCovers,
   UFiles,
   UGraphic,
@@ -169,6 +187,18 @@ uses
   UFilesystem,
   UUnicodeUtils;
 
+var
+  FileDiscoveryCounter: Integer = 0;  // Counter for SDL event processing during discovery
+
+{* Process SDL events to keep app responsive *}
+procedure PumpSDLEvents;
+var
+  Event: TSDL_Event;
+begin
+  while SDL_PollEvent(@Event) <> 0 do
+    ; // Discard events during loading
+end;
+
 constructor TSongs.Create();
 begin
   // do not start thread BEFORE initialization (suspended = true)
@@ -176,6 +206,14 @@ begin
   Self.FreeOnTerminate := true;
 
   SongList           := TList.Create();
+
+  // Initialize loading stats
+  LoadingStats.FilesFound := 0;
+  LoadingStats.SongsLoaded := 0;
+  LoadingStats.SongsFailed := 0;
+  LoadingStats.CurrentFile := 0;
+  LoadingStats.CurrentPath := '';
+  LoadingStats.LoadTimeMs := 0;
 
   // until it is fixed, simply load the song-list
   int_LoadSongList();
@@ -221,11 +259,23 @@ begin
   try
     fProcessing := true;
 
+    // Reset and start timing
+    LoadingStats.FilesFound := 0;
+    LoadingStats.SongsLoaded := 0;
+    LoadingStats.SongsFailed := 0;
+    LoadingStats.CurrentFile := 0;
+    LoadingStats.CurrentPath := '';
+    LoadingStats.StartTime := Now;
+
     Log.LogStatus('Searching For Songs', 'SongList');
 
     // browse directories
     for I := 0 to SongPaths.Count-1 do
       BrowseDir(SongPaths[I] as IPath);
+
+    // Record end time
+    LoadingStats.EndTime := Now;
+    LoadingStats.LoadTimeMs := (LoadingStats.EndTime - LoadingStats.StartTime) * 24 * 60 * 60 * 1000;
 
     if assigned(CatSongs) then
       CatSongs.Refresh;
@@ -272,13 +322,22 @@ begin
   Iter := FileSystem.FileFind(Dir.Append('*'), faAnyFile);
   while (Iter.HasNext) do
   begin
-    // the debug statements in this function have exactly the same message length before it prints the path
     FileInfo := Iter.Next;
     FileName := FileInfo.Name;
+
+    // Process SDL events periodically to keep app responsive
+    Inc(FileDiscoveryCounter);
+    if (FileDiscoveryCounter mod 100 = 0) then
+    begin
+      PumpSDLEvents;
+      // Update window title with discovery progress
+      if Assigned(Screen) then
+        SDL_SetWindowTitle(Screen, PChar(Format('UltraStar Deluxe - Discovering songs: %d found...', [Length(Files)])));
+    end;
+
     if ((FileInfo.Attr and faDirectory) <> 0) then
     begin
       if Recursive and (not FileName.Equals('.')) and (not FileName.Equals('..')) and (not FileName.Equals('')) then begin
-        Log.LogDebug('Recursing: ' + Dir.Append(FileName).ToWide, 'TSongs.FindFilesByExtension');
         FindFilesByExtension(Dir.Append(FileName), Ext, true, Files);
       end;
     end
@@ -287,7 +346,6 @@ begin
       // do not load files which either have wrong extension or start with a point
       if (Ext.Equals(FileName.GetExtension(), true) and not (FileName.ToUTF8()[1] = '.')) then
       begin
-        Log.LogDebug('Found file ' + Dir.Append(FileName).ToWide, 'TSongs.FindFilesByExtension');
         SetLength(Files, Length(Files)+1);
         Files[High(Files)] := Dir.Append(FileName);
       end;
@@ -300,24 +358,51 @@ var
   I: integer;
   Files: TPathDynArray;
   Song: TSong;
-  //CloneSong: TSong;
   Extension: IPath;
 begin
   Log.LogDebug('Searching directory ' + Dir.ToWide + ' for txt files', 'TSongs.BrowseTXTFiles');
   SetLength(Files, 0);
+  FileDiscoveryCounter := 0;  // Reset counter for file discovery
   Extension := Path('.txt');
   FindFilesByExtension(Dir, Extension, true, Files);
 
+  // Update files found count
+  LoadingStats.FilesFound := LoadingStats.FilesFound + Length(Files);
+
   for I := 0 to High(Files) do
   begin
+    // Process SDL events to keep app responsive
+    PumpSDLEvents;
+
+    // Update progress info
+    LoadingStats.CurrentFile := LoadingStats.CurrentFile + 1;
+    LoadingStats.CurrentPath := Files[I].ToUTF8;
+
+    // Log progress and update window title every 50 songs
+    if (LoadingStats.CurrentFile mod 50 = 0) or (LoadingStats.CurrentFile = LoadingStats.FilesFound) then
+    begin
+      Log.LogStatus(Format('Loading songs: %d / %d', [LoadingStats.CurrentFile, LoadingStats.FilesFound]), 'SongLoader');
+      if Assigned(Screen) then
+        SDL_SetWindowTitle(Screen, PChar(Format('UltraStar Deluxe - Loading songs: %d / %d',
+          [LoadingStats.CurrentFile, LoadingStats.FilesFound])));
+    end;
+
+    // Call progress callback if set (for UI updates)
+    if Assigned(SongLoadingProgressCallback) then
+      SongLoadingProgressCallback(LoadingStats);
+
     Song := TSong.Create(Files[I]);
 
     if Song.Analyse then
-      SongList.Add(Song)
+    begin
+      SongList.Add(Song);
+      Inc(LoadingStats.SongsLoaded);
+    end
     else
     begin
       Log.LogError('AnalyseFile failed for "' + Files[I].ToNative + '".');
       FreeAndNil(Song);
+      Inc(LoadingStats.SongsFailed);
     end;
   end;
 

--- a/src/screens/UScreenLoading.pas
+++ b/src/screens/UScreenLoading.pas
@@ -35,26 +35,32 @@ interface
 
 uses
   UMenu,
-  sdl2,
   SysUtils,
   UThemes,
   dglOpenGL;
 
 type
   TScreenLoading = class(TMenu)
+    private
+      ProgressBarIndex: integer;   // Index of the progress bar static element
+      ProgressBarMaxW: real;       // Maximum width of the progress bar
+      TextProgress: integer;       // Index of progress count text
     public
       Fadeout: boolean;
       TextDescription: integer;
+      TextStatus: integer;
 
       constructor Create; override;
       procedure OnShow; override;
       function ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean; override;
+      procedure SetProgress(Current, Total: integer);  // Update progress bar and text
   end;
 
 implementation
 
 uses
   UGraphic,
+  UDisplay,
   UTime;
 
 function TScreenLoading.ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean;
@@ -68,12 +74,86 @@ begin
 
   LoadFromTheme(Theme.Loading);
 
+  // Configure progress bar: use the white bar (Static[1]) as progress indicator
+  if Length(Statics) >= 2 then
+  begin
+    // Hide the colored bar (Static[0])
+    Statics[0].Visible := false;
+
+    // Use the white bar (Static[1]) as progress bar
+    ProgressBarIndex := 1;
+    ProgressBarMaxW := 800;
+    Statics[1].Texture.X := 0;
+    Statics[1].Texture.W := 0;    // Start empty
+  end
+  else if Length(Statics) > 0 then
+  begin
+    // Fallback: just use first static as progress bar
+    ProgressBarIndex := 0;
+    ProgressBarMaxW := 800;
+    Statics[0].Texture.X := 0;
+    Statics[0].Texture.W := 0;
+  end
+  else
+  begin
+    ProgressBarIndex := -1;
+    ProgressBarMaxW := 0;
+  end;
+
+  // Make "Loading..." text black and position at left with small margin
+  if Length(Text) > 0 then
+  begin
+    Text[0].X := 20;        // Left side with 20px margin
+    Text[0].Align := 0;     // Left-aligned (0=left, 1=center, 2=right)
+    Text[0].ColR := 0;      // Black color
+    Text[0].ColG := 0;
+    Text[0].ColB := 0;
+  end;
+
+  // Add progress count text next to "Loading..." (left-aligned, same Y, same style)
+  if Length(Text) > 0 then
+    TextProgress := AddText(130, Text[0].Y, 0, 0, 24, 0, 0, 0, '')
+  else
+    TextProgress := AddText(130, 550, 0, 0, 24, 0, 0, 0, '');
+
+  // Left-align the progress text
+  if (TextProgress >= 0) and (TextProgress < Length(Text)) then
+    Text[TextProgress].Align := 0;  // Left-aligned
+
   Fadeout := false;
 end;
 
 procedure TScreenLoading.OnShow;
 begin
   inherited;
+end;
+
+procedure TScreenLoading.SetProgress(Current, Total: integer);
+var
+  Progress: real;
+begin
+  // Calculate progress percentage
+  if Total > 0 then
+    Progress := Current / Total
+  else
+    Progress := 0;
+
+  // Clamp progress to 0-1 range
+  if Progress < 0 then Progress := 0;
+  if Progress > 1 then Progress := 1;
+
+  // Update progress bar width
+  if (ProgressBarIndex >= 0) and (ProgressBarIndex < Length(Statics)) then
+    Statics[ProgressBarIndex].Texture.W := ProgressBarMaxW * Progress;
+
+  // Update progress text
+  if (TextProgress >= 0) and (TextProgress < Length(Text)) then
+    Text[TextProgress].Text := Format('%d / %d', [Current, Total]);
+
+  // Force a display update to show the progress
+  Self.Draw;
+  Display.Draw;
+  SwapBuffers;
 end;
 
 end.


### PR DESCRIPTION
Display visual progress during song loading to improve UX with large libraries.

**CLI (Only shown with `-debug` CLI param)**

```
[...]
STATUS: Loading songs: 1750 / 1778 [SongLoader]
STATUS: Loading songs: 1778 / 1778 [SongLoader]
STATUS: Search Complete [SongList]
STATUS: Song loading complete: 1746 loaded, 32 failed in 1.953 seconds [Initialization]
```

https://github.com/user-attachments/assets/79c74ce5-a97c-40b3-b476-28a2f75bd058

**Changes:**
- Add progress bar on loading screen showing current/total songs
- Track loading statistics (loaded, failed, duration) in `TSongLoadingStats`
- Enable console progress logging via `-debug` CLI flag
- Pump SDL events during loading to prevent "not responding" state
