### PR TITLE
Refactor scoring in preparation to move away from round-to-multiple-of-10

### DIFF
--- a/src/base/UNote.pas
+++ b/src/base/UNote.pas
@@ -63,6 +63,20 @@ type
 
   PPLayer = ^TPlayer;
   TPlayer = record
+  private
+    _Score:       real;
+    _ScoreLine:   real;
+    _ScoreGolden: real;
+    _ScoreInt:       integer;
+    _ScoreLineInt:   integer;
+    _ScoreGoldenInt: integer;
+    _ScoreTotalInt:  integer;
+    procedure SetScore(newScore: real);
+    procedure SetScoreLine(newScoreLine: real);
+    procedure SetScoreGolden(newScoreGolden: real);
+    procedure UpdateIntScores;
+
+  public
     Name:           UTF8String;
     // Level === Difficulty, both terms appear to be used
     Level:          integer;
@@ -70,16 +84,6 @@ type
     // Index in Teaminfo record
     TeamID:         byte;
     PlayerID:       byte;
-
-    // Scores
-    Score:          real;
-    ScoreLine:      real;
-    ScoreGolden:    real;
-
-    ScoreInt:       integer;
-    ScoreLineInt:   integer;
-    ScoreGoldenInt: integer;
-    ScoreTotalInt:  integer;
 
     // LineBonus
     ScoreLast:      real;    // Last Line Score
@@ -90,6 +94,17 @@ type
     HighNote:       integer; // index of last note (= High(Note)?)
     LengthNote:     integer; // number of notes (= Length(Note)?).
     Note:           array of TPlayerNote;
+
+    // Scores
+    property Score:       real read _Score write SetScore;
+    property ScoreLine:   real read _ScoreLine write SetScoreLine;
+    property ScoreGolden: real read _ScoreGolden write SetScoreGolden;
+
+    property ScoreInt:       integer read _ScoreInt;
+    property ScoreLineInt:   integer read _ScoreLineInt;
+    property ScoreGoldenInt: integer read _ScoreGoldenInt;
+    property ScoreTotalInt:  integer read _ScoreTotalInt;
+    procedure ResetScores;
   end;
 
   TStats = record
@@ -164,6 +179,57 @@ uses
   USkins,
   USongs,
   UThemes;
+
+procedure TPlayer.SetScore(newScore: real);
+begin
+  _Score := newScore;
+  UpdateIntScores;
+end;
+procedure TPlayer.SetScoreLine(newScoreLine: real);
+begin
+  _ScoreLine := newScoreLine;
+  UpdateIntScores;
+end;
+procedure TPlayer.SetScoreGolden(newScoreGolden: real);
+begin
+  _ScoreGolden := newScoreGolden;
+  UpdateIntScores;
+end;
+procedure TPlayer.UpdateIntScores();
+begin
+  // a problem if we use floor instead of round is that a score of
+  // 10000 points is only possible if the last digit of the total points
+  // for golden and normal notes is 0.
+  // if we use round, the max score is 10000 for most songs
+  // but a score of 10010 is possible if the last digit of the total
+  // points for golden and normal notes is 5
+  // the best solution is to use round for one of these scores
+  // and round the other score in the opposite direction
+  // so we assure that the highest possible score is 10000 in every case.
+  _ScoreInt := round(Score / 10) * 10;
+  if (_ScoreInt < Score) then
+    //normal score is floored so we have to ceil golden notes score
+    _ScoreGoldenInt := ceil(ScoreGolden / 10) * 10
+  else
+    //normal score is ceiled so we have to floor golden notes score
+    _ScoreGoldenInt := floor(ScoreGolden / 10) * 10;
+
+  // line bonus
+  _ScoreLineInt := Floor(Round(ScoreLine) / 10) * 10;
+
+  // total score
+  _ScoreTotalInt := ScoreInt + ScoreGoldenInt + ScoreLineInt;
+end;
+procedure TPlayer.ResetScores();
+begin
+  _Score := 0;
+  _ScoreLine := 0;
+  _ScoreGolden := 0;
+  _ScoreInt := 0;
+  _ScoreLineInt := 0;
+  _ScoreGoldenInt := 0;
+  _ScoreTotalInt := 0;
+end;
 
 function GetTimeForBeats(BPM, Beats: real): real;
 begin
