### PR TITLE
Cleanup: Remove legacy Bamboo CI scripts

### DIFF
--- a/dists/bamboo/bamboo-build-lin-laz.bat
+++ b/dists/bamboo/bamboo-build-lin-laz.bat
@@ -1,4 +1,0 @@
-clear
-fpc  -S2cgi -OG1 -gl -vewnhi -l -Filib/JEDI-SDLv1.0/SDL/Pas/ -Fu/usr/lib/lazarus/components/images/lib/i386-linux/ -Fu/usr/lib/lazarus/lcl/units/i386-linux/ -Fu/usr/lib/lazarus/lcl/units/i386-linux/gtk2/ -Fu/usr/lib/lazarus/packager/units/i386-linux/ -Fu. -oUltraStar -dLCL -dLCLgtk2 UltraStar.lpr
-
-#mv ./UltraStar /home/jay/src/ultrastardx/output/

--- a/dists/bamboo/bamboo-build-lin-laz.sh
+++ b/dists/bamboo/bamboo-build-lin-laz.sh
@@ -1,6 +1,0 @@
-svn update
-
-clear
-fpc  -S2cgi -OG1 -gl -vewnhi -l -Filib/JEDI-SDLv1.0/SDL/Pas/ -Fu/usr/lib/lazarus/components/images/lib/i386-linux/ -Fu/usr/lib/lazarus/lcl/units/i386-linux/ -Fu/usr/lib/lazarus/lcl/units/i386-linux/gtk2/ -Fu/usr/lib/lazarus/packager/units/i386-linux/ -Fu. -oUltraStar -dLCL -dLCLgtk2 UltraStar.lpr
-
-#mv ./UltraStar /home/jay/src/ultrastardx/output/

--- a/dists/bamboo/bamboo-build-win-delphi.bat
+++ b/dists/bamboo/bamboo-build-win-delphi.bat
@@ -1,9 +1,0 @@
-"C:\Program Files\Borland\BDS\4.0\Bin\brc32.exe" -r ./UltraStar.rc
-
-"C:\Program Files\Borland\BDS\4.0\Bin\dcc32.exe" -U"lib\JEDI-SDL\SDL\Pas" -O"lib\JEDI-SDL\SDL\Pas" -I"lib\JEDI-SDL\SDL\Pas" -R"lib\JEDI-SDL\SDL\Pas" UltraStar.dpr
-cp UltraStar.exe ..\..\
-
-rem cd ..\..\Installer
-rem "C:\Program Files\NSIS\makeNSIS.exe" UltraStarDeluxe.nsi
-
-rem cd ..\Game\Code

--- a/dists/bamboo/bamboo-build-win-laz.bat
+++ b/dists/bamboo/bamboo-build-win-laz.bat
@@ -1,3 +1,0 @@
-USDXResCompiler.exe UltraStar.rc
-
-C:\lazarus\fpc\2.0.4\bin\i386-win32\ppc386.exe  -S2cgi -OG1 -gl -vewnhi -l -Filib\JEDI-SDLv1.0\SDL\Pas\ -Fuc:\lazarus\components\jpeg\lib\i386-win32\ -Fuc:\lazarus\components\images\lib\i386-win32\ -Fuc:\lazarus\lcl\units\i386-win32\ -Fuc:\lazarus\lcl\units\i386-win32\win32\ -Fuc:\lazarus\packager\units\i386-win32\ -Fu. -oUltraStar.exe -dLCL -dLCLwin32 UltraStar.lpr


### PR DESCRIPTION
This PR removes the old Bamboo build scripts in bamboo.

Why:

- The active build pipeline is GitHub Actions, not Bamboo. The removed scripts hardcode obsolete Lazarus and Delphi toolchains and are no longer part of the supported build flow.

What changed:

- Removed the Bamboo Windows and Linux build scripts from bamboo

Why this is safe:

- The current Windows build is driven by main.yml
- No current docs or build entrypoints depend on these Bamboo scripts
- This only removes legacy CI artifacts and does not touch the active build system