### PR TITLE
Refactor mouse actions in editor: fix collisions and smaller editor bugs

### DIFF
--- a/src/base/UEditorLyrics.pas
+++ b/src/base/UEditorLyrics.pas
@@ -98,7 +98,7 @@ type
 
       procedure SetCursor(WordIndex, CharIndex: integer);
       procedure ClearCursor;
-      function GetCursorFromPoint(const X, Y: real; out WordIndex, CharIndex: integer): boolean;
+      function GetCursorFromPoint(const X, Y, HitTop, HitBottom: real; out WordIndex, CharIndex: integer): boolean;
 
       procedure Clear;
       procedure Draw;
@@ -348,7 +348,7 @@ begin
   Result := MaxChars;
 end;
 
-function TEditorLyrics.GetCursorFromPoint(const X, Y: real; out WordIndex, CharIndex: integer): boolean;
+function TEditorLyrics.GetCursorFromPoint(const X, Y, HitTop, HitBottom: real; out WordIndex, CharIndex: integer): boolean;
 var
   Index: integer;
   LineY: real;
@@ -370,7 +370,12 @@ begin
 
   LineY := Word[0].Y;
   LineHalfHeight := SizeR;
-  if (Y < LineY - LineHalfHeight) or (Y > LineY + LineHalfHeight) then
+  if (HitBottom > HitTop) then
+  begin
+    if (Y < HitTop) or (Y > HitBottom) then
+      Exit;
+  end
+  else if (Y < LineY - LineHalfHeight) or (Y > LineY + LineHalfHeight) then
     Exit;
 
   CursorWidth := 0;

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -1840,14 +1840,14 @@ begin
       // current position in editor
       ThemeLoadButton(EditSub.ButtonCurrentLine, 'EditSubButtonCurrentLine');
       ThemeLoadButton(EditSub.ButtonCurrentNote, 'EditSubButtonCurrentNote');
-      ThemeLoadButton(EditSub.PlayOnly,    'EditSubBarStatic1');
-      ThemeLoadButton(EditSub.PlayWithNote,    'EditSubBarStatic2');
-      ThemeLoadButton(EditSub.PlayNote,    'EditSubBarStatic3');
-      ThemeLoadButton(EditSub.previousseq,    'EditSubBarStatic4');
-      ThemeLoadButton(EditSub.nextseq,    'EditSubBarStatic5');
-      ThemeLoadButton(EditSub.gold,    'EditSubBarStatic6');
-      ThemeLoadButton(EditSub.freestyle,    'EditSubBarStatic7');
-      ThemeLoadButton(EditSub.undo,    'EditSubBarStatic8');
+      ThemeLoadButton(EditSub.undo,        'EditSubBarStatic1');
+      ThemeLoadButton(EditSub.previousseq, 'EditSubBarStatic2');
+      ThemeLoadButton(EditSub.nextseq,     'EditSubBarStatic3');
+      ThemeLoadButton(EditSub.freestyle,   'EditSubBarStatic4');
+      ThemeLoadButton(EditSub.gold,        'EditSubBarStatic5');
+      ThemeLoadButton(EditSub.PlayOnly,    'EditSubBarStatic6');
+      ThemeLoadButton(EditSub.PlayWithNote,'EditSubBarStatic7');
+      ThemeLoadButton(EditSub.PlayNote,    'EditSubBarStatic8');
       ThemeLoadSelectSlide(EditSub.SlideTitle, 'EditSubTitle');
       ThemeLoadSelectSlide(EditSub.SlideArtist, 'EditSubArtist');
       ThemeLoadSelectSlide(EditSub.SlideLanguage, 'EditSubLanguage');

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -432,6 +432,7 @@ type
       procedure ShowInteractiveBackground;
       function  GetMedleyLength: real; //if available returns the length of the medley in seconds, otherwise 0
       procedure SyncVolumeSlidersFromIni;
+      procedure LoadCurrentLyricForTextEdit(CursorPosition: Integer);
       {$IFDEF UseMIDIPort}
       procedure ResetMidiLastNote;
       procedure ReleaseMidiLastNote;
@@ -1634,11 +1635,7 @@ end;
 procedure TScreenEditSub.EnterTextEditMode(SDL_ModState: word);
 begin
   // Enter Text Edit Mode
