### PR TITLE
Improve loading screen progress and responsiveness

### DIFF
--- a/src/base/UGraphic.pas
+++ b/src/base/UGraphic.pas
@@ -927,13 +927,32 @@ begin
 end;
 
 procedure LoadScreens(Title: string);
+  procedure SetLoadingTitle(const Value: string);
+  const
+    MaxLoadingStatusLength = 25;
+  var
+    Event: TSDL_Event;
+    LoadingStatus: string;
+  begin
+    SDL_SetWindowTitle(Screen, PChar(Title + ' - ' + Value));
+    if Assigned(ScreenLoading) then
+    begin
+      LoadingStatus := Value;
+      if Length(LoadingStatus) > MaxLoadingStatusLength then
+        LoadingStatus := Copy(LoadingStatus, 1, MaxLoadingStatusLength - 3) + '...';
+      ScreenLoading.SetStatus(LoadingStatus);
+    end;
+    while SDL_PollEvent(@Event) <> 0 do
+      ;
+  end;
+
 begin
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenMain & ScreenName'));
+  SetLoadingTitle('Loading ScreenMain & ScreenName');
   ScreenMain :=             TScreenMain.Create;
   ScreenName :=             TScreenName.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenSong'));
+  SetLoadingTitle('Loading ScreenSong');
   ScreenSong :=             TScreenSong.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenSongMenu & ScreenJukebox'));
+  SetLoadingTitle('Loading ScreenSongMenu & ScreenJukebox');
   ScreenSongMenu :=             TScreenSongMenu.Create;
   ScreenJukebox :=             TScreenJukebox.Create;
   Log.BenchmarkEnd(3); Log.LogBenchmark('====> Screen Jukebox', 3); Log.BenchmarkStart(3);
@@ -942,62 +961,62 @@ begin
   ScreenJukeboxPlaylist :=   TScreenJukeboxPlaylist.Create;
   Log.BenchmarkEnd(3); Log.LogBenchmark('====> Screen Jukebox Playlist', 3); Log.BenchmarkStart(3);
   ScreenTop5 :=             TScreenTop5.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenOptions & ScreenOptionsGame'));
+  SetLoadingTitle('Loading ScreenOptions & ScreenOptionsGame');
   ScreenOptions :=          TScreenOptions.Create;
   ScreenOptionsGame :=      TScreenOptionsGame.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenOptionsGraphics & ScreenOptionsSound & ScreenOptionsInput'));
+  SetLoadingTitle('Loading ScreenOptionsGraphics & ScreenOptionsSound & ScreenOptionsInput');
   ScreenOptionsGraphics  :=  TScreenOptionsGraphics.Create;
   ScreenOptionsSound    :=     TScreenOptionsSound.Create;
   ScreenOptionsInput    :=     TScreenOptionsInput.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenOptionsLyrics & ScreenOptionsThemes'));
+  SetLoadingTitle('Loading ScreenOptionsLyrics & ScreenOptionsThemes');
   ScreenOptionsLyrics   :=    TScreenOptionsLyrics.Create;
   ScreenOptionsThemes   :=    TScreenOptionsThemes.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenOptionsRecord & ScreenOptionsAdvanced'));
+  SetLoadingTitle('Loading ScreenOptionsRecord & ScreenOptionsAdvanced');
   ScreenOptionsRecord   :=    TScreenOptionsRecord.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenOptionsAdvanced'));
+  SetLoadingTitle('Loading ScreenOptionsAdvanced');
   ScreenOptionsAdvanced :=    TScreenOptionsAdvanced.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenOptionsNetwork'));
+  SetLoadingTitle('Loading ScreenOptionsNetwork');
   ScreenOptionsNetwork :=    TScreenOptionsNetwork.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenOptionsWebCam'));
+  SetLoadingTitle('Loading ScreenOptionsWebCam');
   ScreenOptionsWebcam  :=    TScreenOptionsWebcam.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenOptionsJukebox'));
+  SetLoadingTitle('Loading ScreenOptionsJukebox');
   ScreenOptionsJukebox :=    TScreenOptionsJukebox.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenEditConvert & ScreenEditSub & ScreenEdit'));
+  SetLoadingTitle('Loading ScreenEditConvert & ScreenEditSub & ScreenEdit');
   ScreenEditConvert :=      TScreenEditConvert.Create;
   ScreenEditSub :=          TScreenEditSub.Create;
   ScreenEdit :=             TScreenEdit.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenOpen'));
+  SetLoadingTitle('Loading ScreenOpen');
   ScreenOpen :=             TScreenOpen.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenAbout'));
+  SetLoadingTitle('Loading ScreenAbout');
   ScreenAbout :=             TScreenAbout.Create;
   Log.BenchmarkEnd(3); Log.LogBenchmark('====> Screen About', 3); Log.BenchmarkStart(3);
   //ScreenSingModi :=         TScreenSingModi.Create;
   //Log.BenchmarkEnd(3); Log.LogBenchmark('====> Screen Sing with Modi support', 3); Log.BenchmarkStart(3);
   ScreenSongJumpto :=         TScreenSongJumpto.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenPopupCheck & ScreenPopupError & ScreenPopupHelp'));
