### PR TITLE
Use cached DB count for single-pass song discovery

### DIFF
--- a/src/base/UDataBase.pas
+++ b/src/base/UDataBase.pas
@@ -158,6 +158,8 @@ type
       procedure FreeStats(StatList: TList);
       function GetTotalEntrys(Typ: TStatType): cardinal;
       function GetStatReset: TDateTime;
+      function GetLastSongFileCount: integer;
+      procedure SetLastSongFileCount(Count: integer);
       function FormatDate(time_stamp: integer): UTF8String;
 
       procedure SaveSongOptions(Song: TSong; Options: TSongOptions);
@@ -182,9 +184,10 @@ uses
  0 = USDX 1.01 or no Database
  01 = USDX 1.1
   2 = Trim trailing NUL bytes written into TEXT columns
+  3 = Cache the last discovered song file count
 }
 const
-  cDBVersion = 2;
+  cDBVersion = 3;
   cUS_Scores = 'us_scores';
   cUS_Songs  = 'us_songs';
   cUS_Statistics_Info = 'us_statistics_info';
@@ -219,12 +222,19 @@ begin
     begin
       Log.LogInfo('Outdated song database found - missing table"' + cUS_Statistics_Info + '"', 'TDataBaseSystem.Init');
       ScoreDB.ExecSQL('CREATE TABLE IF NOT EXISTS [' + cUS_Statistics_Info + '] (' +
-                      '[ResetTime] INTEGER' +
+                      '[ResetTime] INTEGER, ' +
+                      '[LastSongFileCount] INTEGER NULL' +
                       ');');
       // insert creation timestamp
       ScoreDB.ExecSQL(Format('INSERT INTO [' + cUS_Statistics_Info + '] ' +
                              '([ResetTime]) VALUES(%d);',
                              [DateTimeToUnix(Now())]));
+    end;
+
+    if not ScoreDB.ContainsColumn(cUS_Statistics_Info, 'LastSongFileCount') then
+    begin
+      Log.LogInfo('Outdated song database found - adding column LastSongFileCount to "' + cUS_Statistics_Info + '"', 'TDataBaseSystem.Init');
+      ScoreDB.ExecSQL('ALTER TABLE ' + cUS_Statistics_Info + ' ADD COLUMN [LastSongFileCount] INTEGER NULL');
     end;
 
     // convert data from 1.01 to 1.1
@@ -1537,6 +1547,41 @@ begin
     Result := UnixToDateTime(ScoreDB.GetTableValue(Query));
   except on E: Exception do
     Log.LogError(E.Message, 'TDataBaseSystem.GetStatReset');
+  end;
+end;
+
+function TDataBaseSystem.GetLastSongFileCount: integer;
+var
+  Query: string;
+begin
+  Result := 0;
+
+  if not Assigned(ScoreDB) then
+    Exit;
+
+  try
+    Query := 'SELECT COALESCE([LastSongFileCount], 0) FROM [' + cUS_Statistics_Info + '];';
+    Result := ScoreDB.GetTableValue(Query);
+  except on E: Exception do
+    Log.LogError(E.Message, 'TDataBaseSystem.GetLastSongFileCount');
+  end;
+end;
+
+procedure TDataBaseSystem.SetLastSongFileCount(Count: integer);
+begin
+  if not Assigned(ScoreDB) then
+    Exit;
+
+  try
+    if ScoreDB.GetTableValue('SELECT COUNT(*) FROM [' + cUS_Statistics_Info + '];') = 0 then
+      ScoreDB.ExecSQL(Format('INSERT INTO [' + cUS_Statistics_Info + '] ' +
+                             '([ResetTime], [LastSongFileCount]) VALUES(%d, %d);',
+                             [DateTimeToUnix(Now()), Count]))
+    else
+      ScoreDB.ExecSQL(Format('UPDATE [' + cUS_Statistics_Info + '] SET [LastSongFileCount] = %d;',
+                             [Count]));
+  except on E: Exception do
+    Log.LogError(E.Message, 'TDataBaseSystem.SetLastSongFileCount');
   end;
 end;
 

--- a/src/base/USongs.pas
+++ b/src/base/USongs.pas
@@ -93,8 +93,7 @@ type
   private
     fParseSongDirectory: boolean;
     fProcessing:         boolean;
-    fDiscoveryDirCount:  integer;
-    fDiscoveryDirsScanned: integer;
+    fEstimatedSongFileCount: integer;
     fTotalSongsToLoad:   integer;
     fSongsLoaded:        integer;
     function CollectSongFiles: TPathDynArray;
