### PR TITLE
Remove in-game console/log overlay

### DIFF
--- a/src/base/UCommon.pas
+++ b/src/base/UCommon.pas
@@ -439,8 +439,6 @@ var
  *)
 procedure _ConsoleWriteLn(const aString: string); {$IFDEF HasInline}inline;{$ENDIF}
 begin
-  if Log <> nil then
-    Log.LogConsole(aString);
   {$IFDEF MSWINDOWS}
   // sanity check to avoid crashes with writeln()
   if IsConsole and HasConsole then

--- a/src/base/ULog.pas
+++ b/src/base/ULog.pas
@@ -66,8 +66,6 @@ const
   LOG_LEVEL_DEFAULT      = LOG_LEVEL_WARN;
   LOG_FILE_LEVEL_DEFAULT = LOG_LEVEL_ERROR;
 
-  CONSOLE_SCROLLBACK_SIZE = 512;
-
 type
   TLog = class
   private
@@ -75,7 +73,6 @@ type
     LogFileOpened:       boolean;
     BenchmarkFile:       TextFile;
     BenchmarkFileOpened: boolean;
-    ConsoleBuffer: TStringList; // stores logged messages for in-game console, capped to CONSOLE_SCROLLBACK_SIZE
     Lock:                TRTLCriticalSection;
 
     LogLevel: integer;
@@ -83,8 +80,6 @@ type
     LogFileLevel: integer;
 
     procedure LogToFile(const Text: string);
-
-    function GetConsoleCount: integer;
 
   public
     BenchmarkTimeStart:   array[0..31] of real;
@@ -127,12 +122,6 @@ type
     // buffer
     procedure LogBuffer(const buf : Pointer; const bufLength : Integer; const filename : IPath);
 
-    // console
-    property ConsoleCount: integer read GetConsoleCount;
-    function GetConsole(const index: integer; FromTheBeginning: boolean = false): string;
-    procedure LogConsole(const Text: string);
-    procedure ClearConsoleLog;
-
   end;
 
 procedure DebugWriteln(const aString: String);
@@ -173,7 +162,6 @@ end;
 
 constructor TLog.Create;
 begin
-  ConsoleBuffer := TStringList.Create;
   inherited;
   LogLevel := LOG_LEVEL_DEFAULT;
   LogFileLevel := LOG_FILE_LEVEL_DEFAULT;
@@ -191,7 +179,6 @@ begin
   if LogFileOpened then
     CloseFile(LogFile);
 
-  ConsoleBuffer.Free;
   inherited;
 end;
 
@@ -376,7 +363,6 @@ begin
     if (Level <= LogLevel) then
     begin
       DebugWriteLn(LogMsg);
-      LogConsole(LogMsg);
     end;
     
     // write message to log-file
@@ -556,35 +542,4 @@ begin
   end;
 end;
 
-procedure TLog.ClearConsoleLog;
-begin
-  EnterCriticalSection(Lock);
-  ConsoleBuffer.Clear;
-  LeaveCriticalSection(Lock);
-end;
-
-function TLog.GetConsole(const index: integer; FromTheBeginning: boolean = false): string;
-begin
-  EnterCriticalSection(Lock);
-  if FromTheBeginning then Result := ConsoleBuffer[index]
-  else Result := ConsoleBuffer[ConsoleBuffer.Count-1-index];
-  LeaveCriticalSection(Lock);
-end;
-
-function TLog.GetConsoleCount: integer;
-begin
-  EnterCriticalSection(Lock);
-  Result := ConsoleBuffer.Count;
-  LeaveCriticalSection(Lock);
-end;
-
-procedure TLog.LogConsole(const Text: string);
-begin
-  EnterCriticalSection(Lock);
-  ConsoleBuffer.Insert(0, Text);
-  if ConsoleBuffer.Count > CONSOLE_SCROLLBACK_SIZE then ConsoleBuffer.Capacity:=CONSOLE_SCROLLBACK_SIZE;
-  LeaveCriticalSection(Lock);
-end;
-
 end.
-

--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -504,12 +504,6 @@ begin
           //if (Event.key.keysym.unicode in [1 .. 26]) then
           //  Event.key.keysym.unicode := Ord('A') + Event.key.keysym.unicode - 1;
 
-          // toggle in-game console if allowed
-          if boolean(Ini.Debug) and ((Event.key.keysym.sym = SInt32('~')) or (Event.key.keysym.sym = SDLK_CARET)) then
-          begin
-            Display.ToggleConsole;
-          end;
-
           if Event.key.keysym.sym = SDLK_RETURN then
           begin
             if (SDL_GetModState and (KMOD_LSHIFT + KMOD_RSHIFT + KMOD_LCTRL + KMOD_RCTRL + KMOD_LALT  + KMOD_RALT) = KMOD_LALT) then