-  BackupEditText := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Text;
-  CurrentEditText := BackupEditText;
-  CurrentSlideId := LyricSlideId;
-  TextPosition := LengthUTF8(BackupEditText);
-  editLengthText := LengthUTF8(BackupEditText);
+  LoadCurrentLyricForTextEdit(-1);
   TextEditMode := true;
   StartTextInput;
 end;
@@ -1705,6 +1702,19 @@ begin
       Text[TextInfo].Text := Language.Translate('EDIT_INFO_PLAY_NOTE_MIDI');
   end;
 end;
+
+procedure TScreenEditSub.LoadCurrentLyricForTextEdit(CursorPosition: Integer);
+begin
+  BackupEditText := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Text;
+  CurrentEditText := BackupEditText;
+  editLengthText := LengthUTF8(CurrentEditText);
+  CurrentSlideId := LyricSlideId;
+  if CursorPosition < 0 then
+    TextPosition := editLengthText
+  else
+    TextPosition := EnsureRange(CursorPosition, 0, editLengthText);
+end;
+
 
       // SDLK_RETURN: ToggleTextEditMode
 procedure TScreenEditSub.ToggleTextEditMode(SDL_ModState: word);
@@ -2897,7 +2907,6 @@ begin
   PrevClickIndex := VolumeClickIndex;
 
   Result := true;
-  nBut := InteractAt(X, Y);
   Action := maNone;
 
   {$IFDEF UseMIDIPort}
@@ -2905,9 +2914,12 @@ begin
     StopMidiPlayback;
   {$ENDIF}
 
-  if BtnDown and (MouseButton = SDL_BUTTON_LEFT) and (nBut = -1) then
+  if BtnDown and (MouseButton = SDL_BUTTON_LEFT) then
   begin
-    if EditorLyrics[CurrentTrack].GetCursorFromPoint(CurrentX, CurrentY, CursorWordIndex, CursorCharIndex) then
+    if EditorLyrics[CurrentTrack].GetCursorFromPoint(CurrentX, CurrentY,
+      Theme.EditSub.SentenceBackground.Y,
+      Theme.EditSub.SentenceBackground.Y + Theme.EditSub.SentenceBackground.H,
+      CursorWordIndex, CursorCharIndex) then
     begin
       CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 1;
       CurrentNote[CurrentTrack] := CursorWordIndex;
@@ -2937,6 +2949,7 @@ begin
     end;
   end;
 
+  nBut := InteractAt(X, Y);
   if nBut >= 0 then
   begin
     //select on mouse-over

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -138,6 +138,20 @@ type
       LastPressedMouseButton:  boolean;
       LastPressedMouseType:    Integer;
       PressedNoteId:           Integer;
+      MouseDownX:              Integer;
+      MouseDownY:              Integer;
+      MouseDownModState:       word;
+      DragStartTone:           Integer;
+      DragAppliedToneDelta:    Integer;
+      DragHasMoved:            boolean;
+      DragUndoCopied:          boolean;
+      PendingNoteClick:        boolean;
+      PendingNoteClickTime:    Integer;
+      PendingNoteClickCooldownUntil: Integer;
+      PendingNoteClickTrack:   Integer;
+      PendingNoteClickLine:    Integer;
+      PendingNoteClickIndex:   Integer;
+      PendingNoteClickModState: word;
 
       TextPosition:            Integer;
       TextEditMode:            boolean;
@@ -433,6 +447,11 @@ type
       function  GetMedleyLength: real; //if available returns the length of the medley in seconds, otherwise 0
       procedure SyncVolumeSlidersFromIni;
       procedure LoadCurrentLyricForTextEdit(CursorPosition: Integer);
+      function  GetInteractiveNoteIndex(InteractionIndex: Integer): Integer;
+      procedure CancelPendingNoteClick;
+      procedure QueuePendingNoteClick(NoteIndex: Integer);
+      procedure PlayPendingNoteClick;
+      procedure SelectNote(NoteIndex: Integer);
       {$IFDEF UseMIDIPort}
       procedure ResetMidiLastNote;
       procedure ReleaseMidiLastNote;
@@ -1715,6 +1734,73 @@ begin
     TextPosition := EnsureRange(CursorPosition, 0, editLengthText);
 end;
 
