### PR TITLE
Fix SDL input device detection after fast scan

### DIFF
--- a/src/media/UAudioInput_SDL.pas
+++ b/src/media/UAudioInput_SDL.pas
@@ -91,6 +91,8 @@ begin
                       'ms) buffer', 'SDL');
       SDL_PauseAudioDevice(DevID, 0);
     end;
+    if DevID <= 0 then
+      Log.LogError('Could not open input device "' + Name + '": ' + SDL_GetError, 'SDL');
   end;
 
   Result := (DevID > 0);
@@ -202,7 +204,7 @@ begin
   // adjust size to actual input-device count
   SetLength(AudioInputProcessor.DeviceList, deviceIndex);
   Log.LogStatus('#Input-Devices: ' + IntToStr(deviceIndex), 'SDL');
-  Result := (deviceIndex > 0);
+  Result := (deviceIndex > 0) or (ScanMode = aimFast);
 end;
 
 function TAudioInput_SDL.InitializeRecord(ScanMode: TAudioInputScanMode): boolean;


### PR DESCRIPTION
This PR fixes a regression from the audio input fast-scan path where SDL input could be removed during startup if no already-configured devices were found.

`aimFast` intentionally skips unconfigured devices, so an empty device list is not enough to conclude that the SDL input backend failed. This keeps the backend available so Options -> Record can later run the full scan and discover devices.

Also logs the SDL error when opening a listed input device fails during capture startup.

Hopefully fixes #1261 but I'm also checking whether we can speed up the Options -> Record screen opening by only fully scanning the selected device.
