### PR TITLE
Improve theme and skin inheritance handling

### DIFF
--- a/src/base/USkins.pas
+++ b/src/base/USkins.pas
@@ -41,6 +41,7 @@ type
   TSkinTexture = record
     Name:     string;
     FileName: IPath;
+    Path:     IPath;
   end;
 
   TSkinEntry = record
@@ -58,6 +59,9 @@ type
     SkinTexture: array of TSkinTexture;
     SkinPath:    IPath;
     Color:       integer;
+    procedure LoadDefaultSkinForTheme(const ThemeName: string; Depth: integer);
+    procedure LoadSkinTextures(const SkinEntry: TSkinEntry; UseAsBasePath: boolean);
+    procedure SetTextureEntry(const TextureName: string; const FileName: IPath; const TexturePath: IPath);
     constructor Create;
     procedure LoadList;
     procedure ParseDir(Dir: IPath);
@@ -85,8 +89,12 @@ uses
   UIni,
   ULog,
   UMain,
+  UThemes,
   UPathUtils,
   UFileSystem;
+
+const
+  MAX_SKIN_INHERITANCE = 10;
 
 constructor TSkin.Create;
 begin
@@ -143,30 +151,99 @@ begin
   SkinIni.Free;
 end;
 
-procedure TSkin.LoadSkin(Name, Theme: string);
+procedure TSkin.SetTextureEntry(const TextureName: string; const FileName: IPath; const TexturePath: IPath);
+var
+  T: integer;
+  CleanTextureName: string;
+begin
+  CleanTextureName := Trim(TextureName);
+
+  for T := 0 to High(SkinTexture) do
+  begin
+    if CompareText(SkinTexture[T].Name, CleanTextureName) = 0 then
+    begin
+      if FileName.IsSet and (not TexturePath.Append(FileName).IsFile) then
+        Exit;
+      SkinTexture[T].FileName := FileName;
+      SkinTexture[T].Path := TexturePath;
+      Exit;
+    end;
+  end;
+
+  T := Length(SkinTexture);
+  SetLength(SkinTexture, T + 1);
+  SkinTexture[T].Name := CleanTextureName;
+  SkinTexture[T].FileName := FileName;
+  SkinTexture[T].Path := TexturePath;
+end;
+
+procedure TSkin.LoadSkinTextures(const SkinEntry: TSkinEntry; UseAsBasePath: boolean);
 var
   SkinIni: TMemIniFile;
-  SL:      TStringList;
-  T:       integer;
-  S:       integer;
+  SL: TStringList;
+  T: integer;
 begin
-  S        := GetSkinNumber(Name, Theme);
-  SkinPath := Skin[S].Path;
+  if UseAsBasePath then
+    SkinPath := SkinEntry.Path;
 
-  SkinIni  := TMemIniFile.Create(SkinPath.Append(Skin[S].FileName).ToNative);
-
+  SkinIni := TMemIniFile.Create(SkinEntry.Path.Append(SkinEntry.FileName).ToNative);
   SL := TStringList.Create;
   SkinIni.ReadSection('Textures', SL);
 
-  SetLength(SkinTexture, SL.Count);
-  for T := 0 to SL.Count-1 do
-  begin
-    SkinTexture[T].Name     := SL.Strings[T];
-    SkinTexture[T].FileName := Path(SkinIni.ReadString('Textures', SL.Strings[T], ''));
-  end;
+  for T := 0 to SL.Count - 1 do
+    SetTextureEntry(SL.Strings[T], Path(SkinIni.ReadString('Textures', SL.Strings[T], '')), SkinEntry.Path);
 
   SL.Free;
   SkinIni.Free;
+end;
+
+procedure TSkin.LoadDefaultSkinForTheme(const ThemeName: string; Depth: integer);
+var
+  ThemeIndex: integer;
+  DefaultSkinIndex: integer;
+  I: integer;
+  ThemeSkins: TUTF8StringDynArray;
+begin
+  if (ThemeName = '') or (Depth >= MAX_SKIN_INHERITANCE) then
+    Exit;
+
+  ThemeIndex := -1;
+  for I := Low(UThemes.Theme.Themes) to High(UThemes.Theme.Themes) do
+  begin
+    if CompareText(UThemes.Theme.Themes[I].Name, ThemeName) = 0 then
+    begin
+      ThemeIndex := I;
+      Break;
+    end;
+  end;
+
+  if (ThemeIndex >= 0) and (UThemes.Theme.Themes[ThemeIndex].DefaultSkin >= 0) and
+     (UThemes.Theme.Themes[ThemeIndex].DefaultSkin < Length(ISkin)) then
+  begin
+    LoadDefaultSkinForTheme(UThemes.Theme.Themes[ThemeIndex].BaseTheme, Depth + 1);
+
+    GetSkinsByTheme(ThemeName, ThemeSkins);
+    if UThemes.Theme.Themes[ThemeIndex].DefaultSkin < Length(ThemeSkins) then
+    begin
+      DefaultSkinIndex := GetSkinNumber(ThemeSkins[UThemes.Theme.Themes[ThemeIndex].DefaultSkin], ThemeName);
+      LoadSkinTextures(Skin[DefaultSkinIndex], Length(SkinTexture) = 0);
+    end;
+  end;
+end;
+
+procedure TSkin.LoadSkin(Name, Theme: string);
+var
+  SelectedSkinIndex: integer;
+begin
+  SelectedSkinIndex := GetSkinNumber(Name, Theme);
+  SetLength(SkinTexture, 0);
+
+  LoadDefaultSkinForTheme(Theme, 0);
+
+  if Length(SkinTexture) = 0 then
+    SkinPath := Skin[SelectedSkinIndex].Path;
+
+  LoadSkinTextures(Skin[SelectedSkinIndex], Length(SkinTexture) = 0);
 end;
 
 function TSkin.GetTextureFileName(TextureName: string): IPath;