+function TScreenEditSub.GetInteractiveNoteIndex(InteractionIndex: Integer): Integer;
+var
+  NoteIndex: Integer;
+begin
+  Result := -1;
+  for NoteIndex := 0 to High(InteractiveNoteId) do
+  begin
+    if InteractiveNoteId[NoteIndex] = InteractionIndex then
+    begin
+      Result := NoteIndex;
+      Exit;
+    end;
+  end;
+end;
+
+procedure TScreenEditSub.CancelPendingNoteClick;
+begin
+  PendingNoteClick := false;
+  PendingNoteClickIndex := -1;
+end;
+
+procedure TScreenEditSub.QueuePendingNoteClick(NoteIndex: Integer);
+begin
+  if SDL_GetTicks() < PendingNoteClickCooldownUntil then
+    Exit;
+
+  PendingNoteClick := true;
+  PendingNoteClickTime := SDL_GetTicks() + 250;
+  PendingNoteClickTrack := CurrentTrack;
+  PendingNoteClickLine := CurrentSong.Tracks[CurrentTrack].CurrentLine;
+  PendingNoteClickIndex := NoteIndex;
+  PendingNoteClickModState := MouseDownModState;
+end;
+
+procedure TScreenEditSub.SelectNote(NoteIndex: Integer);
+begin
+  if (NoteIndex < 0) or
+     (NoteIndex > CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].HighNote) then
+    Exit;
+
+  CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 1;
+  CurrentNote[CurrentTrack] := NoteIndex;
+  CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
+  EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
+  if TextEditMode then
+    LoadCurrentLyricForTextEdit(-1);
+end;
+
+procedure TScreenEditSub.PlayPendingNoteClick;
+begin
+  if not PendingNoteClick then
+    Exit;
+
+  if SDL_GetTicks() < PendingNoteClickTime then
+    Exit;
+
+  if (PendingNoteClickTrack = CurrentTrack) and
+     (PendingNoteClickLine = CurrentSong.Tracks[CurrentTrack].CurrentLine) and
+     (PendingNoteClickIndex >= 0) and
+     (PendingNoteClickIndex <= CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].HighNote) then
+  begin
+    SelectNote(PendingNoteClickIndex);
+    PlayNote(PendingNoteClickModState);
+  end;
+
+  CancelPendingNoteClick;
+end;
 
       // SDLK_RETURN: ToggleTextEditMode
 procedure TScreenEditSub.ToggleTextEditMode(SDL_ModState: word);
@@ -2890,11 +2976,16 @@ var
   nBut:   Integer;
   Action: TMouseClickAction;
   TempR:  real;
-  i:      Integer;
   PrevAudioIndex: Integer;
   PrevClickIndex: Integer;
   CursorWordIndex: Integer;
   CursorCharIndex: Integer;
+  NoteIndex: Integer;
+  BeatDelta: Integer;
+  NoteXBefore: real;
+  NoteXAfter: real;
+  ToneDelta: Integer;
+  SDL_ModState: word;
 begin
   // transfer mousecords to the 800x600 raster we use to draw
   X := Round((X / (ScreenW / Screens)) * RenderW);
@@ -2923,6 +3014,7 @@ begin
       Theme.EditSub.SentenceBackground.Y + Theme.EditSub.SentenceBackground.H,
       CursorWordIndex, CursorCharIndex) then
     begin
+      CancelPendingNoteClick;
       CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 1;
       CurrentNote[CurrentTrack] := CursorWordIndex;
       CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
@@ -2952,24 +3044,245 @@ begin
   end;
 
   nBut := InteractAt(X, Y);
+  NoteIndex := GetInteractiveNoteIndex(nBut);
+
   if nBut >= 0 then
   begin
     //select on mouse-over
     if nBut <> Interaction then
       SetInteraction(nBut);
   end;
-  if not BtnDown then
+
+  if BtnDown and (MouseButton = SDL_BUTTON_LEFT) and
+     (nBut >= 0) and (Interactions[nBut].Typ = iButton) and (NoteIndex < 0) then
   begin