@@ -167,6 +166,7 @@ implementation
 uses
   StrUtils,
   SDL2,
+  UDataBase,
   UFiles,
   UGraphic,
   UMain,
@@ -181,42 +181,6 @@ var
 begin
   while SDL_PollEvent(@Event) <> 0 do
     ;
-end;
-
-function CollectDirectories(const StartDir: IPath; Recursive: Boolean): TPathDynArray;
-var
-  Iter: IFileIterator;
-  FileInfo: TFileInfo;
-  FileName: IPath;
-  SubDirs: TPathDynArray;
-  SubDirCount, SubDirIdx: Integer;
-begin
-  SetLength(Result, 1);
-  Result[0] := StartDir;
-  if not Recursive then
-    Exit;
-
-  Iter := FileSystem.FileFind(StartDir.Append('*'), faDirectory);
-  while Iter.HasNext do
-  begin
-    FileInfo := Iter.Next;
-    FileName := FileInfo.Name;
-    if ((FileInfo.Attr and faDirectory) <> 0) and
-       (not FileName.Equals('.')) and
-       (not FileName.Equals('..')) and
-       (not FileName.Equals('')) then
-    begin
-      Log.LogDebug('Recursing: ' + StartDir.Append(FileName).ToWide, 'TSongs.FindFilesByExtension');
-      SubDirs := CollectDirectories(StartDir.Append(FileName), true);
-      SubDirCount := Length(SubDirs);
-      if SubDirCount > 0 then
-      begin
-        SetLength(Result, Length(Result) + SubDirCount);
-        for SubDirIdx := 0 to SubDirCount - 1 do
-          Result[High(Result) - SubDirCount + 1 + SubDirIdx] := SubDirs[SubDirIdx];
-      end;
-    end;
-  end;
 end;
 
 constructor TSongs.Create();
@@ -275,8 +239,7 @@ begin
 
     Log.LogStatus('Searching For Songs', 'SongList');
 
-    fDiscoveryDirCount := 0;
-    fDiscoveryDirsScanned := 0;
+    fEstimatedSongFileCount := 0;
     fSongsLoaded := 0;
     fTotalSongsToLoad := 0;
     if Assigned(ScreenLoading) then
@@ -333,90 +296,77 @@ end;
 
 procedure TSongs.FindFilesByExtension(const Dir: IPath; const Ext: IPath; Recursive: Boolean; var Files: TPathDynArray);
 var
-  DirList: TPathDynArray;
-  DirIndex: Integer;
   Iter: IFileIterator;
   FileInfo: TFileInfo;
   FileName: IPath;
+  FilePath: IPath;
 begin
-  if Recursive then
-    DirList := CollectDirectories(Dir, true)
-  else
+  Iter := FileSystem.FileFind(Dir.Append('*.txt'), 0);
+  while Iter.HasNext do
   begin
-    SetLength(DirList, 1);
-    DirList[0] := Dir;
+    FileInfo := Iter.Next;
+    FileName := FileInfo.Name;
+    if ((FileInfo.Attr and faDirectory) = 0) and Ext.Equals(FileName.GetExtension(), true) then
+    begin
+      FilePath := Dir.Append(FileName);
+      Log.LogDebug('Found file ' + FilePath.ToWide, 'TSongs.FindFilesByExtension');
+      SetLength(Files, Length(Files) + 1);
+      Files[High(Files)] := FilePath;
+    end;
   end;
 
-  for DirIndex := 0 to High(DirList) do
+  UpdateDiscoveryProgress(Length(Files));
+  PumpLoadingEvents;
+
+  if not Recursive then
+    Exit;
+
+  Iter := FileSystem.FileFind(Dir.Append('*'), faDirectory);
+  while Iter.HasNext do
   begin
-    Iter := FileSystem.FileFind(DirList[DirIndex].Append('*.txt'), 0);
-    while Iter.HasNext do
+    FileInfo := Iter.Next;
+    FileName := FileInfo.Name;
+    if ((FileInfo.Attr and faDirectory) <> 0) and
+       (not FileName.Equals('.')) and
+       (not FileName.Equals('..')) and
+       (not FileName.Equals('')) then
     begin