@@ -177,10 +254,10 @@ begin
   
   for T := 0 to High(SkinTexture) do
   begin
-    if (SkinTexture[T].Name = TextureName) and
+    if (CompareText(SkinTexture[T].Name, Trim(TextureName)) = 0) and
        (SkinTexture[T].FileName.IsSet) then
     begin
-      Result := SkinPath.Append(SkinTexture[T].FileName);
+      Result := SkinTexture[T].Path.Append(SkinTexture[T].FileName);
     end;
   end;
 

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -1112,13 +1112,15 @@ type
   TTheme = class
   private
     ThemeIni:         TMemIniFile;
-    BaseThemeIni:     TMemIniFile;
+    BaseThemeInis:    array of TMemIniFile;
 
     LastThemeBasic:   TThemeBasic;
     procedure CreateThemeObjects();
     procedure OpenFile(ThemeNum: integer);
     procedure CloseFile;
     procedure LoadHeader(FileName: IPath);
+    function FindThemeIndex(const ThemeName: string): integer;
+    procedure AddBaseThemeChain(const ThemeName: string; Depth: integer);
     function ResolveThemeFile(SectionName: string): TMemIniFile;
     function SectionExists(const Name: string; var Enabled: boolean): boolean;
     function GetSectionList(const Name: string): TThemeSectionList;
@@ -1353,31 +1355,76 @@ begin
 end;
 
 procedure TTheme.OpenFile(ThemeNum: integer);
-var
-  I: integer;
 begin
   ThemeIni := TMemIniFile.Create(Themes[ThemeNum].FileName.ToNative);
+  SetLength(BaseThemeInis, 0);
 
   // Load base theme if declared
   if (Themes[ThemeNum].BaseTheme <> '') then
+    AddBaseThemeChain(Themes[ThemeNum].BaseTheme, 0);
+end;
+
+procedure TTheme.CloseFile;
+var
+  I: integer;
+begin
+  freeandnil(ThemeIni);
+  for I := Low(BaseThemeInis) to High(BaseThemeInis) do
+    FreeAndNil(BaseThemeInis[I]);
+  SetLength(BaseThemeInis, 0);
+end;
+
+function TTheme.FindThemeIndex(const ThemeName: string): integer;
+var
+  I: integer;
+begin
+  Result := -1;
+  for I := Low(Themes) to High(Themes) do
   begin
-    for I := Low(Themes) to High(Themes) do
+    if CompareText(ThemeName, Themes[I].Name) = 0 then
     begin
-      if (CompareText(Themes[ThemeNum].BaseTheme, Themes[I].Name) = 0) then
-      begin
-        if (Themes[I].BaseTheme <> '') then
-          Log.LogError('Multiple base themes not allowed', 'TTheme.LoadTheme');
-        BaseThemeIni := TMemIniFile.Create(Themes[I].FileName.ToNative);
-        Break;
-      end;
+      Result := I;
+      Exit;
     end;
   end;
 end;
 
-procedure TTheme.CloseFile;
+procedure TTheme.AddBaseThemeChain(const ThemeName: string; Depth: integer);
+var
+  ThemeIndex: integer;
+  BaseIndex: integer;
 begin