-    PressedNoteId := -1;
-    Xmouse := 0;
+    if Interactions[nBut].Num = UndoButtonId then
+    begin
+      CopyFromUndo;
+      GoldenRec.KillAll;
+      Text[TextInfo].Text := Language.Translate('EDIT_INFO_UNDO');
+      ShowInteractiveBackground;
+      Exit;
+    end;
+
+    if Interactions[nBut].Num = PreviousSeqButtonID then
+    begin
+      PreviousSentence;
+      Exit;
+    end;
+
+    if Interactions[nBut].Num = NextSeqButtonID then
+    begin
+      NextSentence;
+      Exit;
+    end;
+
+    if Interactions[nBut].Num = FreestyleButtonID then
+    begin
+      SetFreestyleNote(0);
+      Exit;
+    end;
+
+    if Interactions[nBut].Num = GoldButtonID then
+    begin
+      SetGoldenNote(0);
+      Exit;
+    end;
+
+    if Interactions[nBut].Num = PlayOnlyButtonID then
+    begin
+      HandlePlaySentence(0);
+      Exit;
+    end;
+
+    if Interactions[nBut].Num = PlayWithNoteButtonID then
+    begin
+      HandlePlaySentence(KMOD_LSHIFT or KMOD_LCTRL);
+      Exit;
+    end;
+
+    if Interactions[nBut].Num = PlayNoteButtonID then
+    begin
+      HandlePlaySentence(KMOD_LSHIFT);
+      Exit;
+    end;
   end;
 
-  if (nBut > -1) then
+  if not BtnDown then
+  begin
+    if (MouseButton = SDL_BUTTON_LEFT) and (PressedNoteId >= 0) and (not DragHasMoved) then
+      QueuePendingNoteClick(PressedNoteId);
+
+    PressedNoteId := -1;
+    Xmouse := 0;
+    DragHasMoved := false;
+    DragUndoCopied := false;
+  end;
+
+  if (nBut > -1) or ((MouseButton = 0) and BtnDown and (PressedNoteId >= 0)) then
   begin
   if (BtnDown) then
   begin
