### PR TITLE
midi volume control should be immediate and include midi emulation

### DIFF
--- a/src/base/UIni.pas
+++ b/src/base/UIni.pas
@@ -186,6 +186,7 @@ type
 
       AudioVolume:    integer;
       VocalsVolume:   integer;
+      MidiVolume:     integer;
       SfxVolume:      integer;
       BackgroundMusicVolume: integer;
 
@@ -1631,6 +1632,7 @@ begin
 
   AudioVolume  := ReadVolumePercent('Sound', 'AudioVolume', 100);
   VocalsVolume := ReadVolumePercent('Sound', 'VocalsVolume', 100);
+  MidiVolume   := ReadVolumePercent('Sound', 'MidiVolume', 100);
   SfxVolume    := ReadVolumePercent('Sound', 'SfxVolume', 100);
   PreviewVolume := ReadVolumePercent('Sound', 'PreviewVolume', 30);
   BackgroundMusicVolume := ReadVolumePercent('Sound', 'BackgroundMusicVolume', 40);
@@ -1951,6 +1953,7 @@ begin
     // Volume Settings
     IniFile.WriteInteger('Sound', 'AudioVolume', AudioVolume);
     IniFile.WriteInteger('Sound', 'VocalsVolume', VocalsVolume);
+    IniFile.WriteInteger('Sound', 'MidiVolume', MidiVolume);
     IniFile.WriteInteger('Sound', 'SfxVolume', SfxVolume);
     IniFile.WriteInteger('Sound', 'BackgroundMusicVolume', BackgroundMusicVolume);
     IniFile.WriteInteger('Sound', 'PreviewVolume', PreviewVolume);

--- a/src/lib/midiemu/MidiAudioSourceStream.pas
+++ b/src/lib/midiemu/MidiAudioSourceStream.pas
@@ -31,6 +31,7 @@ type
     FNote: Integer;
     FFreq: Double;
     FVel: Double;
+    FChannelVolume: Double;
     FPhase: Double;
     FRelease: Boolean;
     FEnvLevel: Double;
@@ -66,6 +67,7 @@ begin
   FNote := -1;
   FFreq := 440.0;
   FVel := 0.0;
+  FChannelVolume := 1.0;
   FOvertoneLevel := 0.0;
   FOvertoneDecay := Power(3e-10, 1 / FFormat.SampleRate); // after 1s amplitude has fallen to 3e-10
   FLock := TCriticalSection.Create;
@@ -140,9 +142,9 @@ begin
 
       if FActive then
       begin
-        sample := Sin(FPhase) * FVel * FEnvLevel;
+        sample := Sin(FPhase) * FVel * FChannelVolume * FEnvLevel;
         // Add overtone with exponential decay for note restart detection
-        overtone := Sin(2 * FPhase) * FOvertoneLevel * FEnvLevel;
+        overtone := Sin(2 * FPhase) * FOvertoneLevel * FChannelVolume * FEnvLevel;
         sample := sample + overtone;
         // Decay overtone
         FOvertoneLevel := FOvertoneLevel * FOvertoneDecay;
@@ -199,6 +201,12 @@ begin
       FEnvLevel := 0;
       FVel := 0;
       FNote := -1;
+      Exit;
+    end;
+
+    if ((MidiMessage and $F0) = MIDI_CONTROLCHANGE) and (Data1 = $07) then
+    begin
+      FChannelVolume := Sqr(Data2 / 127.0);
       Exit;
     end;
 

--- a/src/lib/midiemu/MidiOut.pas
+++ b/src/lib/midiemu/MidiOut.pas
@@ -118,11 +118,6 @@ begin
   if ((MidiMessage and $F0) = $90) and (Data2 <> 0) then
   begin
     Play;
-  end
-  else if ((MidiMessage and $F0) = $B0) and (Data1 = 7) then
-  begin
-    if Assigned(FPlaybackStream) then
-       FPlaybackStream.Volume := Sqr(Data2 / 127);
   end;
   
   if Assigned(FSourceStream) then

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -436,6 +436,7 @@ type
       procedure ResetMidiLastNote;
       procedure ReleaseMidiLastNote;
       procedure StopMidiPlayback;
+      procedure ApplyMidiVolume;
       procedure UpdateMidiPitchOffset;
       function  GetMidiPitch(NoteTone: Integer): Byte;
       {$ENDIF}
@@ -1027,6 +1028,13 @@ begin
   end;
 
   ResetMidiLastNote;
+end;
+
+procedure TScreenEditSub.ApplyMidiVolume;
+begin
+  if Assigned(MidiOut) and
+     (VolumeMidiSlideId >= 0) and (VolumeMidiSlideId <= High(SelectsS)) then
+    MidiOut.PutShort($B1, $7, Floor(1.27 * EnsureRange(SelectsS[VolumeMidiSlideId].SelectedOption, 0, 100)));
 end;
 {$ENDIF}
 
