### PR TITLE
round scores to whole numbers, but not multiples of 10

### DIFF
--- a/src/base/UNote.pas
+++ b/src/base/UNote.pas
@@ -196,28 +196,34 @@ begin
 end;
 procedure TPlayer.UpdateIntScores();
 begin
-  // a problem if we use floor instead of round is that a score of
-  // 10000 points is only possible if the last digit of the total points
-  // for golden and normal notes is 0.
-  // if we use round, the max score is 10000 for most songs
-  // but a score of 10010 is possible if the last digit of the total
-  // points for golden and normal notes is 5
-  // the best solution is to use round for one of these scores
-  // and round the other score in the opposite direction
-  // so we assure that the highest possible score is 10000 in every case.
-  _ScoreInt := round(Score / 10) * 10;
-  if (_ScoreInt < Score) then
-    //normal score is floored so we have to ceil golden notes score
-    _ScoreGoldenInt := ceil(ScoreGolden / 10) * 10
-  else
-    //normal score is ceiled so we have to floor golden notes score
-    _ScoreGoldenInt := floor(ScoreGolden / 10) * 10;
-
-  // line bonus
-  _ScoreLineInt := Floor(Round(ScoreLine) / 10) * 10;
-
   // total score
-  _ScoreTotalInt := ScoreInt + ScoreGoldenInt + ScoreLineInt;
+  _ScoreTotalInt := round(Score + ScoreGolden + ScoreLine);
+  // components
+  _ScoreInt := round(Score);
+  _ScoreGoldenInt := round(ScoreGolden);
+  _ScoreLineInt := round(ScoreLine);
+  // _ScoreTotalInt = as close to the truth as possible, but the components might not add up to it
+  // this can happen if:
+  // * all the components are .2 (total is one higher than sum of components)
+  // * all the components are .6 (total is one less than the sum of components)
+  // in these cases we just +1/-1 a component until it fits
+  while (_ScoreInt + _ScoreGoldenInt + _ScoreLineInt > _ScoreTotalInt) do begin
+    // prefer decreasing golden notes first, then regular notes, as a last resort just -1 the line bonus
+    if (_ScoreGoldenInt > 0) then
+      _ScoreGoldenInt := _ScoreGoldenInt - 1
+    else if (_ScoreInt > 0) then
+      _ScoreInt := _ScoreInt - 1
+    else
+      _ScoreLineInt := _ScoreLineInt - 1;
+  end;
+  while (_ScoreInt + _ScoreGoldenInt + _ScoreLineInt < _ScoreTotalInt) do begin
+    // if the very first note(s) is golden AND this is the very beginning of the song, this might (temporarily) increase the wrong one.
+    // it is estimated that there are way more songs that simply don't have golden notes at all and where it thus would pick the correct one.
+    if (_ScoreInt > 0) or (_ScoreGoldenInt = 0) then
+      _ScoreInt := _ScoreInt + 1
+    else
+      _ScoreGoldenInt := _ScoreGoldenInt + 1;
+  end;
 end;
 procedure TPlayer.ResetScores();
 begin

--- a/src/base/UNote.pas
+++ b/src/base/UNote.pas
@@ -206,8 +206,8 @@ begin
   // this can happen if:
   // * all the components are .2 (total is one higher than sum of components)
   // * all the components are .6 (total is one less than the sum of components)
-  // in these cases we just +1/-1 a component until it fits
-  while (_ScoreInt + _ScoreGoldenInt + _ScoreLineInt > _ScoreTotalInt) do begin
+  // in these cases we just +1/-1 a component so that it fits
+  if (_ScoreInt + _ScoreGoldenInt + _ScoreLineInt > _ScoreTotalInt) then begin
     // prefer decreasing golden notes first, then regular notes, as a last resort just -1 the line bonus
     if (_ScoreGoldenInt > 0) then
       _ScoreGoldenInt := _ScoreGoldenInt - 1
@@ -215,8 +215,7 @@ begin
       _ScoreInt := _ScoreInt - 1
     else
       _ScoreLineInt := _ScoreLineInt - 1;
-  end;
-  while (_ScoreInt + _ScoreGoldenInt + _ScoreLineInt < _ScoreTotalInt) do begin
+  end else if (_ScoreInt + _ScoreGoldenInt + _ScoreLineInt < _ScoreTotalInt) then begin
     // if the very first note(s) is golden AND this is the very beginning of the song, this might (temporarily) increase the wrong one.
     // it is estimated that there are way more songs that simply don't have golden notes at all and where it thus would pick the correct one.
     if (_ScoreInt > 0) or (_ScoreGoldenInt = 0) then

--- a/src/base/USingScores.pas
+++ b/src/base/USingScores.pas
@@ -1195,7 +1195,7 @@ begin
     SetFontPos(Position.TextX, Position.TextY);
     SetFontReflection(false, 0);
 
-    ScoreStr := InttoStr(Players[Index].ScoreDisplayed div 10) + '0';
+    ScoreStr := InttoStr(Players[Index].ScoreDisplayed);
     while (Length(ScoreStr) < 5) do
       ScoreStr := '0' + ScoreStr;
 


### PR DESCRIPTION
This change will be marked as breaking in release notes. It's not breaking for end users, but any highscore website might need to adjust their input validation to no longer require multiples of 10.

Rationale for this change: during an event in 2024 lily and me often got identical or very close scores. Because of the amount of rounding involved, it was unclear if we were actually equal, or maybe one of us won by 15 points. In early 2025 I made a first version of this. While this was still off-by-one in some cases, it immediately proved useful at an event in May 2025, where on like the second song we immediately ended with 7575 vs 7577.

Other usecases I've seen over the year I've been running with it are that when replaying songs to go for a new highscore, I've more than once ended up on _exactly_  my previous highscore, or improved it by literally 1 point.

I have also not heard any negative comments from normal/casual players. The 0 was always on screen, now it's an actual value but humans only seem to "parse" it when the scores are actually that close. 83xx is still higher than 81xx at a glance.

With this new version, the total score will be off by at most 0.5, instead of double digits for the multiples of 10. Individual components are also a lot closer to their actual score. The `while` loops will in practice only do +1 XOR -1 to a single component.