### PR TITLE
Add F5 theme reload shortcut

### DIFF
--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -83,6 +83,7 @@ uses
   UJoystick,
   ULanguage,
   ULog,
+  UMenu,
   UPathUtils,
   UPlaylist,
   UMusic,
@@ -296,6 +297,31 @@ end;
 procedure SetTextInput(enabled: boolean);
 begin
   if enabled then StartTextInput else StopTextInput;
+end;
+
+procedure ReloadCurrentTheme;
+var
+  CurrentScreen: PMenu;
+begin
+  CurrentScreen := Display.CurrentScreen;
+
+  Display.NextScreen := nil;
+  Display.NextScreenWithCheck := nil;
+
+  Theme.LoadTheme(Ini.Theme, Ini.Color);
+  UGraphic.UnloadScreens;
+  UGraphic.LoadScreens(USDXVersionStr);
+
+  if Assigned(CurrentScreen) and Assigned(CurrentScreen^) then
+  begin
+    Display.CurrentScreen := CurrentScreen;
+    Display.CurrentScreen^.OnShow;
+  end
+  else
+  begin
+    Display.CurrentScreen := @ScreenMain;
+    ScreenMain.OnShow;
+  end;
 end;
 
 procedure MainLoop;
@@ -542,6 +568,8 @@ begin
             // if print is pressed -> make screenshot and save to screenshot path
             if (SimKey = SDLK_SYSREQ) or (SimKey = SDLK_PRINTSCREEN) then
               Display.SaveScreenShot
+            else if (SimKey = SDLK_F5) then
+              ReloadCurrentTheme
             // if there is a visible popup then let it handle input instead of underlying screen
             // shoud be done in a way to be sure the topmost popup has preference (maybe error, then check)
             else if (ScreenPopupError <> nil) and (ScreenPopupError.Visible) then

--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -83,6 +83,7 @@ uses
   UJoystick,
   ULanguage,
   ULog,
+  UMenu,
   UPathUtils,
   UPlaylist,
   UMusic,
@@ -296,6 +297,31 @@ end;
 procedure SetTextInput(enabled: boolean);
 begin
   if enabled then StartTextInput else StopTextInput;
+end;
+
+procedure ReloadCurrentTheme;
+var
+  CurrentScreen: PMenu;
+begin
+  CurrentScreen := Display.CurrentScreen;
+
+  Display.NextScreen := nil;
+  Display.NextScreenWithCheck := nil;
+
+  Theme.LoadTheme(Ini.Theme, Ini.Color);
+  UGraphic.UnloadScreens;
+  UGraphic.LoadScreens(USDXVersionStr);
+
+  if Assigned(CurrentScreen) and Assigned(CurrentScreen^) then
+  begin
+    Display.CurrentScreen := CurrentScreen;
+    Display.CurrentScreen^.OnShow;
+  end
+  else
+  begin
+    Display.CurrentScreen := @ScreenMain;
+    ScreenMain.OnShow;
+  end;
 end;
 
 procedure MainLoop;
@@ -544,6 +570,8 @@ begin
             // if print is pressed -> make screenshot and save to screenshot path
             if (SimKey = SDLK_SYSREQ) or (SimKey = SDLK_PRINTSCREEN) then
               Display.SaveScreenShot
+            else if (SimKey = SDLK_F5) then
+              ReloadCurrentTheme
             // if there is a visible popup then let it handle input instead of underlying screen
             // shoud be done in a way to be sure the topmost popup has preference (maybe error, then check)
             else if (ScreenPopupError <> nil) and (ScreenPopupError.Visible) then


### PR DESCRIPTION
When adjusting themes it is much of a hassle to always restart, check, restart, check - or alternatively go to the options screen.

This adds a key F5 which just reloads the theme (same as the options screen would).

There is literally no advantage for any regular user with this, even the risk of people accidentally reloading the theme. But for editing themes, this was soooo useful.
So maybe this should not be merged or someone has an idea what to do with it, or maybe condition it on a flag, debug mode or something?