-  freeandnil(ThemeIni);
-  freeandnil(BaseThemeIni);
+  if ThemeName = '' then
+    Exit;
+
+  if Depth >= MAX_INHERITANCE then
+  begin
+    Log.LogError('Maximum base theme inheritance depth exceeded for theme "' + ThemeName + '"', 'TTheme.LoadTheme');
+    Exit;
+  end;
+
+  ThemeIndex := FindThemeIndex(ThemeName);
+  if ThemeIndex < 0 then
+  begin
+    Log.LogError('Base theme not found: ' + ThemeName, 'TTheme.LoadTheme');
+    Exit;
+  end;
+
+  for BaseIndex := Low(BaseThemeInis) to High(BaseThemeInis) do
+  begin
+    if CompareText(Themes[ThemeIndex].FileName.ToNative, BaseThemeInis[BaseIndex].FileName) = 0 then
+    begin
+      Log.LogError('Circular base theme inheritance detected for theme "' + ThemeName + '"', 'TTheme.LoadTheme');
+      Exit;
+    end;
+  end;
+
+  BaseIndex := Length(BaseThemeInis);
+  SetLength(BaseThemeInis, BaseIndex + 1);
+  BaseThemeInis[BaseIndex] := TMemIniFile.Create(Themes[ThemeIndex].FileName.ToNative);
+
+  if Themes[ThemeIndex].BaseTheme <> '' then
+    AddBaseThemeChain(Themes[ThemeIndex].BaseTheme, Depth + 1);
 end;
 
 procedure TTheme.LoadHeader(FileName: IPath);
@@ -2146,31 +2193,38 @@ end;
 
 // Return the the theme file that contains the desired section
 function TTheme.ResolveThemeFile(SectionName: string): TMemIniFile; inline;
+var
+  I: integer;
 begin
-  Result := ThemeIni;
-  if (BaseThemeIni = nil) then
+  if ThemeIni.SectionExists(SectionName) then
+  begin
+    Result := ThemeIni;
     Exit;
-  if (not ThemeIni.SectionExists(SectionName) and BaseThemeIni.SectionExists(SectionName)) then
-    Result := BaseThemeIni;
+  end;
+
+  for I := Low(BaseThemeInis) to High(BaseThemeInis) do
+  begin
+    if BaseThemeInis[I].SectionExists(SectionName) then
+    begin
+      Result := BaseThemeInis[I];
+      Exit;
+    end;
+  end;
+
+  Result := nil;
 end;
 
 // Determine if the section exists in the theme or in the base theme
 // If it exists, determine whethere it is enabled. This allows the user
 // to opt out of optional texts/statics in derived themes
 function TTheme.SectionExists(const Name: string; var Enabled: boolean): boolean;
+var
+  IniFile: TMemIniFile;
 begin
-  if (ThemeIni.SectionExists(Name)) then
-  begin
-    Result := True;
-    Enabled := ThemeIni.ReadBool(Name, 'Enabled', true);
-  end
-  else if ((BaseThemeIni <> nil) and BaseThemeIni.SectionExists(Name)) then
-  begin
-    Result := True;
-    Enabled := BaseThemeIni.ReadBool(Name, 'Enabled', true);
-  end
-  else
-    Result := False;
+  IniFile := ResolveThemeFile(Name);
+  Result := IniFile <> nil;
+  if Result then
+    Enabled := IniFile.ReadBool(Name, 'Enabled', true);
 end;
 
 function TTheme.GetSectionList(const Name: string): TThemeSectionList;
@@ -2180,12 +2234,10 @@ var
   NextSection: string;
 begin
   Result := nil;
-  if (ThemeIni.SectionExists(Name)) then
-    IniFile := ThemeIni
-  else if ((BaseThemeIni <> nil) and (BaseThemeIni.SectionExists(Name))) then
-    IniFile := BaseThemeIni
-  else
+  IniFile := ResolveThemeFile(Name);
+  if IniFile = nil then
     Exit;
+
   SetLength(Result, 1);
   I := 0;
   Result[I].Name := Name;
@@ -2196,11 +2248,8 @@ begin
     NextSection := Result[I].IniFile.ReadString(Result[I].Name, 'Inherits', '');
     if (NextSection = '') then
       Break;
-    if (ThemeIni.SectionExists(NextSection)) then
-      IniFile := ThemeIni
-    else if ((BaseThemeIni <> nil) and (BaseThemeIni.SectionExists(Name))) then
-      IniFile := BaseThemeIni
-    else
+    IniFile := ResolveThemeFile(NextSection);
+    if IniFile = nil then
     begin
       Log.LogError('Inherited section "' + NextSection + '" not found (from section "' + Result[I].Name + '")', 'TTheme.GetSectionList');
       Break;
@@ -2403,7 +2452,7 @@ end;
 
 procedure TTheme.ThemeLoadOptionalStatic(var ThemeStatic: TThemeStatic; const Name: string);
 begin
-  if ThemeIni.SectionExists(Name) or ((BaseThemeIni <> nil) and BaseThemeIni.SectionExists(Name)) then
+  if ResolveThemeFile(Name) <> nil then
   begin
     ThemeLoadStatic(ThemeStatic, Name);
   end;
@@ -2448,7 +2497,7 @@ end;
 
 procedure TTheme.ThemeLoadOptionalStaticRectangle(var ThemeStaticRectangle: TThemeStaticRectangle; const Name: string);
 begin
-  if ThemeIni.SectionExists(Name) or ((BaseThemeIni <> nil) and BaseThemeIni.SectionExists(Name)) then
+  if ResolveThemeFile(Name) <> nil then
   begin
     ThemeLoadStaticRectangle(ThemeStaticRectangle, Name);
   end;
