### PR TITLE
Cleanup: Remove soundfont leftover files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -262,9 +262,6 @@ install-data:
 	$(MAKE) RECURSIVE_SRC_DIR="$(USDX_GAME_DIR)/resources" \
             RECURSIVE_DST_DIR="$(DESTDIR)$(INSTALL_DATADIR)/resources" \
             install-data-recursive
-	$(MAKE) RECURSIVE_SRC_DIR="$(USDX_GAME_DIR)/soundfonts" \
-            RECURSIVE_DST_DIR="$(DESTDIR)$(INSTALL_DATADIR)/sounds" \
-            install-data-recursive
 	$(MAKE) RECURSIVE_SRC_DIR="$(USDX_GAME_DIR)/sounds" \
             RECURSIVE_DST_DIR="$(DESTDIR)$(INSTALL_DATADIR)/sounds" \
             install-data-recursive

--- a/installer/settings/files_main_install.nsh
+++ b/installer/settings/files_main_install.nsh
@@ -143,7 +143,6 @@ File /r /x .git /x .gitignore ..\game\fonts
 File /r /x .git /x .gitignore ..\game\resources
 File /r /x .git /x .gitignore ..\game\visuals
 File /r /x .git /x .gitignore ..\game\webs
-File /r /x .git /x .gitignore ..\game\soundfonts
 File /r /x .git /x .gitignore ..\game\avatars
 
 ; Root dir:

--- a/src/base/UIni.pas
+++ b/src/base/UIni.pas
@@ -182,7 +182,6 @@ type
       ThresholdIndex: integer;
       AudioOutputBufferSizeIndex: integer;
       VoicePassthrough: integer;
-      SoundFont:      string;
       ReplayGain:     integer;
 
       SyncTo: integer;
@@ -299,8 +298,6 @@ type
       procedure SaveTeamColors;
       procedure SaveShowWebScore;
       procedure SaveJukeboxSongMenu;
-
-      procedure SaveSoundFont(Name: string);
       procedure SaveWebcamSettings();
       procedure SaveNumberOfPlayers;
       procedure SaveSingTimebarMode;
@@ -1553,8 +1550,6 @@ begin
 
   //AudioRepeat aka VoicePassthrough
   VoicePassthrough := ReadArrayIndex(IVoicePassthrough, IniFile, 'Sound', 'VoicePassthrough', 0);
-  
-  SoundFont := IniFile.ReadString('Sound', 'SoundFont', '');
 
   // Lyrics Font
   LyricsFont := ReadArrayIndex(ILyricsFont, IniFile, 'Lyrics', 'LyricsFont', 0);
@@ -2194,20 +2189,6 @@ begin
     //Colors for Names Mod
     for I := 1 to 3 do
       IniFile.WriteString('TeamColor', 'T' + IntToStr(I), IntToStr(TeamColor[I-1]));
-
-    IniFile.Free;
-  end;
-end;
-
-procedure TIni.SaveSoundFont(Name: string);
-var
-  IniFile: TIniFile;
-begin
-  if not Filename.IsReadOnly() then
-  begin
-    IniFile := TIniFile.Create(Filename.ToNative);
-
-    IniFile.WriteString('Sound', 'SoundFont', Name);
 
     IniFile.Free;
   end;

--- a/src/base/UPathUtils.pas
+++ b/src/base/UPathUtils.pas
@@ -55,7 +55,6 @@ var
   PlaylistPath:     IPath;
   WebsitePath:      IPath;
   WebScoresPath:    IPath;
-  SoundFontsPath:   IPath;
   AvatarsPath:      IPath;
 
 function FindPath(out PathResult: IPath; const RequestedPath: IPath; NeedsWritePermission: boolean): boolean;
@@ -181,7 +180,6 @@ begin
   FindPath(FontPath,      SharedPath.Append('fonts'),     false);
   FindPath(ResourcesPath, SharedPath.Append('resources'), false);
   FindPath(WebsitePath,   SharedPath.Append('webs'), false);
-  FindPath(SoundFontsPath, SharedPath.Append('soundfonts'), false);
   FindPath(AvatarsPath, SharedPath.Append('avatars'), false);
 
   // Playlists are not shared as we need one directory to write too


### PR DESCRIPTION
This PR removes leftover soundfont-specific config, path, and packaging code that no longer appears to be connected to any live runtime behavior!?

Changes in this PR:
- remove the unused SoundFont field/load/save handling from UIni
- remove SoundFontsPath from path initialization
- stop installing/uninstalling
- remove the empty .include placeholder

Impact:
- removes dead config and packaging residue
- avoids shipping an empty, unused soundfont directory