### PR TITLE
Fix invisible/overlapping buttons on statistics detail screens

### DIFF
--- a/game/themes/Modern.ini
+++ b/game/themes/Modern.ini
@@ -4341,6 +4341,7 @@ Text = STAT_PREV
 
 [StatDetailButtonReverse]
 Inherits = StatMainButtonScores
+Y = 220
 
 [StatDetailButtonReverseText1]
 Inherits = StatMainButtonScoresText1
@@ -4348,6 +4349,7 @@ Text = STAT_REVERSE
 
 [StatDetailButtonExit]
 Inherits = StatMainButtonScores
+Y = 280
 
 [StatDetailButtonExitText1]
 Inherits = StatMainButtonScoresText1


### PR DESCRIPTION
Issue reported in #1240 by @justuslethen:

This fixes the layout of the statistics detail screens so all four action buttons are visible and usable with both mouse and keyboard.

Affected screens:
- HighScores
- Best Singers
- Most Popular Songs
- Most Popular Bands

Root Cause
- The issue was caused by overlapping theme definitions in Modern.ini for the statistics detail screen. StatDetailButtonReverse and StatDetailButtonExit inherited the same base position as StatDetailButtonNext without overriding their Y position.

Result
- keyboard navigation still worked, because the screen logic iterates through all button interactions
- mouse hover and click did not work correctly for the overlapped buttons, because hit-testing used the shared on-screen rectangle

Fix
- Assigned distinct vertical positions to the missing buttons in the statistics detail theme layout:

Reverse: Y = 220
Exit: Y = 280

This restores the intended four-button vertical stack and makes all actions visible and mouse-accessible again.
Looks like it did before the recent theme changes now.