### PR TITLE
Fix playlist selection, scrolling, and non-fixed start behavior

### DIFF
--- a/src/base/UPlaylist.pas
+++ b/src/base/UPlaylist.pas
@@ -341,8 +341,7 @@ end;
  *}
 procedure TPlayListManager.SetPlayList(Index: Integer; SongID: Integer = -1);
 var
-  I, SongIdx: Integer;
-  Found: Boolean;
+  I, SongIdx, TargetSongID, RandomVisibleIndex, VisibleCount: Integer;
 begin
   if (Index < 0) or (Index > High(PlayLists)) then
     exit;
@@ -398,30 +397,84 @@ begin
   else
     ScreenSong.ShowCatTLCustom(Format(Theme.Playlist.CatText,[Playlists[Index].Name + '  [Fixed Order: Off]']));
 
-  //Fix SongSelection
-  ScreenSong.Interaction := 0;
-  Found := False;
+  ScreenSong.ResetRandomSongState;
+
+  // Fix SongSelection and keep the viewport aligned with the selected song.
+  TargetSongID := -1;
   if (SongID <> -1) then
   begin
     for I := 0 to high(PlayLists[Index].Items) do
     begin
-      ScreenSong.SelectNext;
-      if (PlayLists[Index].Items[I].SongID = Int(SongID)) then
+      if (PlayLists[Index].Items[I].SongID = SongID) then
       begin
-        Found := True;
+        TargetSongID := SongID;
         Break;
       end;
     end;
   end;
-  if (not Found) then
+
+  if (TargetSongID = -1) and not Playlists[Index].FixedOrder and (CatSongs.VisibleSongs > 0) then
+  begin
+    RandomVisibleIndex := Random(CatSongs.VisibleSongs);
+    VisibleCount := 0;
+
+    for I := 0 to High(CatSongs.Song) do
+    begin
+      if CatSongs.Song[I].Visible then
+      begin
+        if (VisibleCount = RandomVisibleIndex) then
+        begin
+          TargetSongID := I;
+          Break;
+        end;
+        Inc(VisibleCount);
+      end;
+    end;
+  end;
+
+  if (TargetSongID = -1) then
+  begin
+    for I := 0 to high(PlayLists[Index].Items) do
+    begin
+      SongIdx := PlayLists[Index].Items[I].SongID;
+      if (SongIdx >= 0) and (SongIdx <= High(CatSongs.Song)) and CatSongs.Song[SongIdx].Visible then
+      begin
+        TargetSongID := SongIdx;
+        Break;
+      end;
+    end;
+  end;
+
+  if (TargetSongID = -1) then
+  begin
     ScreenSong.Interaction := 0;
-  if (ScreenSong.Interaction = 0) then
-    ScreenSong.SelectNext;
-  ScreenSong.FixSelected;
+    case TSongMenuMode(Ini.SongMenu) of
+      smChessboard:
+        ScreenSong.ChessboardMinLine := 0;
+      smList:
+        ScreenSong.ListMinLine := 0;
+    end;
+  end
+  else
+  begin
+    case TSongMenuMode(Ini.SongMenu) of
+      smRoulette,
+      smChessboard,
+      smList:
+        ScreenSong.SkipTo(CatSongs.VisibleIndex(TargetSongID), TargetSongID, CatSongs.VisibleSongs);
+    else
+      begin
+        ScreenSong.Interaction := TargetSongID;
+        ScreenSong.FixSelected;
+      end;
+    end;
+  end;
+
+  if (TargetSongID = -1) then
+    ScreenSong.FixSelected;
 
   //Play correct Music
   //ScreenSong.ChangeMusic;
