### PR TITLE
Update checkout action in linter job to support Node.js 24

### DIFF
--- a/.github/workflows/check-whitespace.yml
+++ b/.github/workflows/check-whitespace.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
Github Actions will deprecate support for Node.js 20 in June.
This PR updates the last action that was still running on Node.js 20 to a newer version supporting Node.js 24
See warnings here: https://github.com/UltraStar-Deluxe/USDX/actions/runs/23799372085