@@ -2550,7 +2599,7 @@ var
   I: integer;
 begin
   I := 1;
-  while ThemeIni.SectionExists(Name + IntToStr(I)) or ((BaseThemeIni <> nil) and BaseThemeIni.SectionExists(Name + IntToStr(I))) do
+  while ResolveThemeFile(Name + IntToStr(I)) <> nil do
   begin
     SetLength(Collections, I);
     ThemeLoadButtonCollection(Collections[I-1], Name + IntToStr(I));
@@ -3817,6 +3866,12 @@ begin
   Song.Cover.Y := ReadInteger(SectionList, 'Y', 190);
   Song.Cover.W := ReadInteger(SectionList, 'W', 300);
   Song.Cover.H := ReadInteger(SectionList, 'H', 200);
+  Song.Cover.SelectX := ReadInteger(SectionList, 'SelectX', Song.Cover.X);
+  Song.Cover.SelectY := ReadInteger(SectionList, 'SelectY', Song.Cover.Y);
+  Song.Cover.SelectW := ReadInteger(SectionList, 'SelectW', Song.Cover.W);
+  Song.Cover.SelectH := ReadInteger(SectionList, 'SelectH', Song.Cover.H);
+  Song.Cover.SelectReflection := ReadBool(SectionList, 'SelectReflection', false);
+  Song.Cover.SelectReflectionSpacing := ReadInteger(SectionList, 'SelectReflectionSpacing', 0);
 
   // Song menu modes: 0 - roulette, 1 - chessboard, 2 - list
   
@@ -3825,12 +3880,6 @@ begin
     Song.Cover.Rows := ReadInteger(SectionList, 'Rows', 4);
     Song.Cover.Cols := ReadInteger(SectionList, 'Cols', 4);
     Song.Cover.Padding := ReadInteger(SectionList, 'Padding', 0);
-    Song.Cover.SelectX := ReadInteger(SectionList, 'SelectX', 300);
-    Song.Cover.SelectY := ReadInteger(SectionList, 'SelectY', 120);
-    Song.Cover.SelectW := ReadInteger(SectionList, 'SelectW', 325);
-    Song.Cover.SelectH := ReadInteger(SectionList, 'SelectH', 200);
-    Song.Cover.SelectReflection := ReadBool(SectionList, 'SelectReflection', false);
-    Song.Cover.SelectReflectionSpacing := ReadInteger(SectionList, 'SelectReflectionSpacing', 0);
     Song.Cover.ZoomThumbW := ReadInteger(SectionList, 'ZoomThumbW', 120);
     Song.Cover.ZoomThumbH := ReadInteger(SectionList, 'ZoomThumbH', 120);
     Song.Cover.ZoomThumbStyle := ReadInteger(SectionList, 'ZoomThumbStyle', 0);
@@ -3840,12 +3889,6 @@ begin
 
   if (TSongMenuMode(Ini.SongMenu) = smList) then
   begin
-    Song.Cover.SelectX := ReadInteger(SectionList, 'SelectX', 300);
-    Song.Cover.SelectY := ReadInteger(SectionList, 'SelectY', 120);
-    Song.Cover.SelectW := ReadInteger(SectionList, 'SelectW', 325);
-    Song.Cover.SelectH := ReadInteger(SectionList, 'SelectH', 200);
-    Song.Cover.SelectReflection := ReadBool(SectionList, 'SelectReflection', false);
-    Song.Cover.SelectReflectionSpacing := ReadInteger(SectionList, 'SelectReflectionSpacing', 0);
     Song.Cover.Padding := ReadInteger(SectionList, 'Padding', 4);
 
     SectionList := GetSectionList('Song' + prefix + 'SelectSong');

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -1116,13 +1116,15 @@ type
   TTheme = class
   private
     ThemeIni:         TMemIniFile;
-    BaseThemeIni:     TMemIniFile;
+    BaseThemeInis:    array of TMemIniFile;
 
     LastThemeBasic:   TThemeBasic;
     procedure CreateThemeObjects();
     procedure OpenFile(ThemeNum: integer);
     procedure CloseFile;
     procedure LoadHeader(FileName: IPath);
+    function FindThemeIndex(const ThemeName: string): integer;
+    procedure AddBaseThemeChain(const ThemeName: string; Depth: integer);
     function ResolveThemeFile(SectionName: string): TMemIniFile;
     function SectionExists(const Name: string; var Enabled: boolean): boolean;
     function GetSectionList(const Name: string): TThemeSectionList;
@@ -1329,31 +1331,76 @@ begin
 end;
 
 procedure TTheme.OpenFile(ThemeNum: integer);
-var
-  I: integer;
 begin
   ThemeIni := TMemIniFile.Create(Themes[ThemeNum].FileName.ToNative);