-
 end;
 
 {**

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -319,6 +319,7 @@ type
       procedure ParseInputNextVertical(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean);
       procedure ParseInputPrevVertical(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean);
 
+        procedure ResetRandomSongState;
       procedure ResetScrollList;
   end;
 
@@ -420,6 +421,14 @@ begin
   Text[TextCat].Text := Theme.Song.TextCat.Text;
 end;
 //Show Cat in Top Left Mod End
+
+procedure TScreenSong.ResetRandomSongState;
+begin
+  SetLength(RandomSongOrder, 0);
+  SetLength(RandomSearchOrder, 0);
+  NextRandomSongIdx := High(cardinal);
+  NextRandomSearchIdx := High(cardinal);
+end;
 
 procedure TScreenSong.ResetScrollList();
 begin
@@ -1148,15 +1157,18 @@ begin
               //Show Cat in Top Left Mod
               HideCatTL;
 
+              ChessboardMinLine := MainChessboardMinLine;
+              ListMinLine := MainListMinLine;
+
               //Show Wrong Song when Tabs on Fix
               if (Fix) then
               begin
                 SelectNext;
-                FixSelected;
+                if (TSongMenuMode(Ini.SongMenu) in [smChessboard, smList]) then
+                  SkipTo(CatSongs.VisibleIndex(Interaction), Interaction, CatSongs.VisibleSongs)
+                else
+                  FixSelected;
               end;
-
-              ChessboardMinLine := MainChessboardMinLine;
-              ListMinLine := MainListMinLine;
             end
             else
             begin
@@ -1172,12 +1184,18 @@ begin
                 HideCatTL;
                 Interaction := 0;
 
+                ChessboardMinLine := MainChessboardMinLine;
+                ListMinLine := MainListMinLine;
+
                 PlaylistMan.UnsetPlaylist;
 
                 //Show Wrong Song when Tabs on Fix
                 SelectNext;
                 SelectPrev;
-                FixSelected;
+                if (TSongMenuMode(Ini.SongMenu) in [smChessboard, smList]) then
+                  SkipTo(CatSongs.VisibleIndex(Interaction), Interaction, CatSongs.VisibleSongs)
+                else
+                  FixSelected;
               end
               else
               begin
@@ -3029,6 +3047,9 @@ begin
 end;
 
 procedure TScreenSong.OnShowFinish;
+var
+  I: Integer;
+  NextSongID: Integer;
 begin
   DuetChange := false;
   RapToFreestyle := false;
@@ -3039,7 +3060,32 @@ begin
   if (PlaylistMan.CurPlayList <> -1) then
   begin
     if PlaylistMan.ReloadPlayList(PlaylistMan.CurPlayList) then
-      PlaylistMan.SetPlayList(PlaylistMan.CurPlayList, SongIndex);
+    begin
+      if PlaylistMan.Playlists[PlaylistMan.CurPlayList].FixedOrder then
+      begin
+        NextSongID := SongIndex;
+
+        if (SongIndex <> -1) then
+        begin
+          I := PlaylistMan.GetIndexbySongID(SongIndex);
+          if (I <> -1) then
+          begin
+            repeat
+              Inc(I);
+              if (I > High(PlaylistMan.Playlists[PlaylistMan.CurPlayList].Items)) then
+                I := 0;
+
+              NextSongID := PlaylistMan.Playlists[PlaylistMan.CurPlayList].Items[I].SongID;
+            until (NextSongID <> SongIndex) or
+                  (Length(PlaylistMan.Playlists[PlaylistMan.CurPlayList].Items) <= 1);
+          end;
+        end;
+        end
+      else
+        NextSongID := -1;
+
+      PlaylistMan.SetPlayList(PlaylistMan.CurPlayList, NextSongID);
+    end;
   end;
 
   FilterDuetsInPartyMode; // in party mode

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -3007,17 +3007,7 @@ begin
       end;
   end;
 
-  //Playlist Mode
-  if not(Mode = smPartyClassic) then
-  begin
-    //If Playlist Shown -> Select Next automatically
-    if not(Mode = smPartyFree) and (CatSongs.CatNumShow = -3) then
-    begin
-      SelectNext;
-    end;
-  end
-  //Party Mode
-  else
+  if (Mode = smPartyClassic) then
   begin
     if (Ini.PartyPopup = 1) then
     begin
@@ -3035,7 +3025,6 @@ end;
 
 procedure TScreenSong.OnShowFinish;
 var
-  I: Integer;
   NextSongID: Integer;
 begin
   DuetChange := false;
@@ -3048,28 +3037,11 @@ begin
   begin
     if PlaylistMan.ReloadPlayList(PlaylistMan.CurPlayList) then
     begin
-      if PlaylistMan.Playlists[PlaylistMan.CurPlayList].FixedOrder then
-      begin
-        NextSongID := SongIndex;
-
-        if (SongIndex <> -1) then
-        begin
-          I := PlaylistMan.GetIndexbySongID(SongIndex);
-          if (I <> -1) then
-          begin
-            repeat
-              Inc(I);
-              if (I > High(PlaylistMan.Playlists[PlaylistMan.CurPlayList].Items)) then
-                I := 0;
-
-              NextSongID := PlaylistMan.Playlists[PlaylistMan.CurPlayList].Items[I].SongID;
-            until (NextSongID <> SongIndex) or
-                  (Length(PlaylistMan.Playlists[PlaylistMan.CurPlayList].Items) <= 1);
-          end;
-        end;
-        end
-      else
-        NextSongID := -1;
+      NextSongID := SongIndex;
+      if (NextSongID = -1) then
+        NextSongID := CatSongs.Selected;
+      if (NextSongID = -1) then
+        NextSongID := Interaction;
 
       PlaylistMan.SetPlayList(PlaylistMan.CurPlayList, NextSongID);
     end;
@@ -3760,8 +3732,8 @@ end;
 procedure TScreenSong.SkipTo(Target: cardinal; TargetInteraction: integer = -1; VS: integer = -1);
 var
   i: integer;
-  MaxLine: real;
-  ChessboardLine: real;
+  MaxLine: integer;
+  TargetLine: integer;
 begin
   if (TSongMenuMode(Ini.SongMenu) = smRoulette) then
   begin
@@ -3797,22 +3769,29 @@ begin
     Interaction := TargetInteraction;
     SongTarget := Interaction;
 
-    if not (Button[Interaction].Visible) then
+    if (VS > 0) and (Theme.Song.Cover.Cols > 0) and (Theme.Song.Cover.Rows > 0) then
     begin
       i := CatSongs.VisibleIndex(Interaction);
-      ChessboardMinLine := Trunc(i / Theme.Song.Cover.Cols) - (Theme.Song.Cover.Rows - 1);
 
-      if (ChessboardMinLine < 0) then
+      MaxLine := 0;
+      if (VS > Theme.Song.Cover.Cols * Theme.Song.Cover.Rows) then
+        MaxLine := (VS - Theme.Song.Cover.Cols * Theme.Song.Cover.Rows + Theme.Song.Cover.Cols - 1) div Theme.Song.Cover.Cols;
+
+      if ChessboardMinLine < 0 then
         ChessboardMinLine := 0;
+      if ChessboardMinLine > MaxLine then
+        ChessboardMinLine := MaxLine;
 
-      MaxLine := (VS - Theme.Song.Cover.Cols * Theme.Song.Cover.Rows) / Theme.Song.Cover.Cols;
-      if (Frac(Maxline) > 0) then
-        MaxLine := Round(MaxLine) + 1
-      else
-        MaxLine := Round(MaxLine);
+      TargetLine := i div Theme.Song.Cover.Cols;
+      if TargetLine < ChessboardMinLine then
+        ChessboardMinLine := TargetLine
+      else if TargetLine >= ChessboardMinLine + Theme.Song.Cover.Rows then
+        ChessboardMinLine := TargetLine - Theme.Song.Cover.Rows + 1;
 
-      if (ChessboardMinLine > Round(MaxLine)) then
-        ChessboardMinLine := Round(MaxLine);
+      if ChessboardMinLine < 0 then
+        ChessboardMinLine := 0;
+      if ChessboardMinLine > MaxLine then
+        ChessboardMinLine := MaxLine;
     end;
 
     FixSelected;
@@ -3824,20 +3803,28 @@ begin
     Interaction := TargetInteraction;
     SongTarget := Interaction;
 
-    if not (Button[Interaction].Visible) then
+    if (VS > 0) and (Theme.Song.ListCover.Rows > 0) then
     begin
       i := CatSongs.VisibleIndex(Interaction);
-      if i > ListMinLine then
-        ListMinLine := i - Theme.Song.ListCover.Rows + 1
-      else
-        ListMinLine := i;
 
-      i := VS - Theme.Song.ListCover.Rows;
-      if (ListMinLine > i) then
-        ListMinLine := i;
+      MaxLine := VS - Theme.Song.ListCover.Rows;
+      if MaxLine < 0 then
+        MaxLine := 0;
 
       if ListMinLine < 0 then
         ListMinLine := 0;
+      if ListMinLine > MaxLine then
+        ListMinLine := MaxLine;
+
+      if i < ListMinLine then
+        ListMinLine := i
+      else if i >= ListMinLine + Theme.Song.ListCover.Rows then
+        ListMinLine := i - Theme.Song.ListCover.Rows + 1;
+
+      if ListMinLine < 0 then
+        ListMinLine := 0;
+      if ListMinLine > MaxLine then
+        ListMinLine := MaxLine;
     end;
 
     FixSelected;

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -320,6 +320,7 @@ type
       procedure ParseInputNextVertical(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean);
       procedure ParseInputPrevVertical(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean);
 
+        procedure ResetRandomSongState;
       procedure ResetScrollList;
   end;
 
@@ -444,6 +445,14 @@ begin
   Text[TextCat].Text := Theme.Song.TextCat.Text;
 end;
 //Show Cat in Top Left Mod End
+
+procedure TScreenSong.ResetRandomSongState;
+begin
+  SetLength(RandomSongOrder, 0);
+  SetLength(RandomSearchOrder, 0);
+  NextRandomSongIdx := High(cardinal);
+  NextRandomSearchIdx := High(cardinal);
+end;
 
 procedure TScreenSong.ResetScrollList();
 begin
@@ -1172,15 +1181,18 @@ begin
               //Show Cat in Top Left Mod
               HideCatTL;
 
+              ChessboardMinLine := MainChessboardMinLine;
+              ListMinLine := MainListMinLine;
+
               //Show Wrong Song when Tabs on Fix
               if (Fix) then
               begin
                 SelectNext;
-                FixSelected;
+                if (TSongMenuMode(Ini.SongMenu) in [smChessboard, smList]) then
+                  SkipTo(CatSongs.VisibleIndex(Interaction), Interaction, CatSongs.VisibleSongs)
+                else
+                  FixSelected;
               end;
-
-              ChessboardMinLine := MainChessboardMinLine;
-              ListMinLine := MainListMinLine;
             end
             else
             begin
@@ -1196,12 +1208,18 @@ begin
                 HideCatTL;
                 Interaction := 0;
 
+                ChessboardMinLine := MainChessboardMinLine;
+                ListMinLine := MainListMinLine;
+
                 PlaylistMan.UnsetPlaylist;
 
                 //Show Wrong Song when Tabs on Fix
                 SelectNext;
                 SelectPrev;
-                FixSelected;
+                if (TSongMenuMode(Ini.SongMenu) in [smChessboard, smList]) then
+                  SkipTo(CatSongs.VisibleIndex(Interaction), Interaction, CatSongs.VisibleSongs)
+                else
+                  FixSelected;
               end
               else
               begin
@@ -3016,6 +3034,9 @@ begin
 end;
 
 procedure TScreenSong.OnShowFinish;
+var
+  I: Integer;
+  NextSongID: Integer;
 begin
   DuetChange := false;
   RapToFreestyle := false;
@@ -3026,7 +3047,32 @@ begin
   if (PlaylistMan.CurPlayList <> -1) then
   begin
     if PlaylistMan.ReloadPlayList(PlaylistMan.CurPlayList) then
-      PlaylistMan.SetPlayList(PlaylistMan.CurPlayList, SongIndex);
+    begin
+      if PlaylistMan.Playlists[PlaylistMan.CurPlayList].FixedOrder then
+      begin
+        NextSongID := SongIndex;
+
+        if (SongIndex <> -1) then
+        begin
+          I := PlaylistMan.GetIndexbySongID(SongIndex);
+          if (I <> -1) then
+          begin
+            repeat
+              Inc(I);
+              if (I > High(PlaylistMan.Playlists[PlaylistMan.CurPlayList].Items)) then
+                I := 0;
+
+              NextSongID := PlaylistMan.Playlists[PlaylistMan.CurPlayList].Items[I].SongID;
+            until (NextSongID <> SongIndex) or
+                  (Length(PlaylistMan.Playlists[PlaylistMan.CurPlayList].Items) <= 1);
+          end;
+        end;
+        end
+      else
+        NextSongID := -1;
+
+      PlaylistMan.SetPlayList(PlaylistMan.CurPlayList, NextSongID);
+    end;
   end;
 
   FilterDuetsInPartyMode; // in party mode

--- a/src/screens/UScreenSongMenu.pas
+++ b/src/screens/UScreenSongMenu.pas
@@ -1053,7 +1053,6 @@ begin
               PlaylistMan.ReloadPlaylist(SelectValue3);
               PlaylistMan.SetPlayList(SelectValue3);
               Visible := false;
-              ScreenSong.SelectNext(false);
               ScreenSong.SetScrollRefresh;
             end;
         end;


### PR DESCRIPTION
This PR fixes several playlist navigation bugs: When loading or leaving playlists, selection and scroll state could get out of sync. Fixed-order and non-fixed-order playlists also shared some state in ways that produced wrong start positions or unexpected behavior.

Bugs Fixed
- Loading a playlist could advance one extra song immediately, which could skip the intended first selection to song 2, so for a fixed-order playlist it could start on the wrong song instead of the first valid playlist entry.
- Leaving a playlist could keep the selected song outside the visible scroll window.
- Non-ordered playlists could reopen on a remembered deterministic song order instead of behaving like a fresh non-ordered playlist. Especially pressing R after opening a playlist could reuse stale cached random order and produce the same sequence repeatedly.
- Opening a non-ordered playlist could always start from the first listed playlist entry rather than a random visible playlist song.

What Changed
- Removed the extra manual advance after playlist load in UScreenSongMenu.pas:1053 - not sure why I added it before, that was also to fix something...
- Reworked playlist activation in UPlaylist.pas:342 so it selects a concrete target song directly instead of walking selection with repeated next-song calls.
- For fixed-order playlists, activation still respects ordered progression but for non-fixed playlists opened without an explicit target song, the initial selection is now a random playlist song.
- Playlist activation now resets cached random-song state
- Leaving playlist mode in now restores the previous main scroll window first and then ensures the selected song is actually visible.