-      FileInfo := Iter.Next;
-      FileName := FileInfo.Name;
-      if ((FileInfo.Attr and faDirectory) = 0) and Ext.Equals(FileName.GetExtension(), true) then
-      begin
-        Log.LogDebug('Found file ' + DirList[DirIndex].Append(FileName).ToWide, 'TSongs.FindFilesByExtension');
-        SetLength(Files, Length(Files) + 1);
-        Files[High(Files)] := DirList[DirIndex].Append(FileName);
-      end;
+      FilePath := Dir.Append(FileName);
+      Log.LogDebug('Recursing: ' + FilePath.ToWide, 'TSongs.FindFilesByExtension');
+      FindFilesByExtension(FilePath, Ext, true, Files);
     end;
   end;
 end;
 
 function TSongs.CollectSongFiles: TPathDynArray;
 var
-  DirIndex, FileIndex, AppendIndex, AdditionalCount, ScanIndex: integer;
-  DirList: TPathDynArray;
-  AllDirs: TPathDynArray;
-  DirFiles: TPathDynArray;
+  DirIndex: integer;
   Extension: IPath;
   DirPath: IPath;
 begin
   SetLength(Result, 0);
-  SetLength(AllDirs, 0);
 
   if SongPaths = nil then
     Exit;
 
   Extension := Path('.txt');
+  if Assigned(DataBase) then
+    fEstimatedSongFileCount := DataBase.GetLastSongFileCount
+  else
+    fEstimatedSongFileCount := 0;
+  UpdateDiscoveryProgress(0, true);
 
   for DirIndex := 0 to SongPaths.Count - 1 do
   begin
     DirPath := SongPaths[DirIndex] as IPath;
     Log.LogDebug('Searching directory ' + DirPath.ToWide + ' for txt files', 'TSongs.CollectSongFiles');
-    DirList := CollectDirectories(DirPath, true);
-    AdditionalCount := Length(DirList);
-    if AdditionalCount > 0 then
-    begin
-      AppendIndex := Length(AllDirs);
-      SetLength(AllDirs, AppendIndex + AdditionalCount);
-      for FileIndex := 0 to AdditionalCount - 1 do
-        AllDirs[AppendIndex + FileIndex] := DirList[FileIndex];
-    end;
+    FindFilesByExtension(DirPath, Extension, true, Result);
   end;
 
-  fDiscoveryDirCount := Length(AllDirs);
-  UpdateDiscoveryProgress(0, true);
-
-  for ScanIndex := 0 to High(AllDirs) do
-  begin
-    SetLength(DirFiles, 0);
-    FindFilesByExtension(AllDirs[ScanIndex], Extension, false, DirFiles);
-    AdditionalCount := Length(DirFiles);
-    if AdditionalCount > 0 then
-    begin
-      AppendIndex := Length(Result);
-      SetLength(Result, AppendIndex + AdditionalCount);
-      for FileIndex := 0 to AdditionalCount - 1 do
-        Result[AppendIndex + FileIndex] := DirFiles[FileIndex];
-    end;
-
-    Inc(fDiscoveryDirsScanned);
-    UpdateDiscoveryProgress(Length(Result));
-    PumpLoadingEvents;
-    SetLength(DirFiles, 0);
-  end;
+  fEstimatedSongFileCount := Length(Result);
+  if Assigned(DataBase) then
+    DataBase.SetLastSongFileCount(fEstimatedSongFileCount);
+  UpdateDiscoveryProgress(Length(Result), true);
 end;
 
 procedure TSongs.LoadSongFromFile(const FilePath: IPath);
@@ -439,7 +389,7 @@ begin
   if not Assigned(ScreenLoading) then
     Exit;
 
-  ScreenLoading.SetDiscoveryProgress(fDiscoveryDirsScanned, fDiscoveryDirCount, SongsFound);
+  ScreenLoading.SetDiscoveryProgress(SongsFound, fEstimatedSongFileCount, SongsFound);
   if Force then
     ScreenLoading.RefreshProgress(true);
 end;


### PR DESCRIPTION
We made a lot of progress on startup times now with startup times below 10 seconds on recent high-end systems.
However, @bohning reported that almost 2m30s are spent on a pre-discovery of files (a step which apparently takes <1 second on many systems) which is just used for the progress bar.

Now this is pretty wasteful, so this PR removes the upfront recursive directory collection pass and discovers song txt files in a single traversal instead. The loading screen now uses the previous run's discovered song-file count from the database as an estimate, then stores the actual count after discovery completes, keeping startup responsive without needing a full pre-scan just for progress.

The left part of the progress bar might complete too early or jump from midway to 100% if the file count changed drastically from the previous run with the same Ultrastar.db.

Still, I think for @bohning, and people with a similar setup, this pushes the start up time further down from 6-7 minutes to about 4 minutes. I'm not sure how many people are affected by this but I also don't see much of a disadvantage in doing this.