+    if ((MouseButton = SDL_BUTTON_RIGHT) or (MouseButton = SDL_BUTTON_LEFT)) and (NoteIndex >= 0) then
+    begin
+      LastPressedMouseType := MouseButton;
+      LastX := CurrentX;
+      LastY := CurrentY;
+      MouseDownX := CurrentX;
+      MouseDownY := CurrentY;
+      MouseDownModState := SDL_GetModState and (KMOD_LSHIFT + KMOD_RSHIFT
+        + KMOD_LCTRL + KMOD_RCTRL + KMOD_LALT  + KMOD_RALT {+ KMOD_CAPS});
+      PressedNoteId := NoteIndex;
+      DragStartTone := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[NoteIndex].Tone;
+      DragAppliedToneDelta := 0;
+      DragHasMoved := false;
+      DragUndoCopied := false;
+
+      MoveNote := true;
+      ResizeNoteLeft := false;
+      ResizeNoteRight := false;
+      if (Interactions[nBut].Typ = iButton) then
+      begin
+        if CurrentX < Button[Interactions[nBut].Num].X + Button[Interactions[nBut].Num].W * 0.2 then
+        begin
+          ResizeNoteLeft := true;
+          MoveNote := false;
+        end
+        else if CurrentX > Button[Interactions[nBut].Num].X + Button[Interactions[nBut].Num].W - Button[Interactions[nBut].Num].W * 0.2 then
+        begin
+          ResizeNoteRight := true;
+          MoveNote := false;
+        end;
+      end;
+
+      SelectNote(NoteIndex);
+
+      SDL_ModState := SDL_GetModState and (KMOD_LSHIFT + KMOD_RSHIFT
+        + KMOD_LCTRL + KMOD_RCTRL + KMOD_LALT  + KMOD_RALT {+ KMOD_CAPS});
+      if (MouseButton = SDL_BUTTON_LEFT) and PendingNoteClick and
+         (PendingNoteClickTrack = CurrentTrack) and
+         (PendingNoteClickLine = CurrentSong.Tracks[CurrentTrack].CurrentLine) and
+         (PendingNoteClickIndex = NoteIndex) and
+         (SDL_GetTicks() < PendingNoteClickTime) and
+         (SDL_ModState = 0) then
+      begin
+        CancelPendingNoteClick;
+        PendingNoteClickCooldownUntil := SDL_GetTicks() + 350;
+        CopyToUndo;
+        GoldenRec.KillAll;
+        DivideNote(true);
+        ShowInteractiveBackground;
+        PressedNoteId := -1;
+        Exit;
+      end;
+
+      if (MouseButton = SDL_BUTTON_LEFT) or (MouseButton = SDL_BUTTON_RIGHT) then
+        CancelPendingNoteClick;
+
+      Exit;
+    end;
+
+    if (MouseButton = 0) and (PressedNoteId >= 0) then
+    begin
+      if (Abs(CurrentX - MouseDownX) > 3) or (Abs(CurrentY - MouseDownY) > 3) then
+      begin
+        DragHasMoved := true;
+        CancelPendingNoteClick;
+      end;
+
+      if DragHasMoved then
+      begin
+        TempR := 720 / (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat - CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat);
+        BeatDelta := Round((CurrentX - LastX) / TempR);
+        if MoveNote and (LastPressedMouseType <> SDL_BUTTON_RIGHT) then
+          ToneDelta := -Round((CurrentY - MouseDownY) / (LineSpacing / 2)) - DragAppliedToneDelta
+        else
+          ToneDelta := 0;
+
+        if (BeatDelta <> 0) or (ToneDelta <> 0) then
+        begin
+          if not DragUndoCopied then
+          begin
+            CopyToUndo;
+            DragUndoCopied := true;
+          end;
+
+          if BeatDelta <> 0 then
+          begin
+            NoteXBefore := Theme.EditSub.NotesBackground.X + NotesSkipX +
+              (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat -
+              CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat) * TempR + 0.5;
+            if ResizeNoteRight then
+              NoteXBefore := NoteXBefore + CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration * TempR - 0.5;
+
+            if LastPressedMouseType = SDL_BUTTON_RIGHT then
+            begin
+              if MoveNote then
+                MoveAllToEnd(BeatDelta);
+              if (ResizeNoteRight) and (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration + BeatDelta > 0) then
+              begin
+                CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration + BeatDelta;
+                if CurrentNote[CurrentTrack] = CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].HighNote then
+                  CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat + BeatDelta;
+              end;
+              if (ResizeNoteLeft) and (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration - BeatDelta > 0) then
+              begin
+                CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat + BeatDelta;
+                CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration - BeatDelta;
+                if CurrentNote[CurrentTrack] = 0 then
+                  CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].StartBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].StartBeat + BeatDelta;
+              end;
+            end
+            else
+            begin
+              if MoveNote then
+              begin
+                CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat + BeatDelta;
+                if CurrentNote[CurrentTrack] = 0 then
+                  CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].StartBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].StartBeat - BeatDelta;
+                if CurrentNote[CurrentTrack] = CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].HighNote then
+                  CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat + BeatDelta;
+              end;
+              if (ResizeNoteRight) and (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration + BeatDelta > 0) then
+              begin
+                CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration + BeatDelta;
+                if CurrentNote[CurrentTrack] = CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].HighNote then
+                  CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat + BeatDelta;
+              end;
+              if (ResizeNoteLeft) and (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration - BeatDelta > 0) then
+              begin
+                CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat + BeatDelta;
+                CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration - BeatDelta;
+                if CurrentNote[CurrentTrack] = 0 then
+                  CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].StartBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].StartBeat + BeatDelta;
+              end;
+            end;
+
+            TempR := 720 / (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat - CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat);
+            NoteXAfter := Theme.EditSub.NotesBackground.X + NotesSkipX +
+              (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat -
+              CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat) * TempR + 0.5;
+            if ResizeNoteRight then
+              NoteXAfter := NoteXAfter + CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration * TempR - 0.5;
+            LastX := LastX + Round(NoteXAfter - NoteXBefore);
+          end;
+
+          if ToneDelta <> 0 then
+          begin
+            CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Tone := DragStartTone + DragAppliedToneDelta + ToneDelta;
+            Inc(DragAppliedToneDelta, ToneDelta);
+          end;
+
+          GoldenRec.KillAll;
+          ShowInteractiveBackground;
+        end;
+      end;
+      Exit;
+    end;
+
     if (MouseButton = SDL_BUTTON_RIGHT) or (MouseButton = SDL_BUTTON_LEFT) then
     begin