+  SetLength(BaseThemeInis, 0);
 
   // Load base theme if declared
   if (Themes[ThemeNum].BaseTheme <> '') then
+    AddBaseThemeChain(Themes[ThemeNum].BaseTheme, 0);
+end;
+
+procedure TTheme.CloseFile;
+var
+  I: integer;
+begin
+  freeandnil(ThemeIni);
+  for I := Low(BaseThemeInis) to High(BaseThemeInis) do
+    FreeAndNil(BaseThemeInis[I]);
+  SetLength(BaseThemeInis, 0);
+end;
+
+function TTheme.FindThemeIndex(const ThemeName: string): integer;
+var
+  I: integer;
+begin
+  Result := -1;
+  for I := Low(Themes) to High(Themes) do
   begin
-    for I := Low(Themes) to High(Themes) do
+    if CompareText(ThemeName, Themes[I].Name) = 0 then
     begin
-      if (CompareText(Themes[ThemeNum].BaseTheme, Themes[I].Name) = 0) then
-      begin
-        if (Themes[I].BaseTheme <> '') then
-          Log.LogError('Multiple base themes not allowed', 'TTheme.LoadTheme');
-        BaseThemeIni := TMemIniFile.Create(Themes[I].FileName.ToNative);
-        Break;
-      end;
+      Result := I;
+      Exit;
     end;
   end;
 end;
 
-procedure TTheme.CloseFile;
+procedure TTheme.AddBaseThemeChain(const ThemeName: string; Depth: integer);
+var
+  ThemeIndex: integer;
+  BaseIndex: integer;
 begin
-  freeandnil(ThemeIni);
-  freeandnil(BaseThemeIni);
+  if ThemeName = '' then
+    Exit;
+
+  if Depth >= MAX_INHERITANCE then
+  begin
+    Log.LogError('Maximum base theme inheritance depth exceeded for theme "' + ThemeName + '"', 'TTheme.LoadTheme');
+    Exit;
+  end;
+
+  ThemeIndex := FindThemeIndex(ThemeName);
+  if ThemeIndex < 0 then
+  begin
+    Log.LogError('Base theme not found: ' + ThemeName, 'TTheme.LoadTheme');
+    Exit;
+  end;
+
+  for BaseIndex := Low(BaseThemeInis) to High(BaseThemeInis) do
+  begin
+    if CompareText(Themes[ThemeIndex].FileName.ToNative, BaseThemeInis[BaseIndex].FileName) = 0 then
+    begin
+      Log.LogError('Circular base theme inheritance detected for theme "' + ThemeName + '"', 'TTheme.LoadTheme');
+      Exit;
+    end;
+  end;
+
+  BaseIndex := Length(BaseThemeInis);
+  SetLength(BaseThemeInis, BaseIndex + 1);
+  BaseThemeInis[BaseIndex] := TMemIniFile.Create(Themes[ThemeIndex].FileName.ToNative);
+
+  if Themes[ThemeIndex].BaseTheme <> '' then
+    AddBaseThemeChain(Themes[ThemeIndex].BaseTheme, Depth + 1);
 end;
 
 procedure TTheme.LoadHeader(FileName: IPath);
@@ -2130,31 +2177,38 @@ end;
 
 // Return the the theme file that contains the desired section
 function TTheme.ResolveThemeFile(SectionName: string): TMemIniFile; inline;
+var
+  I: integer;
 begin
-  Result := ThemeIni;
-  if (BaseThemeIni = nil) then
+  if ThemeIni.SectionExists(SectionName) then
+  begin
+    Result := ThemeIni;
     Exit;
-  if (not ThemeIni.SectionExists(SectionName) and BaseThemeIni.SectionExists(SectionName)) then
-    Result := BaseThemeIni;
+  end;
+
+  for I := Low(BaseThemeInis) to High(BaseThemeInis) do
+  begin
+    if BaseThemeInis[I].SectionExists(SectionName) then
+    begin
+      Result := BaseThemeInis[I];
+      Exit;
+    end;
+  end;
+
+  Result := nil;
 end;
 
 // Determine if the section exists in the theme or in the base theme
 // If it exists, determine whethere it is enabled. This allows the user
 // to opt out of optional texts/statics in derived themes
 function TTheme.SectionExists(const Name: string; var Enabled: boolean): boolean;
+var
+  IniFile: TMemIniFile;
 begin
-  if (ThemeIni.SectionExists(Name)) then
-  begin
-    Result := True;
-    Enabled := ThemeIni.ReadBool(Name, 'Enabled', true);
-  end
-  else if ((BaseThemeIni <> nil) and BaseThemeIni.SectionExists(Name)) then
-  begin
-    Result := True;
-    Enabled := BaseThemeIni.ReadBool(Name, 'Enabled', true);
-  end
-  else
-    Result := False;
+  IniFile := ResolveThemeFile(Name);
+  Result := IniFile <> nil;
+  if Result then
+    Enabled := IniFile.ReadBool(Name, 'Enabled', true);
 end;
 
 function TTheme.GetSectionList(const Name: string): TThemeSectionList;