@@ -518,29 +584,6 @@ begin
                   ntRap:       CurrentPlayer.Score       := CurrentPlayer.Score       + CurNotePoints;
                   ntRapGolden: CurrentPlayer.ScoreGolden := CurrentPlayer.ScoreGolden + CurNotePoints;
                 end;
-
-                // a problem if we use floor instead of round is that a score of
-                // 10000 points is only possible if the last digit of the total points
-                // for golden and normal notes is 0.
-                // if we use round, the max score is 10000 for most songs
-                // but a score of 10010 is possible if the last digit of the total
-                // points for golden and normal notes is 5
-                // the best solution is to use round for one of these scores
-                // and round the other score in the opposite direction
-                // so we assure that the highest possible score is 10000 in every case.
-                CurrentPlayer.ScoreInt := round(CurrentPlayer.Score / 10) * 10;
-
-                if (CurrentPlayer.ScoreInt < CurrentPlayer.Score) then
-                  //normal score is floored so we have to ceil golden notes score
-                  CurrentPlayer.ScoreGoldenInt := ceil(CurrentPlayer.ScoreGolden / 10) * 10
-                else
-                  //normal score is ceiled so we have to floor golden notes score
-                  CurrentPlayer.ScoreGoldenInt := floor(CurrentPlayer.ScoreGolden / 10) * 10;
-
-
-                CurrentPlayer.ScoreTotalInt := CurrentPlayer.ScoreInt +
-                                               CurrentPlayer.ScoreGoldenInt +
-                                               CurrentPlayer.ScoreLineInt;
               end;
             end; // operation
           end; // for

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -1922,7 +1922,7 @@ begin
       for IndexUser := 0 to High(DataBase.NetworkUser[IndexWeb].Userlist) do
       begin
         Send := false;
-        TotalScore := player[PlayerIndex - 1].ScoreInt + player[PlayerIndex - 1].ScoreLineInt + player[PlayerIndex - 1].ScoreGoldenInt;
+        TotalScore := player[PlayerIndex - 1].ScoreTotalInt;
 
         case (Act_Level) of
           0: if (TotalScore >= DataBase.NetworkUser[IndexWeb].UserList[IndexUser].AutoScoreEasy)
@@ -1988,7 +1988,7 @@ begin
       for IndexUser := 0 to High(DataBase.NetworkUser[IndexWeb].Userlist) do
       begin
         Save := false;
-        TotalScore := player[PlayerIndex - 1].ScoreInt + player[PlayerIndex - 1].ScoreLineInt + player[PlayerIndex - 1].ScoreGoldenInt;
+        TotalScore := player[PlayerIndex - 1].ScoreTotalInt;
 
         case (Act_Level) of
           0: if (TotalScore >= DataBase.NetworkUser[IndexWeb].UserList[IndexUser].AutoScoreEasy)

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -264,14 +264,7 @@ begin
         for i1 := 0 to High(Player) do
         with Player[i1] do
         begin
-          Score          := 0;
-          ScoreLine      := 0;
-          ScoreGolden    := 0;
-
-          ScoreInt       := 0;
-          ScoreLineInt   := 0;
-          ScoreGoldenInt := 0;
-          ScoreTotalInt  := 0;
+          ResetScores;
 
           ScoreLast      := 0;
 
@@ -586,14 +579,7 @@ begin
         for i1 := 0 to High(Player) do
         with Player[i1] do
         begin
-          Score          := 0;
-          ScoreLine      := 0;
-          ScoreGolden    := 0;
-
-          ScoreInt       := 0;
-          ScoreLineInt   := 0;
-          ScoreGoldenInt := 0;
-          ScoreTotalInt  := 0;
+          ResetScores;
 
           ScoreLast      := 0;
 
@@ -877,14 +863,7 @@ begin
   for PlayerIndex := 0 to High(Player) do
     with Player[PlayerIndex] do
     begin