@@ -2880,6 +2888,7 @@ var
   TempR:  real;
   i:      Integer;
   PrevAudioIndex: Integer;
+  PrevMidiIndex: Integer;
   PrevClickIndex: Integer;
   CursorWordIndex: Integer;
   CursorCharIndex: Integer;
@@ -2894,6 +2903,7 @@ begin
   CurrentY := Y;
 
   PrevAudioIndex := VolumeAudioIndex;
+  PrevMidiIndex := VolumeMidiIndex;
   PrevClickIndex := VolumeClickIndex;
 
   Result := true;
@@ -3194,6 +3204,11 @@ begin
 
   if (VolumeAudioSlideId = Interactions[nBut].Num) and (VolumeAudioIndex <> PrevAudioIndex) then
     SetAudioVolumePercent(EnsureRange(VolumeAudioIndex, 0, 100));
+
+  {$IFDEF UseMIDIPort}
+  if (VolumeMidiSlideId = Interactions[nBut].Num) and (VolumeMidiIndex <> PrevMidiIndex) then
+    ApplyMidiVolume;
+  {$ENDIF}
 
   if (VolumeClickSlideId = Interactions[nBut].Num) and (VolumeClickIndex <> PrevClickIndex) then
     SetSfxVolumePercent(EnsureRange(VolumeClickIndex, 0, 100));

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -1034,7 +1034,10 @@ procedure TScreenEditSub.ApplyMidiVolume;
 begin
   if Assigned(MidiOut) and
      (VolumeMidiSlideId >= 0) and (VolumeMidiSlideId <= High(SelectsS)) then
-    MidiOut.PutShort($B1, $7, Floor(1.27 * EnsureRange(SelectsS[VolumeMidiSlideId].SelectedOption, 0, 100)));
+  begin
+    Ini.MidiVolume := EnsureRange(SelectsS[VolumeMidiSlideId].SelectedOption, 0, 100);
+    MidiOut.PutShort($B1, $7, Floor(1.27 * Ini.MidiVolume));
+  end;
 end;
 {$ENDIF}
 
@@ -3207,7 +3210,10 @@ begin
 
   {$IFDEF UseMIDIPort}
   if (VolumeMidiSlideId = Interactions[nBut].Num) and (VolumeMidiIndex <> PrevMidiIndex) then
+  begin
     ApplyMidiVolume;
+    Ini.Save;
+  end;
   {$ENDIF}
 
   if (VolumeClickSlideId = Interactions[nBut].Num) and (VolumeClickIndex <> PrevClickIndex) then
@@ -5748,7 +5754,7 @@ begin
       VolumeClick[VolumeIndex] := IntToStr(VolumeIndex);
     end;
     VolumeAudioIndex := EnsureRange(Ini.AudioVolume, 0, 100);
-    VolumeMidiIndex  := 100;
+    VolumeMidiIndex  := EnsureRange(Ini.MidiVolume, 0, 100);
     VolumeClickIndex := EnsureRange(Ini.SfxVolume, 0, 100);
     UpdateSelectSlideOptions(VolumeAudioSlideId, VolumeAudio, VolumeAudioIndex);
     UpdateSelectSlideOptions(VolumeMidiSlideId,  VolumeMidi,  VolumeMidiIndex);
@@ -5850,6 +5856,7 @@ end;
 procedure TScreenEditSub.SyncVolumeSlidersFromIni;
 var
   NewAudio: Integer;
+  NewMidi: Integer;
   NewClick: Integer;
 begin
   NewAudio := EnsureRange(Ini.AudioVolume, 0, 100);
@@ -5858,6 +5865,14 @@ begin
   begin
     VolumeAudioIndex := NewAudio;
     SelectsS[VolumeAudioSlideId].SelectedOption := VolumeAudioIndex;
+  end;
+
+  NewMidi := EnsureRange(Ini.MidiVolume, 0, 100);
+  if (VolumeMidiIndex <> NewMidi) and
+     (VolumeMidiSlideId >= 0) and (VolumeMidiSlideId <= High(SelectsS)) then
+  begin
+    VolumeMidiIndex := NewMidi;
+    SelectsS[VolumeMidiSlideId].SelectedOption := VolumeMidiIndex;
   end;
 
   NewClick := EnsureRange(Ini.SfxVolume, 0, 100);


### PR DESCRIPTION
This PR  makes sure to send updated MIDI volume immediately when the editor MIDI volume slider changes.
It also applies MIDI CC 7 volume inside the MIDI emulation synth. It also applies this to currently sounding emulated notes.