@@ -2164,12 +2218,10 @@ var
   NextSection: string;
 begin
   Result := nil;
-  if (ThemeIni.SectionExists(Name)) then
-    IniFile := ThemeIni
-  else if ((BaseThemeIni <> nil) and (BaseThemeIni.SectionExists(Name))) then
-    IniFile := BaseThemeIni
-  else
+  IniFile := ResolveThemeFile(Name);
+  if IniFile = nil then
     Exit;
+
   SetLength(Result, 1);
   I := 0;
   Result[I].Name := Name;
@@ -2180,11 +2232,8 @@ begin
     NextSection := Result[I].IniFile.ReadString(Result[I].Name, 'Inherits', '');
     if (NextSection = '') then
       Break;
-    if (ThemeIni.SectionExists(NextSection)) then
-      IniFile := ThemeIni
-    else if ((BaseThemeIni <> nil) and (BaseThemeIni.SectionExists(Name))) then
-      IniFile := BaseThemeIni
-    else
+    IniFile := ResolveThemeFile(NextSection);
+    if IniFile = nil then
     begin
       Log.LogError('Inherited section "' + NextSection + '" not found (from section "' + Result[I].Name + '")', 'TTheme.GetSectionList');
       Break;
@@ -2387,7 +2436,7 @@ end;
 
 procedure TTheme.ThemeLoadOptionalStatic(var ThemeStatic: TThemeStatic; const Name: string);
 begin
-  if ThemeIni.SectionExists(Name) or ((BaseThemeIni <> nil) and BaseThemeIni.SectionExists(Name)) then
+  if ResolveThemeFile(Name) <> nil then
   begin
     ThemeLoadStatic(ThemeStatic, Name);
   end;
@@ -2432,7 +2481,7 @@ end;
 
 procedure TTheme.ThemeLoadOptionalStaticRectangle(var ThemeStaticRectangle: TThemeStaticRectangle; const Name: string);
 begin
-  if ThemeIni.SectionExists(Name) or ((BaseThemeIni <> nil) and BaseThemeIni.SectionExists(Name)) then
+  if ResolveThemeFile(Name) <> nil then
   begin
     ThemeLoadStaticRectangle(ThemeStaticRectangle, Name);
   end;
@@ -2534,7 +2583,7 @@ var
   I: integer;
 begin
   I := 1;
-  while ThemeIni.SectionExists(Name + IntToStr(I)) or ((BaseThemeIni <> nil) and BaseThemeIni.SectionExists(Name + IntToStr(I))) do
+  while ResolveThemeFile(Name + IntToStr(I)) <> nil do
   begin
     SetLength(Collections, I);
     ThemeLoadButtonCollection(Collections[I-1], Name + IntToStr(I));
@@ -3821,6 +3870,12 @@ begin
   Song.Cover.Y := ReadInteger(SectionList, 'Y', 190);
   Song.Cover.W := ReadInteger(SectionList, 'W', 300);
   Song.Cover.H := ReadInteger(SectionList, 'H', 200);
+  Song.Cover.SelectX := ReadInteger(SectionList, 'SelectX', Song.Cover.X);
+  Song.Cover.SelectY := ReadInteger(SectionList, 'SelectY', Song.Cover.Y);
+  Song.Cover.SelectW := ReadInteger(SectionList, 'SelectW', Song.Cover.W);
+  Song.Cover.SelectH := ReadInteger(SectionList, 'SelectH', Song.Cover.H);
+  Song.Cover.SelectReflection := ReadBool(SectionList, 'SelectReflection', false);
+  Song.Cover.SelectReflectionSpacing := ReadInteger(SectionList, 'SelectReflectionSpacing', 0);
 
   // Song menu modes: 0 - roulette, 1 - chessboard, 2 - list
   
@@ -3829,12 +3884,6 @@ begin
     Song.Cover.Rows := ReadInteger(SectionList, 'Rows', 4);
     Song.Cover.Cols := ReadInteger(SectionList, 'Cols', 4);
     Song.Cover.Padding := ReadInteger(SectionList, 'Padding', 0);
-    Song.Cover.SelectX := ReadInteger(SectionList, 'SelectX', 300);
-    Song.Cover.SelectY := ReadInteger(SectionList, 'SelectY', 120);
-    Song.Cover.SelectW := ReadInteger(SectionList, 'SelectW', 325);
-    Song.Cover.SelectH := ReadInteger(SectionList, 'SelectH', 200);
-    Song.Cover.SelectReflection := ReadBool(SectionList, 'SelectReflection', false);
-    Song.Cover.SelectReflectionSpacing := ReadInteger(SectionList, 'SelectReflectionSpacing', 0);
     Song.Cover.ZoomThumbW := ReadInteger(SectionList, 'ZoomThumbW', 120);
     Song.Cover.ZoomThumbH := ReadInteger(SectionList, 'ZoomThumbH', 120);
     Song.Cover.ZoomThumbStyle := ReadInteger(SectionList, 'ZoomThumbStyle', 0);