+      CancelPendingNoteClick;
       LastPressedMouseType := MouseButton;
       LastX := CurrentX;
       LastY := CurrentY;
@@ -2977,26 +3290,6 @@ begin
       MoveNote := true;
       ResizeNoteLeft := false;
       ResizeNoteRight := false;
-      // check current mouse position to resize note - 20% of left or right note to resize
-      if (Interactions[nBut].Typ = iButton) then
-      begin
-        if CurrentX < Button[Interactions[nBut].Num].X + Button[Interactions[nBut].Num].W * 0.2 then
-        begin
-          // selected left side note - 20%
-          ResizeNoteLeft := true;
-          ResizeNoteRight := false;
-          MoveNote := false;
-        end;
-
-        if CurrentX > Button[Interactions[nBut].Num].X + Button[Interactions[nBut].Num].W - Button[Interactions[nBut].Num].W * 0.2 then
-        begin
-          // selected right side note - 20%
-          ResizeNoteLeft := false;
-          ResizeNoteRight := true;
-          MoveNote := false;
-        end;
-        PressedNoteId :=  Interactions[nBut].Num;
-      end;
     end;
 
     if (MouseButton = SDL_BUTTON_LEFT) then
@@ -3008,92 +3301,6 @@ begin
       end
       else
         Action := maReturn;
-    end;
-
-    // move notes by mouse move (left-right)
-    TempR := 720 / (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat - CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat);
-    if (MouseButton = 0) and (LastPressedMouseType = SDL_BUTTON_RIGHT) and (PressedNoteId >=0) then
-    begin
-      // left & right
-      if (Floor((CurrentX - 40) / TempR) > Floor((LastX - 40) / TempR)) or  (Floor((CurrentX - 40) / TempR) < Floor((LastX - 40) / TempR)) then
-      begin
-        CopyToUndo;
-        i := Floor((currentx-40) / Floor(TempR)) - Floor((lastx - 40) / Floor(TempR));
-        if MoveNote then
-          MoveAllToEnd(i);
-        if (ResizeNoteRight) and (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration + i > 0) then
-        begin
-          MoveAllToEnd(i);
-          CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat - i;
-          CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration + i;
-        end;
-        if (ResizeNoteLeft) and (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration - i > 0) then
-        begin
-          CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat + i;
-          CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration - i;
-          if CurrentNote[CurrentTrack] = 0 then
-            CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].StartBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].StartBeat - i;
-        end;
-        LastX := CurrentX;
-        GoldenRec.KillAll;
-        ShowInteractiveBackground;
-      end;
-      // up & down
-      if (CurrentY - LastY < -6) or (CurrentY - LastY > 6) then
-      begin
-        CopyToUndo;
-        TransposeNote(-1* Floor((CurrentY-LastY) div (6)));
-        LastY := CurrentY;
-        GoldenRec.KillAll;
-        ShowInteractiveBackground;
-      end;
-    end;
-
-    //move one note by mouse move
-    if (MouseButton = 0) and (LastPressedMouseType = SDL_BUTTON_LEFT) and (PressedNoteId >= 0) then
-    begin
-      if (Floor((CurrentX - 40) / TempR) > Floor((LastX - 40) / TempR)) or (Floor((CurrentX - 40) / TempR) < Floor((LastX - 40) / TempR)) then
-      begin
-        CopyToUndo;
-        // move left & right
-        i := Floor((currentx - 40) / Floor(TempR)) - Floor((lastx - 40) / Floor(TempR));
-        if MoveNote then
-        begin
-            CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat +i;
-            if CurrentNote[CurrentTrack] = 0 then
-              CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].StartBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].StartBeat - i;
-            if CurrentNote[CurrentTrack] = CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].HighNote then
-              CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat + i;
-        end;
-        // resize note
-        if (ResizeNoteRight) and (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration + i > 0) then
-        begin
-          CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration + i;
-          if CurrentNote[CurrentTrack] = CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].HighNote then
-              CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat + i;
-        end;
-        if (ResizeNoteLeft) and (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration - i > 0) then
-        begin
-          CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat + i;
-          CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration - i;
-          if CurrentNote[CurrentTrack] = 0 then
-              CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].StartBeat := CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].StartBeat + i;
-        end;
-
-        LastX := CurrentX;
-        GoldenRec.KillAll;
-        ShowInteractiveBackground;
-      end;
-
-      // up & down
-      if (CurrentY - LastY < -6) or (CurrentY - LastY > 6) then
-      begin
-        CopyToUndo;
-        TransposeNote(-1* Floor((CurrentY-LastY) div (6)));
-        LastY := CurrentY;
-        GoldenRec.KillAll;
-        ShowInteractiveBackground;
-      end;
     end;
 
     // change to next sequence