-      Score          := 0;
-      ScoreLine      := 0;
-      ScoreGolden    := 0;
-
-      ScoreInt       := 0;
-      ScoreLineInt   := 0;
-      ScoreGoldenInt := 0;
-      ScoreTotalInt  := 0;
+      ResetScores;
 
       ScoreLast      := 0;
 
@@ -1668,22 +1647,6 @@ begin
             PlaylistMedley.Stats[len].Player[I].ScoreGolden :=
               PlaylistMedley.Stats[len].Player[I].ScoreGolden +
               PlaylistMedley.Stats[J].Player[I].ScoreGolden;
-
-            PlaylistMedley.Stats[len].Player[I].ScoreInt :=
-              PlaylistMedley.Stats[len].Player[I].ScoreInt +
-              PlaylistMedley.Stats[J].Player[I].ScoreInt;
-
-            PlaylistMedley.Stats[len].Player[I].ScoreLineInt :=
-              PlaylistMedley.Stats[len].Player[I].ScoreLineInt +
-              PlaylistMedley.Stats[J].Player[I].ScoreLineInt;
-
-            PlaylistMedley.Stats[len].Player[I].ScoreGoldenInt :=
-              PlaylistMedley.Stats[len].Player[I].ScoreGoldenInt +
-              PlaylistMedley.Stats[J].Player[I].ScoreGoldenInt;
-
-            PlaylistMedley.Stats[len].Player[I].ScoreTotalInt :=
-              PlaylistMedley.Stats[len].Player[I].ScoreTotalInt +
-              PlaylistMedley.Stats[J].Player[I].ScoreTotalInt;
           end; //of for I
         end; //of for J
 
@@ -1698,18 +1661,6 @@ begin
 
           PlaylistMedley.Stats[len].Player[I].ScoreGolden := round(
             PlaylistMedley.Stats[len].Player[I].ScoreGolden / len);
-
-          PlaylistMedley.Stats[len].Player[I].ScoreInt := round(
-            PlaylistMedley.Stats[len].Player[I].ScoreInt / len);
-
-          PlaylistMedley.Stats[len].Player[I].ScoreLineInt := round(
-            PlaylistMedley.Stats[len].Player[I].ScoreLineInt / len);
-
-          PlaylistMedley.Stats[len].Player[I].ScoreGoldenInt := round(
-            PlaylistMedley.Stats[len].Player[I].ScoreGoldenInt / len);
-
-          PlaylistMedley.Stats[len].Player[I].ScoreTotalInt := round(
-            PlaylistMedley.Stats[len].Player[I].ScoreTotalInt / len);
         end;
 
         Party.CallAfterSing;
@@ -1796,12 +1747,6 @@ begin
       // apply line-bonus
       CurrentPlayer.ScoreLine :=
         CurrentPlayer.ScoreLine + LineBonus * LinePerfection;
-      CurrentPlayer.ScoreLineInt := Floor(Round(CurrentPlayer.ScoreLine) / 10) * 10;
-      // update total score
-      CurrentPlayer.ScoreTotalInt :=
-        CurrentPlayer.ScoreInt +
-        CurrentPlayer.ScoreGoldenInt
-        + CurrentPlayer.ScoreLineInt;
 
       // spawn rating pop-up
       Rating := Round(LinePerfection * MAX_LINE_RATING);


### PR DESCRIPTION
This moves all the score rounding stuff (where it goes from `real` to a bunch of `integer`) to a single place, with some extra fluff in the form of just using `ScoreTotalnt` when autosaving/sending scores, and a `ResetScores` method instead of resetting 7 fields manually.

I _think_ this does change how medleys are scored a bit? But then you look at medley scoring as a whole and... it was always rounding the reals? And it was never doing any of this round-to-multiple-of-10 for the int parts? But however this PR changes medley scoring*, the _next_ PR will move away from this round-to-multiple-of-10 entirely, so that'll probably also revert whatever this changes on the int rounding front. Medleys aren't saved anyway.

\* = if someone can confirm that medley scoring still somewhat works that would be great, because I have no idea how they're even _supposed_ to work in the first place.