### PR TITLE
Fix sound options back button interaction ID

### DIFF
--- a/src/screens/UScreenOptionsSound.pas
+++ b/src/screens/UScreenOptionsSound.pas
@@ -101,9 +101,13 @@ type
   InteractionID = (
     iVoicePassthroughSlide,
     iBackgroundMusicSlide,
+    iBackgroundMusicVolumeSlide,
     iClickAssistSlide,
     iBeatClickSlide,
     iReplayGainSlide,
+    iAudioVolumeSlide,
+    iVocalsVolumeSlide,
+    iSfxVolumeSlide,
     iPreviewVolumeSlide,
     iPreviewFadingSlide,
     iBackButton


### PR DESCRIPTION
Adds the missing InteractionID entries for the new sound volume sliders so the enum matches the widget order in LoadWidgets.

This restores the Options -> Sound back button behavior after the volume settings added in #1093.