@@ -3213,7 +3420,7 @@ begin
   if (VolumeClickSlideId = Interactions[nBut].Num) and (VolumeClickIndex <> PrevClickIndex) then
     SetSfxVolumePercent(EnsureRange(VolumeClickIndex, 0, 100));
   end
-  else if (MouseButton = SDL_BUTTON_RIGHT) then
+  else if BtnDown and (MouseButton = SDL_BUTTON_RIGHT) then
   begin
     if length(UndoLines) > 0 then
     begin
@@ -3800,6 +4007,12 @@ begin
 
   with CurrentSong.Tracks[CurrentTrack].Lines[LineIndex] do
   begin
+    if not doubleclick then
+      CutPosition := Round(Notes[CurrentNote[CurrentTrack]].Duration / 2);
+
+    if (CutPosition <= 0) or (CutPosition >= Notes[CurrentNote[CurrentTrack]].Duration) then
+      Exit;
+
     Inc(HighNote);
     SetLength(Notes, HighNote + 1);
 
@@ -5807,6 +6020,11 @@ begin
     ResizeNoteLeft := false;
     ResizeNoteRight := false;
     MoveNote := false;
+    PressedNoteId := -1;
+    DragHasMoved := false;
+    DragUndoCopied := false;
+    PendingNoteClickCooldownUntil := 0;
+    CancelPendingNoteClick;
     //show transparent background for notes
     ShowInteractiveBackground;
     // user input tracking
@@ -5881,6 +6099,7 @@ var
   {$ENDIF}
 begin
   SyncVolumeSlidersFromIni;
+  PlayPendingNoteClick;
 
   {$IFDEF UseMIDIPort} // midi music
   if PlaySentenceMidi and Not (PlayOneMidi) then
@@ -6232,6 +6451,8 @@ end;
 
 procedure TScreenEditSub.OnHide;
 begin
+  CancelPendingNoteClick;
+  PressedNoteId := -1;
   {$IFDEF UseMIDIPort}
   StopMidiPlayback;
   FreeAndNil(MidiOut);

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -1813,7 +1813,7 @@ begin
     // Interaction = 16 // PreviewSlideId
     // Interaction = 17 // RelativeSlideId
 
-    if Interaction = MedleyStartSlideId then
+    if CurrentSong.isDuet and (Interaction = MedleyStartSlideId) then
     begin
       BackupEditText := ifthen(CurrentSong.DuetNames[0] <> '', CurrentSong.DuetNames[0], NOT_SET);
       CurrentEditText := ifthen(BackupEditText <> NOT_SET, BackupEditText, '');
@@ -1824,7 +1824,7 @@ begin
       StartTextInput;
     end;
 
-    if Interaction = MedleyEndSlideId then
+    if CurrentSong.isDuet and (Interaction = MedleyEndSlideId) then
     begin
       BackupEditText := ifthen(CurrentSong.DuetNames[1] <> '', CurrentSong.DuetNames[1], NOT_SET);
       CurrentEditText := ifthen(BackupEditText <> NOT_SET, BackupEditText, '');
@@ -1850,7 +1850,7 @@ begin
       StartTextInput;
     end;
 
-    if Interaction = 24 then // UndoButtonId
+    if (Interactions[Interaction].Typ = iButton) and (Interactions[Interaction].Num = UndoButtonId) then
     begin
       CopyFromUndo;
       GoldenRec.KillAll;
@@ -1858,17 +1858,17 @@ begin
       ShowInteractiveBackground;
     end;
 
-    if Interaction = 25 then // PreviousSeqButtonID
+    if (Interactions[Interaction].Typ = iButton) and (Interactions[Interaction].Num = PreviousSeqButtonID) then
     begin
       PreviousSentence;
     end;
 
