### PR TITLE
Add startup song validation flag

### DIFF
--- a/src/base/UCommandLine.pas
+++ b/src/base/UCommandLine.pas
@@ -60,6 +60,7 @@ type
       Debug:      boolean;
       Benchmark:  boolean;
       NoLog:      boolean;
+      CheckSongs: boolean;
       ScreenMode: TScreenMode;
       Joypad:     boolean;
       Split:      TSplitMode;
@@ -89,6 +90,7 @@ var
 const
   cHelp            = 'help';
   cDebug           = 'debug';
+  cCheckSongs      = 'check-songs';
   cMediaInterfaces = 'showinterfaces';
 
 
@@ -128,6 +130,7 @@ begin
   writeln('  ----------------------------------------------------------');
   writeln('  '+ Fmt(cMediaInterfaces) +' : Show in-use media interfaces');
   writeln('  '+ Fmt(cDebug) +' : Display Debugging info');
+  writeln('  '+ Fmt(cCheckSongs) +' : Fully validate song files during startup');
   writeln;
 
   platform.halt;
@@ -141,6 +144,7 @@ begin
   Debug       := false;
   Benchmark   := False;
   NoLog       := false;
+  CheckSongs  := false;
   ScreenMode  := scmDefault;
   Joypad      := False;
   Split       := spmDefault;
@@ -185,6 +189,8 @@ begin
       // boolean triggers
       if (Command = 'debug') then
         Debug       := True
+      else if (Command = cCheckSongs) then
+        CheckSongs  := True
       else if (Command = 'benchmark') then
         Benchmark   := True
       else if (Command = 'nolog') then

--- a/src/base/USongs.pas
+++ b/src/base/USongs.pas
@@ -167,6 +167,7 @@ implementation
 uses
   StrUtils,
   SDL2,
+  UCommandLine,
   UFiles,
   UGraphic,
   UMain,
@@ -425,7 +426,7 @@ var
 begin
   Song := TSong.Create(FilePath);
 
-  if Song.Analyse then
+  if Song.Analyse(false, false, false, false, 0, Params.CheckSongs) then
     SongList.Add(Song)
   else
   begin


### PR DESCRIPTION
With #1100 we removed the song checking on startup, which speeds up loading times drastically.

As suggested by @bohning, this PR adds a check-songs command-line option that fully validates song files during startup, while keeping normal startup on the faster header-only path.