+  SetLoadingTitle('Loading ScreenPopupCheck & ScreenPopupError & ScreenPopupHelp');
   ScreenPopupCheck := TScreenPopupCheck.Create;
   ScreenPopupError := TScreenPopupError.Create;
   ScreenPopupHelp  := TScreenPopupHelp.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenPopupInfo & ScreenScoreX & ScreenPartyNewRound'));
+  SetLoadingTitle('Loading ScreenPopupInfo & ScreenScoreX & ScreenPartyNewRound');
   ScreenPopupInfo := TScreenPopupInfo.Create;
   ScreenPopupInsertUser := TScreenPopupInsertUser.Create;
   ScreenPopupSendScore := TScreenPopupSendScore.Create;
   ScreenPopupScoreDownload := TScreenPopupScoreDownload.Create;
   ScreenPartyNewRound :=    TScreenPartyNewRound.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenPartyScore & ScreenPartyWin'));
+  SetLoadingTitle('Loading ScreenPartyScore & ScreenPartyWin');
   ScreenPartyScore :=       TScreenPartyScore.Create;
   ScreenPartyWin :=         TScreenPartyWin.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenPartyOptions & ScreenPartyPlayer'));
+  SetLoadingTitle('Loading ScreenPartyOptions & ScreenPartyPlayer');
   ScreenPartyOptions :=     TScreenPartyOptions.Create;
   ScreenPartyPlayer :=      TScreenPartyPlayer.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenPartyRounds & ScreenTournamentX & ScreenStatMain'));
+  SetLoadingTitle('Loading ScreenPartyRounds & ScreenTournamentX & ScreenStatMain');
   ScreenPartyRounds :=      TScreenPartyRounds.Create;
   ScreenPartyTournamentRounds :=      TScreenPartyTournamentRounds.Create;
   ScreenPartyTournamentPlayer :=      TScreenPartyTournamentPlayer.Create;
   ScreenPartyTournamentOptions :=      TScreenPartyTournamentOptions.Create;
   ScreenPartyTournamentWin :=      TScreenPartyTournamentWin.Create;
   ScreenStatMain :=         TScreenStatMain.Create;
-  SDL_SetWindowTitle(Screen, PChar(Title + ' - Loading ScreenStatDetail'));
+  SetLoadingTitle('Loading ScreenStatDetail');
   ScreenStatDetail :=       TScreenStatDetail.Create;
   SDL_SetWindowTitle(Screen, PChar(Title));
 end;

--- a/src/base/USongs.pas
+++ b/src/base/USongs.pas
@@ -93,6 +93,7 @@ type
   private
     fParseSongDirectory: boolean;
     fProcessing:         boolean;
+    fDiscoveringDirectories: boolean;
     fDiscoveryDirCount:  integer;
     fDiscoveryDirsScanned: integer;
     fTotalSongsToLoad:   integer;
@@ -175,15 +176,27 @@ uses
   UFilesystem,
   UUnicodeUtils;
 
+var
+  LastLoadingEventPumpTicks: cardinal = 0;
+
 procedure PumpLoadingEvents;
+const
+  LoadingEventPumpIntervalMs = 50;
 var
   Event: TSDL_Event;
+  NowTicks: cardinal;
 begin
+  NowTicks := SDL_GetTicks;
+  if (LastLoadingEventPumpTicks <> 0) and (NowTicks - LastLoadingEventPumpTicks < LoadingEventPumpIntervalMs) then
+    Exit;
+
   while SDL_PollEvent(@Event) <> 0 do
     ;
+
+  LastLoadingEventPumpTicks := NowTicks;
 end;
 
-function CollectDirectories(const StartDir: IPath; Recursive: Boolean): TPathDynArray;
+function CollectDirectories(const StartDir: IPath; Recursive: Boolean; Owner: TSongs = nil): TPathDynArray;
 var
   Iter: IFileIterator;
   FileInfo: TFileInfo;
@@ -193,6 +206,12 @@ var
 begin
   SetLength(Result, 1);
   Result[0] := StartDir;
+  if Assigned(Owner) then
+  begin
+    Inc(Owner.fDiscoveryDirCount);
+    Owner.UpdateDiscoveryProgress(0);
+    PumpLoadingEvents;
+  end;
   if not Recursive then
     Exit;
 
@@ -207,7 +226,7 @@ begin
        (not FileName.Equals('')) then
     begin
       Log.LogDebug('Recursing: ' + StartDir.Append(FileName).ToWide, 'TSongs.FindFilesByExtension');
-      SubDirs := CollectDirectories(StartDir.Append(FileName), true);
+      SubDirs := CollectDirectories(StartDir.Append(FileName), true, Owner);
       SubDirCount := Length(SubDirs);
       if SubDirCount > 0 then
       begin
@@ -275,6 +294,7 @@ begin
 
     Log.LogStatus('Searching For Songs', 'SongList');
 