-    if Interaction = 26 then // NextSeqButtonID
+    if (Interactions[Interaction].Typ = iButton) and (Interactions[Interaction].Num = NextSeqButtonID) then
     begin
       NextSentence;
     end;
 
-    if Interaction = 27 then // FreestyleButtonID
+    if (Interactions[Interaction].Typ = iButton) and (Interactions[Interaction].Num = FreestyleButtonID) then
     begin
       CopyToUndo;
       if (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].NoteType = ntFreestyle) then
@@ -1891,7 +1891,7 @@ begin
       Exit;
     end;
 
-    if Interaction = 28 then // GoldButtonID
+    if (Interactions[Interaction].Typ = iButton) and (Interactions[Interaction].Num = GoldButtonID) then
     begin
       CopyToUndo;
       if (CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].NoteType = ntGolden) then
@@ -1910,7 +1910,7 @@ begin
       Exit;
     end;
 
-    if Interaction = 29 then // PlayOnlyButtonID
+    if (Interactions[Interaction].Typ = iButton) and (Interactions[Interaction].Num = PlayOnlyButtonID) then
     begin
       // Play Sentence
       Click := true;
@@ -1931,7 +1931,7 @@ begin
       Text[TextInfo].Text := Language.Translate('EDIT_INFO_PLAY_SENTENCE');
     end;
 
-    if Interaction = 30 then // PlayWithNoteButtonID
+    if (Interactions[Interaction].Typ = iButton) and (Interactions[Interaction].Num = PlayWithNoteButtonID) then
     begin
       CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 1;
       CurrentNote[CurrentTrack] := 0;
@@ -1957,7 +1957,7 @@ begin
       Text[TextInfo].Text := Language.Translate('EDIT_INFO_PLAY_SENTENCE');
     end;
 
-    if Interaction = 31 then // PlayNoteButtonID
+    if (Interactions[Interaction].Typ = iButton) and (Interactions[Interaction].Num = PlayNoteButtonID) then
     begin
       CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 1;
       CurrentNote[CurrentTrack] := 0;

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -2092,6 +2092,7 @@ begin
     AudioPlayback.Stop;
     PlaySentence := false;
     PlayOne := false;
+    PlaySentenceMidi := false;
     PlayVideo := false;
     CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 1;
     Inc(CurrentNote[CurrentTrack]);
@@ -2168,6 +2169,7 @@ begin
     AudioPlayback.Stop();
     PlaySentence := false;
     PlayOne := false;
+    PlaySentenceMidi := false;
     PlayVideo := false;
 
     CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 1;
@@ -3643,6 +3645,7 @@ begin
   EditorLyrics[CurrentTrack].Selected := 0;
   AudioPlayback.Stop();
   PlaySentence := false;
+  PlaySentenceMidi := false;
   PlayVideo := false;
   GoldenRec.KillAll;
 end;
@@ -3652,6 +3655,7 @@ begin
   AudioPlayback.Stop();
   PlayVideo := false;
   PlaySentence := false;
+  PlaySentenceMidi := false;
   PlayOne := false;
 
   CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 1;


### PR DESCRIPTION
This PR is large mainly because the old mouse handler mixed click, double-click, drag, resize, right-click, and generic button actions in one block. This changes that flow so each mouse action has a clearer owner:

- Separates note click playback from drag, resize, and double-click handling. (Play + Move bug)
- Gives lyric clicks precedence over note/button interactions behind the lyrics area.
- Improves note drag/resize tracking so fast mouse movement does not accumulate pointer drift.
- Prevents resize mode from changing pitch vertically.
- Clears stale sentence MIDI playback state in existing navigation stop paths. (Alt+V bug)
- Maps the editor toolbar buttons to the correct themed statics.
- Prevents toolbar clicks from falling through into note playback/drag behavior.
- Adds a short cooldown after double-click split so triple-click does not immediately play.
- Routes mouse note playback through the same PlayNote modifier behavior as keyboard playback.
- Prevents right-click shift-all from changing note pitch vertically.
- Avoids entering duet P1/P2 edit mode from medley fields in non-duet songs.
- Handles selecting a different note while in text edit mode.