### PR TITLE
UAudioInput_Portaudio: skip vdownmix device

### DIFF
--- a/src/media/UAudioInput_Portaudio.pas
+++ b/src/media/UAudioInput_Portaudio.pas
@@ -369,6 +369,13 @@ begin
     if (channelCnt <= 0) then
       continue;
 
+    // workaround for https://github.com/alsa-project/alsa-plugins/issues/13
+    if CompareStr(paDeviceInfo^.name, 'vdownmix') = 0 then
+    begin
+      Log.LogWarn('Skipping vdownmix device because of alsa-plugins Github issue 13', 'Portaudio.EnumDevices');
+      continue;
+    end;
+
     paDevice := TPortaudioInputDevice.Create();
     AudioInputProcessor.DeviceList[deviceIndex] := paDevice;
 


### PR DESCRIPTION
The vdownmix ALSA plugin is for mixing surround sound to stereo. It has a bug that causes it to crash when used in the capture direction since it fails to swap the channel number restrictions for itself and the slave pcm when the slave is on its input (i.e. in capture direction) and then expects the input buffer to have 4-6 channels. Unfortunately the default configuration provided with alsa-plugins defines a device with the name vdownmix that uses the bidirectional plug:hw as slave. Skip this device to avoid the crashes.

Fixes #496
Fixes #537
Fixes #544
Fixes #547
Fixes #1230