+    fDiscoveringDirectories := false;
     fDiscoveryDirCount := 0;
     fDiscoveryDirsScanned := 0;
     fSongsLoaded := 0;
@@ -340,7 +360,7 @@ var
   FileName: IPath;
 begin
   if Recursive then
-    DirList := CollectDirectories(Dir, true)
+    DirList := CollectDirectories(Dir, true, Self)
   else
   begin
     SetLength(DirList, 1);
@@ -359,6 +379,7 @@ begin
         Log.LogDebug('Found file ' + DirList[DirIndex].Append(FileName).ToWide, 'TSongs.FindFilesByExtension');
         SetLength(Files, Length(Files) + 1);
         Files[High(Files)] := DirList[DirIndex].Append(FileName);
+        PumpLoadingEvents;
       end;
     end;
   end;
@@ -380,12 +401,14 @@ begin
     Exit;
 
   Extension := Path('.txt');
+  fDiscoveringDirectories := true;
+  UpdateDiscoveryProgress(0, true);
 
   for DirIndex := 0 to SongPaths.Count - 1 do
   begin
     DirPath := SongPaths[DirIndex] as IPath;
     Log.LogDebug('Searching directory ' + DirPath.ToWide + ' for txt files', 'TSongs.CollectSongFiles');
-    DirList := CollectDirectories(DirPath, true);
+    DirList := CollectDirectories(DirPath, true, Self);
     AdditionalCount := Length(DirList);
     if AdditionalCount > 0 then
     begin
@@ -396,7 +419,9 @@ begin
     end;
   end;
 
+  fDiscoveringDirectories := false;
   fDiscoveryDirCount := Length(AllDirs);
+  fDiscoveryDirsScanned := 0;
   UpdateDiscoveryProgress(0, true);
 
   for ScanIndex := 0 to High(AllDirs) do
@@ -435,11 +460,29 @@ begin
 end;
 
 procedure TSongs.UpdateDiscoveryProgress(SongsFound: integer; Force: boolean = false);
+var
+  Percent: integer;
+  FilesNeeded: integer;
 begin
   if not Assigned(ScreenLoading) then
     Exit;
 
-  ScreenLoading.SetDiscoveryProgress(fDiscoveryDirsScanned, fDiscoveryDirCount, SongsFound);
+  if fDiscoveringDirectories then
+  begin
+    FilesNeeded := 0;
+    Percent := 0;
+    while (Percent < 99) and (fDiscoveryDirCount >= FilesNeeded + 5 * (Percent + 1)) do
+    begin
+      Inc(Percent);
+      Inc(FilesNeeded, 5 * Percent);
+    end;
+    ScreenLoading.SetDiscoveryProgress(Percent, 200, SongsFound);
+  end
+  else if fDiscoveryDirCount > 0 then
+    ScreenLoading.SetDiscoveryProgress(fDiscoveryDirCount + fDiscoveryDirsScanned, fDiscoveryDirCount * 2, SongsFound)
+  else
+    ScreenLoading.SetDiscoveryProgress(0, 100, SongsFound);
+
   if Force then
     ScreenLoading.RefreshProgress(true);
 end;

--- a/src/screens/UScreenLoading.pas
+++ b/src/screens/UScreenLoading.pas
@@ -66,6 +66,7 @@ type
       function ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean; override;
       procedure SetDiscoveryProgress(Current, Total, SongsFound: integer);
       procedure SetSongLoadingProgress(Current, Total: integer);
+      procedure SetStatus(const Value: UTF8String);
       procedure RefreshProgress(Force: boolean = false);
   end;
 
@@ -197,7 +198,10 @@ end;
 procedure TScreenLoading.SetDiscoveryProgress(Current, Total, SongsFound: integer);
 begin
   UpdateBar(DiscoveryBarBaseIndex, DiscoveryBarFillIndex, ClampProgress(Current, Total), DiscoveryBarAlpha * 0.5, DiscoveryBarAlpha);
-  UpdateStatus(Format('0 / %5d', [SongsFound]));
+  if SongsFound > 0 then
+    UpdateStatus(Format('0 / %5d', [SongsFound]))
+  else
+    UpdateStatus('');
   RefreshProgress;
 end;
 
@@ -209,6 +213,13 @@ begin
   else
     UpdateStatus('');
   RefreshProgress;
+end;
+
+procedure TScreenLoading.SetStatus(const Value: UTF8String);
+begin
+  if (StatusTextIndex >= 0) and (StatusTextIndex < Length(Text)) then
+    Text[StatusTextIndex].Text := Value;
+  RefreshProgress(true);
 end;
 
 procedure TScreenLoading.RefreshProgress(Force: boolean);


### PR DESCRIPTION
This PR makes the loading more responsive and the progress more visible. It has no performance advantage over the current master, it just keeps the game window responsive and updates the loading progress more.

- split discovery progress into estimated directory discovery and exact directory scanning
- keep the loading window responsive by pumping SDL events during directory discovery, scanning, and screen loading (reuse the loading statements from the window title for that)
- update the loading status text during all loading phases appropriately