@@ -3844,12 +3893,6 @@ begin
 
   if (TSongMenuMode(Ini.SongMenu) = smList) then
   begin
-    Song.Cover.SelectX := ReadInteger(SectionList, 'SelectX', 300);
-    Song.Cover.SelectY := ReadInteger(SectionList, 'SelectY', 120);
-    Song.Cover.SelectW := ReadInteger(SectionList, 'SelectW', 325);
-    Song.Cover.SelectH := ReadInteger(SectionList, 'SelectH', 200);
-    Song.Cover.SelectReflection := ReadBool(SectionList, 'SelectReflection', false);
-    Song.Cover.SelectReflectionSpacing := ReadInteger(SectionList, 'SelectReflectionSpacing', 0);
     Song.Cover.Padding := ReadInteger(SectionList, 'Padding', 4);
 
     SectionList := GetSectionList('Song' + prefix + 'SelectSong');

--- a/src/menu/UMenu.pas
+++ b/src/menu/UMenu.pas
@@ -1002,16 +1002,19 @@ begin
 
   Button[Result].Fade := ThemeButton.Fade;
   Button[Result].FadeText := ThemeButton.FadeText;
-  if (ThemeButton.Typ = TEXTURE_TYPE_COLORIZED) then
+  if ThemeButton.Fade then
   begin
-    Button[Result].FadeTex := Texture.GetTexture(
-      Skin.GetTextureFileName(ThemeButton.FadeTex), TEXTURE_TYPE_COLORIZED,
-      RGBFloatToInt(ThemeButton.ColR, ThemeButton.ColG, ThemeButton.ColB));
-  end
-  else
-  begin
-    Button[Result].FadeTex := Texture.GetTexture(
-      Skin.GetTextureFileName(ThemeButton.FadeTex), ThemeButton.Typ);
+    if (ThemeButton.Typ = TEXTURE_TYPE_COLORIZED) then
+    begin
+      Button[Result].FadeTex := Texture.GetTexture(
+        Skin.GetTextureFileName(ThemeButton.FadeTex), TEXTURE_TYPE_COLORIZED,
+        RGBFloatToInt(ThemeButton.ColR, ThemeButton.ColG, ThemeButton.ColB));
+    end
+    else
+    begin
+      Button[Result].FadeTex := Texture.GetTexture(
+        Skin.GetTextureFileName(ThemeButton.FadeTex), ThemeButton.Typ);
+    end;
   end;
 
   Button[Result].FadeTexPos := ThemeButton.FadeTexPos;

--- a/src/menu/UMenu.pas
+++ b/src/menu/UMenu.pas
@@ -998,16 +998,19 @@ begin
 
   Button[Result].Fade := ThemeButton.Fade;
   Button[Result].FadeText := ThemeButton.FadeText;
-  if (ThemeButton.Typ = TEXTURE_TYPE_COLORIZED) then
+  if ThemeButton.Fade then
   begin
-    Button[Result].FadeTex := Renderer.GetTexture(
-      Skin.GetTextureFileName(ThemeButton.FadeTex), TEXTURE_TYPE_COLORIZED,
-      RGBFloatToInt(ThemeButton.ColR, ThemeButton.ColG, ThemeButton.ColB));
-  end
-  else
-  begin
-    Button[Result].FadeTex := Renderer.GetTexture(
-      Skin.GetTextureFileName(ThemeButton.FadeTex), ThemeButton.Typ);
+    if (ThemeButton.Typ = TEXTURE_TYPE_COLORIZED) then
+    begin
+      Button[Result].FadeTex := Renderer.GetTexture(
+        Skin.GetTextureFileName(ThemeButton.FadeTex), TEXTURE_TYPE_COLORIZED,
+        RGBFloatToInt(ThemeButton.ColR, ThemeButton.ColG, ThemeButton.ColB));
+    end
+    else
+    begin
+      Button[Result].FadeTex := Renderer.GetTexture(
+        Skin.GetTextureFileName(ThemeButton.FadeTex), ThemeButton.Typ);
+    end;
   end;
 
   Button[Result].FadeTexPos := ThemeButton.FadeTexPos;

--- a/src/menu/UMenuBackgroundVideo.pas
+++ b/src/menu/UMenuBackgroundVideo.pas
@@ -97,7 +97,7 @@ type }
 {var
   BGVideoPool: TBGVideoPool;  }
 const
-  SUPPORTED_EXTS_BACKGROUNDVIDEO: array[0..6] of string = ('.avi', '.mov', '.divx', '.mpg', '.mp4', '.mpeg', '.m2v');
+  SUPPORTED_EXTS_BACKGROUNDVIDEO: array[0..7] of string = ('.avi', '.mov', '.divx', '.mpg', '.mp4', '.mpeg', '.m2v', '.webm');
 
 implementation
 

