### PR TITLE
Prevent duplicate score saves on the Top 5 screen

### DIFF
--- a/src/base/UDataBase.pas
+++ b/src/base/UDataBase.pas
@@ -634,7 +634,7 @@ begin
   if not Assigned(ScoreDB) then
     Exit;
 
-  // Prevent 0 Scores from being added EDIT: ==> UScreenTop5.pas!
+  // Prevent 0 scores from being added. Callers are expected to filter these.
   //if (Score <= 0) then
   //  Exit;
 

--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -174,6 +174,7 @@ type
 
       procedure RefreshTexts;
       procedure ResetScores;
+      procedure SaveLocalScores;
 
       procedure StartPreview;
       procedure StartVoice;
@@ -1342,10 +1343,34 @@ begin
   BarTime := SDL_GetTicks();
 end;
 
+procedure TScreenScore.SaveLocalScores;
+var
+  I: integer;
+  Sung: boolean;
+begin
+  if (ScreenSong.Mode <> smNormal) or ScreenSing.SungPaused or (not ScreenSing.SungToEnd) then
+    Exit;
+
+  Sung := false;
+  for I := 0 to PlayersPlay - 1 do
+  begin
+    if Round(Player[I].ScoreTotalInt) > 0 then
+    begin
+      DataBase.AddScore(CurrentSong, Player[I].Level, Player[I].Name, Round(Player[I].ScoreTotalInt));
+      Sung := true;
+    end;
+  end;
+
+  if Sung then
+    DataBase.WriteScore(CurrentSong);
+end;
+
 procedure TScreenScore.onShowFinish;
 var
   index: integer;
 begin
+  SaveLocalScores;
+
   for index := 1 to (PlayersPlay) do
   begin
     TextScore_ActualValue[index]  := 0;

--- a/src/screens/UScreenTop5.pas
+++ b/src/screens/UScreenTop5.pas
@@ -177,7 +177,6 @@ end;
 procedure TScreenTop5.OnShow;
 var
   I:    integer;
-  sung: boolean; //score added? otherwise in wasn't sung!
   Report: string;
 begin
   inherited;
@@ -185,31 +184,15 @@ begin
   if not Help.SetHelpID(ID) then
     Log.LogWarn('No Entry for Help-ID ' + ID, 'ScreenTop5');
 
-  sung := false;
   Fadeout := false;
   DifficultyShow := Player[0].Level;
 
-  //ReadScore(CurrentSong);
-
-  for I := 0 to PlayersPlay - 1 do
-  begin
-    if (Round(Player[I].ScoreTotalInt) > 0) and (ScreenSing.SungToEnd) then
-    begin
-      DataBase.AddScore(CurrentSong, Player[I].Level, Player[I].Name, Round(Player[I].ScoreTotalInt));
-      sung:=true;
-    end;
-  end;
-
   try
-    if sung then
-    begin
-       DataBase.WriteScore(CurrentSong);
-    end;
     DataBase.ReadScore(CurrentSong);
   except
     on E : Exception do
     begin
-      Report := 'Writing or reading songscore failed in Top-5-creen. Faulty database file?' + LineEnding +
+      Report := 'Reading songscore failed in Top-5-screen. Faulty database file?' + LineEnding +
       'Stacktrace:' + LineEnding;
       if E <> nil then
       begin

--- a/src/screens/UScreenTop5.pas
+++ b/src/screens/UScreenTop5.pas
@@ -177,7 +177,6 @@ end;
 procedure TScreenTop5.OnShow;
 var
   I:    integer;
-  sung: boolean; //score added? otherwise in wasn't sung!
   Report: string;
 begin
   inherited;
@@ -185,31 +184,15 @@ begin
   if not Help.SetHelpID(ID) then
     Log.LogWarn('No Entry for Help-ID ' + ID, 'ScreenTop5');
 
-  sung := false;
   Fadeout := false;
   DifficultyShow := Player[0].Level;
 
-  //ReadScore(CurrentSong);
-
-  for I := 0 to PlayersPlay - 1 do
-  begin
-    if (Player[I].ScoreTotalInt > 0) and (ScreenSing.SungToEnd) then
-    begin
-      DataBase.AddScore(CurrentSong, Player[I].Level, Player[I].Name, Player[I].ScoreTotalInt);
-      sung:=true;
-    end;
-  end;
-
   try
-    if sung then
-    begin
-       DataBase.WriteScore(CurrentSong);
-    end;
     DataBase.ReadScore(CurrentSong);
   except
     on E : Exception do
     begin
-      Report := 'Writing or reading songscore failed in Top-5-creen. Faulty database file?' + LineEnding +
+      Report := 'Reading songscore failed in Top-5-screen. Faulty database file?' + LineEnding +
       'Stacktrace:' + LineEnding;
       if E <> nil then
       begin

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -83,6 +83,7 @@ type
     procedure ResetLinesAndLyrics();
     procedure ClearLyricEngines();
     procedure CalculateStartTime;
+    procedure SaveLocalScores;
   public
     CheckPlayerConfigOnNextSong: boolean;
     eSongLoaded: THookableEvent; //< event is called after lyrics of a song are loaded on OnShow
@@ -1592,14 +1593,20 @@ var
   len, num: integer;
 
 begin
+  Log.LogStatus('TScreenSingController.Finish', 'TScreenSingController.Finish');
   AudioInput.CaptureStop;
   AudioPlayback.Stop;
   AudioPlayback.SetSyncSource(nil);
 
-  if (ScreenSong.Mode = smNormal) and (SungToEnd) and (Length(DllMan.Websites) > 0) then
+  if (ScreenSong.Mode = smNormal) and SungToEnd then
   begin
-    AutoSendScore;
-    AutoSaveScore;
+    SaveLocalScores;
+
+    if (Length(DllMan.Websites) > 0) then
+    begin
+      AutoSendScore;
+      AutoSaveScore;
+    end;
   end;
 
   LyricsState.Stop();
@@ -1877,6 +1884,25 @@ begin
 end;
 
 
+procedure TScreenSingController.SaveLocalScores;
+var
+  I: integer;
+  Sung: boolean;
+begin
+  Sung := false;
+  for I := 0 to PlayersPlay - 1 do
+  begin
+    if Player[I].ScoreTotalInt > 0 then
+    begin
+      DataBase.AddScore(CurrentSong, Player[I].Level, Player[I].Name, Player[I].ScoreTotalInt);
+      Sung := true;
+    end;
+  end;
+
+  if Sung then
+    DataBase.WriteScore(CurrentSong);
+end;
+
 procedure TScreenSingController.AutoSendScore;
 var
   SendInfo: TSendInfo;
@@ -2014,4 +2040,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
Addresses the bug reported in #1247 

In multiscreen mode, the Top 5 screen could run its show logic multiple times, which caused the same song results to be written to the database more than once.

This change saves local highscores when leaving the sing screen and the song has been sung to end. The top 5 screen then is read-only now and avoids database writes.