--- a/src/menu/UDisplay.pas
+++ b/src/menu/UDisplay.pas
@@ -78,15 +78,7 @@ type
 
       Cursor_Update:       boolean;
 
-      Console_Draw:         boolean;
-      Console_ScrollOffset: integer;
       procedure DrawDebugInformation;
-      procedure DrawDebugConsole;
-
-      { Handles parsing of inputs when console is opened. Called from ParseInput }
-      function ConsoleParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown : boolean): boolean;
-       { Handles parsing of inputs when console is opened. Called from ParseMouse }
-      function ConsoleParseMouse(MouseButton: integer; BtnDown: boolean; X, Y: integer): boolean;
 
       { called by MoveCursor and OnMouseButton to update last move and start fade in }
       procedure UpdateCursorFade;
@@ -109,8 +101,6 @@ type
 
       procedure InitFadeTextures();
 
-      procedure ToggleConsole;
-      
       procedure SaveScreenShot;
 
       function  Draw: boolean;
@@ -455,12 +445,6 @@ begin
     if ((Ini.Debug = 1) or (Params.Debug)) and (S = 1) then
     begin
       DrawDebugInformation;
-      if Console_Draw then DrawDebugConsole;
-    end else if Console_Draw then
-    begin
-      // clear flag to prevent drawing console when toggling debug
-      // TODO: considers using event in ScreenOptions for clearing debug
-      Console_Draw := false;
     end;
 
     if not BlackScreen then
@@ -643,13 +627,6 @@ end;
 
 function TDisplay.ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown : boolean; out SuppressKey: boolean): boolean;
 begin
-  if Console_Draw then
-  begin
-    Result := true;
-    SuppressKey := true;
-    Exit;
-  end;
-
   if (assigned(NextScreen)) then
     Result := NextScreen^.ShouldHandleInput(PressedKey, CharCode, PressedDown, SuppressKey)
   else if (assigned(CurrentScreen)) then
@@ -660,8 +637,6 @@ end;
 
 function TDisplay.ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown : boolean): boolean;
 begin
-  if Console_Draw and ConsoleParseInput(PressedKey, CharCode, PressedDown) then Exit;
-
   if (assigned(NextScreen)) then
     Result := NextScreen^.ParseInput(PressedKey, CharCode, PressedDown)
   else if (assigned(CurrentScreen)) then
@@ -672,8 +647,6 @@ end;
 
 function TDisplay.ParseMouse(MouseButton: integer; BtnDown: boolean; X, Y: integer): boolean;
 begin
-  if Console_Draw and ConsoleParseMouse(MouseButton, BtnDown, X, Y) then Exit;
-
   if (assigned(NextScreen)) then
     Result := NextScreen^.ParseMouse(MouseButton, BtnDown, X, Y)
   else
@@ -842,144 +815,6 @@ begin
   glColor4f(0.8, 0.5, 0.2, 1);
   glPrint ('Game.Debug');
 
