### PR TITLE
do not play midi when clicking a note

### DIFF
--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -2010,16 +2010,12 @@ begin
         CurrentNote[CurrentTrack] := NoteIndex;
         CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := P1_INVERTED;
         EditorLyrics[CurrentTrack].Selected := CurrentNote[CurrentTrack];
-        //play current note playonewithmidi
+        //play current note
         PlaySentenceMidi := false;
         midinotefound := false;
         PlayOne := true;
-        PlayOneMidi := true;
-        {$IFDEF UseMIDIPort} MidiTime := USTime.GetTime;
-        MidiStart := GetTimeFromBeat(CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat);
-        MidiStop := GetTimeFromBeat(
-          CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].StartBeat +
-          CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Duration); {$ENDIF}
+        // TODO: temporary fix: don't force-play Midi when clicking a note
+        PlayOneMidi := false;
 
         // playone
         PlayVideo := false;


### PR DESCRIPTION
it's incredibly annoying when splitting notes by double-clicking. this is a temporary way of achieving this goal since the mouse in the editor in general appears to be mostly broken. it is also questionable as to whether this midi-playing when clicking a note was ever a wider-agreed-upon feature

this midi-playing-when-clicking appears to have been silently introduced by https://github.com/UltraStar-Deluxe/legacy-sourceforge-svn-mirror/commit/debbdd3c1cfe9ff74c02a282ade69dd0dcbbc2a1 which is weird because there was always a placeholder for the keyboard way of doing it (the `Play Midi` comment was always there) but it silently changes the click comment and the commit message doesn't tell anything.

#1266 also addresses this, but also tries to address some other issues but also keeps introducing new bugs preventing it from getting merged, and I'm not willing to push the release back any more for it