--- a/src/menu/UMenuButton.pas
+++ b/src/menu/UMenuButton.pas
@@ -438,7 +438,7 @@ begin
     end;
 
     //Draw FadeTex
-    if (FadeTex.TexNum > 0) then
+    if Fade and (FadeTex.TexNum > 0) then
       DrawTexture(FadeTex);
 
     if Texture2.Alpha > 0 then
@@ -693,6 +693,9 @@ begin
 
   Fade           := false;
   FadeTex.TexNum := 0;
+  FadeTex.Alpha  := 0;
+  Texture2.TexNum:= 0;
+  Texture2.Alpha := 0;
   FadeProgress   := 0;
   FadeText       := false;
   SelectW        := DeSelectW;

--- a/src/menu/UMenuButton.pas
+++ b/src/menu/UMenuButton.pas
@@ -447,7 +447,7 @@ begin
     end;
 
     //Draw FadeTex
-    if (FadeTex <> nil) then
+    if Fade and (FadeTex <> nil) then
       Renderer.DrawTexture(FadeTex);
 
     for T := 0 to High(Text) do

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -1679,13 +1679,28 @@ procedure TScreenSong.ColorizeJokers;
 var
   StartJoker, I, J: integer;
   Col: TRGB;
+  JokerTyp: TTextureType;
 begin
 
   StartJoker := StaticTeam1Joker1;
 
   for I:= 0 to 2 do
   begin
-    Col := GetPlayerColor(Ini.SingColor[I]);
+    case I of
+      0: JokerTyp := Theme.Song.StaticTeam1Joker1.Typ;
+      1: JokerTyp := Theme.Song.StaticTeam2Joker1.Typ;
+    else
+      JokerTyp := Theme.Song.StaticTeam3Joker1.Typ;
+    end;
+
+    if (JokerTyp = TEXTURE_TYPE_COLORIZED) then
+      Col := GetPlayerColor(Ini.SingColor[I])
+    else
+    begin
+      Col.R := 1;
+      Col.G := 1;
+      Col.B := 1;
+    end;
 
     for J := StartJoker + I * 5 to (StartJoker + I * 5 - 1) + 5  do
     begin
@@ -1760,6 +1775,7 @@ begin
   StaticTeam3Joker3 := AddStatic(Theme.Song.StaticTeam3Joker3);
   StaticTeam3Joker4 := AddStatic(Theme.Song.StaticTeam3Joker4);
   StaticTeam3Joker5 := AddStatic(Theme.Song.StaticTeam3Joker5);
+  ColorizeJokers;
 
   //Load Party or NonParty specific Statics and Texts
   SetLength(StaticParty, Length(Theme.Song.StaticParty));

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -1705,13 +1705,28 @@ procedure TScreenSong.ColorizeJokers;
 var
   StartJoker, I, J: integer;
   Col: TRGB;
+  JokerTyp: TTextureType;
 begin
 
   StartJoker := StaticTeam1Joker1;
 
   for I:= 0 to 2 do
   begin
-    Col := GetPlayerColor(Ini.SingColor[I]);
+    case I of
+      0: JokerTyp := Theme.Song.StaticTeam1Joker1.Typ;
+      1: JokerTyp := Theme.Song.StaticTeam2Joker1.Typ;
+    else
+      JokerTyp := Theme.Song.StaticTeam3Joker1.Typ;
+    end;
+
+    if (JokerTyp = TEXTURE_TYPE_COLORIZED) then
+      Col := GetPlayerColor(Ini.SingColor[I])
+    else
+    begin
+      Col.R := 1;
+      Col.G := 1;
+      Col.B := 1;
+    end;
 
     for J := StartJoker + I * 5 to (StartJoker + I * 5 - 1) + 5  do
     begin
@@ -1786,6 +1801,7 @@ begin
   StaticTeam3Joker3 := AddStatic(Theme.Song.StaticTeam3Joker3);
   StaticTeam3Joker4 := AddStatic(Theme.Song.StaticTeam3Joker4);
   StaticTeam3Joker5 := AddStatic(Theme.Song.StaticTeam3Joker5);
+  ColorizeJokers;
 
   //Load Party or NonParty specific Statics and Texts
   SetLength(StaticParty, Length(Theme.Song.StaticParty));


### PR DESCRIPTION
I ported all USDX 1.1 themes and the USWP themes to USDX. Some minimal changes were necessary to address:
- theme section inheritance through BaseTheme, including chained base themes
- skin texture fallback from a theme’s default/base skin
- missing song cover selection area settings
- optional fade textures being loaded/drawn when they shouldn't
- uninitialized secondary/fade button texture state
- non-colorized joker textures being tinted incorrectly
- .webm background video support