-  glColor4f(1, 1, 1, 1);
-end;
-
-procedure TDisplay.ToggleConsole;
-begin
-  Console_Draw := not Console_Draw;
-  Console_ScrollOffset := 0;
-end;
-
-function TDisplay.ConsoleParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown : boolean): boolean;
-var
-  SDL_ModState:  word;
-begin
-  Result := false;
-
-  if (PressedDown) then
-  begin // Key Down
-    Result := true;
-    SDL_ModState := SDL_GetModState and (KMOD_LSHIFT + KMOD_RSHIFT
-    + KMOD_LCTRL + KMOD_RCTRL + KMOD_LALT  + KMOD_RALT);
-
-    case PressedKey of
-      SDLK_PAGEUP: Console_ScrollOffset := Min(Console_ScrollOffset+3, Log.ConsoleCount-1);
-      SDLK_PAGEDOWN: Console_ScrollOffset := Max(Console_ScrollOffset-3, 0);
-      SDLK_HOME: Console_ScrollOffset := Log.ConsoleCount-1;
-      SDLK_END: Console_ScrollOffset := 0;
-      SDLK_DELETE: if SDL_ModState and KMOD_CTRL <> 0 then Log.ClearConsoleLog;
-      otherwise Result := false;
-    end;
-  end;
-end;
-
-function TDisplay.ConsoleParseMouse(MouseButton: integer; BtnDown: boolean; X, Y: integer): boolean;
-begin
-  Result := false;
-
-  if (BtnDown) then
-  begin // button Down
-    Result := true;
-    case MouseButton of
-      SDL_BUTTON_WHEELUP: Console_ScrollOffset := Min(Console_ScrollOffset+3, Log.ConsoleCount-1);
-      SDL_BUTTON_WHEELDOWN: Console_ScrollOffset := Max(Console_ScrollOffset-3, 0);
-      otherwise Result := false;
-    end;
-  end;
-end;
-
-//------------
-// DrawDebugInformation - procedure draw fps and some other informations on screen
-//------------
-procedure TDisplay.DrawDebugConsole;
-var
-  I, LineCount: integer;
-  YOffset, ScaleF, FontSize: real;
-  PosY: real;
-  W, H: real;
-  ScrollPad, ScrollW: real;
-  OldStretch: real;
-begin
-  FontSize := 16.0;
-  W := 800.0;
-  H := 400.0;
-  ScrollPad := 5.0;
-  ScrollW := 10.0;
-
-  // Some black background
-  glEnable(GL_BLEND);
-  glDisable(GL_TEXTURE_2D);
-  glColor4f(0, 0, 0, 0.85);
-  glBegin(GL_QUADS);
-    glVertex2f(0, 0);
-    glVertex2f(0, H);
-    glVertex2f(W, H);
-    glVertex2f(W, 0);
-  glEnd;
-  glDisable(GL_BLEND);
-
-  // scale sizes to DPI/aspect
-  ScaleF := (1.0*ScreenH)/(1.0*ScreenW);
-  FontSize := FontSize * 600.0/(1.0*ScreenH);
-  ScrollW := ScrollW * 800.0/(1.0*ScreenW);
-  ScrollPad := ScrollPad * ScaleF;
-
-  // set font specs
-  SetFontFamily(0);
-  SetFontStyle(ftRegular);
-  SetFontSize(FontSize);
-  SetFontItalic(false);
-  SetFontReflection(false, 0);
-  glColor4f(1, 1, 1, 1);
-
-  OldStretch := Fonts[CurrentFont.FontFamily][CurrentFont.FontStyle].Font.Stretch;
-  Fonts[CurrentFont.FontFamily][CurrentFont.FontStyle].Font.Stretch := 1.4*ScaleF * Min(1.3, Max(0.8, power((1.0*ScreenW)/800.0, 1.2)));
-
-  // don't draw anything else if nothing's logged
-  if Log.ConsoleCount < 1 then Exit;
-
-
-  // draw log buffer
-  YOffset := H; // start at bottom
-  LineCount := 0;
-  I := Log.ConsoleCount-1 - Console_ScrollOffset;
-  while (I >= 0) and (YOffset > 0) do
-  begin
-    YOffset := YOffset - FontSize;
-    SetFontPos(5, YOffset);
-    glPrint(Log.GetConsole(i));
-
-    Dec(i);
-    Inc(LineCount);
-  end;
-
-  // draw scoll bar
-  glEnable(GL_BLEND);
-  glDisable(GL_TEXTURE_2D);
-  glColor4f(0.33, 0.33, 0.33, 1);
-  glBegin(GL_QUADS);
-    glVertex2f(W-ScrollPad-ScrollW, ScrollPad); // top left
-    glVertex2f(W-ScrollPad, ScrollPad); // top right
-    glVertex2f(W-ScrollPad, H-ScrollPad); // bottom right
-    glVertex2f(W-ScrollPad-ScrollW, H-ScrollPad); // bottom left
-  glEnd;
-
-  // visible height bar + offset
-  YOffset := H * ((1.0*LineCount)/(1.0*Log.ConsoleCount));
-  PosY := 0;
-  if I > 0 then PosY := (H-2.0*ScrollPad) * Max(0.0, I)/(1.0*Log.ConsoleCount);
-
-  glColor4f(1, 1, 1, 1);
-  glBegin(GL_QUADS);
-    glVertex2f(W-ScrollPad-ScrollW, ScrollPad + PosY); // top left
-    glVertex2f(W-ScrollPad, ScrollPad + PosY); // top right
-    glVertex2f(W-ScrollPad, ScrollPad + PosY + YOffset); // bottom right
-    glVertex2f(W-ScrollPad-ScrollW, ScrollPad + PosY + YOffset); // bottom left
-  glEnd;
-  glDisable(GL_BLEND);
-
-  Fonts[CurrentFont.FontFamily][CurrentFont.FontStyle].Font.Stretch := OldStretch;
   glColor4f(1, 1, 1, 1);
 end;
 


### PR DESCRIPTION
This PR removes the in-game console/log overlay, including:

- the `~` / `^` debug hotkey
- console draw/input/mouse handling in `TDisplay`
- the in-memory console scrollback buffer in `TLog`
- the `ConsoleWriteLn` hook that copied stdout/debug output into the overlay

Normal logging to `Error.log` and stdout/process console output remains unchanged.

## Why

The in-game console has been inactive and little-used for years, is not documented as part of normal workflows, and duplicates the existing log file/stdout debugging paths. Removing it avoids carrying unused UI/debug code. It also would lead to closing #62.

Removed it as follows:
- deleted the key handling in `UMain`
- removed console state, rendering, scrolling, and input interception from `UDisplay`
- removed console scrollback storage and accessors from `ULog`
- stopped mirroring `ConsoleWriteLn` output into the removed overlay buffer
