### PR TITLE
throw away the lyric tracks we just parsed to save memory instead of cpu time

### DIFF
--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -213,6 +213,7 @@ type
     destructor  Destroy; override;
     function    LoadSong(DuetChange: boolean): boolean;
     function    Analyse(const ReadCustomTags: Boolean = false; DuetChange: boolean = false; RapToFreestyle: boolean = false; OutOfBoundsToFreestyle: boolean = false; AudioLength: real = 0): boolean;
+    procedure   ReleaseTracks();
     procedure   SetMedleyMode();
     procedure   Clear();
     function    MD5SongFile(SongFileR: TTextFileStream): string;
@@ -1842,6 +1843,11 @@ begin
   DuetNames[1] := 'P2';
 
   Relative := false;
+end;
+
+procedure TSong.ReleaseTracks();
+begin
+  SetLength(Tracks, 0);
 end;
 
 function TSong.Analyse(const ReadCustomTags: Boolean; DuetChange: boolean; RapToFreestyle: boolean; OutOfBoundsToFreestyle: boolean; AudioLength: real): boolean;

--- a/src/base/USongs.pas
+++ b/src/base/USongs.pas
@@ -313,7 +313,10 @@ begin
     Song := TSong.Create(Files[I]);
 
     if Song.Analyse then
+    begin
+      Song.ReleaseTracks();
       SongList.Add(Song)
+    end
     else
     begin
       Log.LogError('AnalyseFile failed for "' + Files[I].ToNative + '".');


### PR DESCRIPTION
I don't think this is a good idea but it addresses the concern from #1134 that we are using too much memory by keeping all track data in memory all the time.

I think #1121 is strictly the better approach to resolve this as it also provides significantly faster startup times.

<img width="957" height="837" alt="grafik" src="https://github.com/user-attachments/assets/ea9ef5f3-1ed1-4cb4-8207-61f7f3c18039" />

Above is without this PR, below is with this PR - we're talking about a 2.8GB memory usage difference on the current master:

Without this PR: 3.4GB for 56k songs.

With this PR: 0.5GB for 56k songs.

(Regardless of this difference, neither of these would work under the older 32-bit Windows compiles because the allocation size is far above the virtual address space size of 32-bit Windows processes and even with this patch reducing the memory usage by 2.8GB, it would still fail in a 32-bit process!)

@barbeque-squared there is nothing going on with cover images - it is just the tracks.

The reason is also very simple: every syllable gets a separate allocation of a string in the heap. this will have minimum sizes and alignment, so this does eat up actual memory! Even a 1 byte syllable may blow up to 32 bytes or more there due to heap alignment.

Again, #1121 is strictly better - don't do the work if you don't want the data. This PR is to get the discussion going about what we want and that we can finally close those issues.

The startup time with 56k songs is 39 seconds on my system.
With #1121 it is just 15 seconds.

Either way, this PR is a minimal change that is ready to be merged.