### PR TITLE
Avoid repeated record device scans

### DIFF
--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -403,6 +403,12 @@ begin
         Display.CheckOK := true;
       end;
 
+      SDL_AUDIODEVICEADDED, SDL_AUDIODEVICEREMOVED:
+      begin
+        if (Event.adevice.iscapture <> 0) then
+          MarkAudioInputDevicesChanged;
+      end;
+
       SDL_MOUSEMOTION, SDL_MOUSEBUTTONDOWN, SDL_MOUSEBUTTONUP, SDL_MOUSEWHEEL:
       begin
         if (Ini.Mouse > 0) then

--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -658,6 +658,8 @@ procedure InitializeSound;
 procedure InitializeVideo;
 procedure FinalizeMedia;
 function RefreshAudioInputDevices(ScanMode: TAudioInputScanMode): boolean;
+procedure MarkAudioInputDevicesChanged;
+function AudioInputDevicesNeedRefresh: boolean;
 
 function  Visualization(): IVideoPlayback;
 function  VideoPlayback(): IVideoPlayback;
@@ -696,6 +698,8 @@ var
   DefaultAudioInput    : IAudioInput;
   AudioDecoderList     : TInterfaceList;
   MediaInterfaceList   : TInterfaceList;
+  AudioInputDevicesDirty: boolean;
+  AudioInputDeviceListComplete: boolean;
 
 
 constructor TAudioFormatInfo.Create(Channels: byte; SampleRate: double; Format: TAudioSampleFormat);
@@ -793,8 +797,26 @@ begin
   Result := CurrentAudioInput.InitializeRecord(ScanMode);
   if not Result then
     Log.LogError('Failed to refresh input devices for ' + CurrentAudioInput.GetName());
+  if Result then
+  begin
+    AudioInputDevicesDirty := false;
+    AudioInputDeviceListComplete := (ScanMode = aimFull);
+  end;
 
   AudioInputProcessor.UpdateInputDeviceConfig();
+end;
+
+procedure MarkAudioInputDevicesChanged;
+begin
+  AudioInputDevicesDirty := true;
+  AudioInputDeviceListComplete := false;
+end;
+
+function AudioInputDevicesNeedRefresh: boolean;
+begin
+  Result := AudioInputDevicesDirty or
+            not AudioInputDeviceListComplete or
+            (Length(AudioInputProcessor.DeviceList) = 0);
 end;
 
 procedure SetAudioVolumePercent(Value: integer);

--- a/src/media/UAudioInput_SDL.pas
+++ b/src/media/UAudioInput_SDL.pas
@@ -91,6 +91,8 @@ begin
                       'ms) buffer', 'SDL');
       SDL_PauseAudioDevice(DevID, 0);
     end;
+    if DevID <= 0 then
+      Log.LogError('Could not open input device "' + Name + '": ' + SDL_GetError, 'SDL');
   end;
 
   Result := (DevID > 0);
@@ -202,7 +204,7 @@ begin
   // adjust size to actual input-device count
   SetLength(AudioInputProcessor.DeviceList, deviceIndex);
   Log.LogStatus('#Input-Devices: ' + IntToStr(deviceIndex), 'SDL');
-  Result := (deviceIndex > 0);
+  Result := (deviceIndex > 0) or (ScanMode = aimFast);
 end;
 
 function TAudioInput_SDL.InitializeRecord(ScanMode: TAudioInputScanMode): boolean;

--- a/src/screens/UScreenOptions.pas
+++ b/src/screens/UScreenOptions.pas
@@ -91,7 +91,8 @@ uses
 
 procedure TScreenOptions.OpenRecordOptions;
 begin
-  RefreshAudioInputDevices(aimFull);
+  if AudioInputDevicesNeedRefresh then
+    RefreshAudioInputDevices(aimFull);
   FreeAndNil(ScreenOptionsRecord);
   ScreenOptionsRecord := TScreenOptionsRecord.Create;
   FadeTo(@ScreenOptionsRecord, SoundLib.Start);


### PR DESCRIPTION
This PR avoids refreshing audio input devices every time Options -> Record is opened.

The game now tracks SDL capture-device hotplug events (`SDL_AUDIODEVICEADDED` / `SDL_AUDIODEVICEREMOVED`) and marks the cached input device list dirty only when a capture device changes. Options -> Record refreshes the list only when it is dirty, incomplete, or empty.

This keeps newly connected/removed microphones visible on the next Record screen visit while avoiding the repeated full scan delay on normal visits.