### PR TITLE
Build AppImage with Debian Jessie instead of CentOS 7 and drop 32-bit support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Cache build
         uses: actions/cache@v5
         with:
-          key: linux-docker-${{ hashFiles('dists/linux/dl.sh', 'dists/linux/tasks.sh') }}
+          key: linux-docker-${{ hashFiles('dists/linux/dl.sh', 'dists/linux/tasks.sh', 'dists/linux/dockerenv.sh', 'dists/linux/Dockerfile.in') }}
           path: |
             dists/linux/prefix
       - name: Start container builder

--- a/dists/linux/Dockerfile.in
+++ b/dists/linux/Dockerfile.in
@@ -1,26 +1,23 @@
 FROM %%from%%
 
-RUN sed -i 's;^.*baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
+RUN apt-get update
 
-RUN [ -z "%%epelpkgs%%" ] || yum install -y --setopt=tsflags=nodocs \
-    https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm
+RUN apt-get upgrade -y
 
-RUN yum upgrade -y --setopt=tsflags=nodocs
-
-RUN yum install -y --setopt=tsflags=nodocs \
-    make automake autoconf patch which file git unzip bzip2 gcc gcc-c++ \
-    glibc-devel mesa-libGL-devel mesa-libgbm-devel alsa-lib-devel \
-    libX11-devel libXext-devel libXcursor-devel libXinerama-devel libXrandr-devel libXi-devel libxkbcommon-devel \
-    dbus-devel systemd-devel zlib-devel libffi-devel expat-devel libxml2-devel libtool python3-pip \
-    wget vim-common desktop-file-utils glib2-devel cairo-devel fuse-devel libarchive-devel %%epelpkgs%%
+RUN apt-get install -y --no-install-recommends \
+    build-essential make automake autoconf patch file git unzip bzip2 xz-utils \
+    libgl1-mesa-dev libgbm-dev libasound2-dev \
+    libx11-dev libxext-dev libxcursor-dev libxinerama-dev libxrandr-dev libxi-dev libxkbcommon-dev \
+    libdbus-1-dev libsystemd-dev zlib1g-dev libffi-dev libexpat1-dev libxml2-dev libssl-dev libtool python3-pip pkg-config \
+    wget curl ca-certificates vim-common desktop-file-utils libglib2.0-dev libcairo2-dev libfuse-dev libarchive-dev
 
 RUN mkdir /tmp/fpcinst \
     && wget --progress=dot:giga -O - %%fpcpackage%% | tar xC /tmp/fpcinst --strip-components=1 \
     && (echo /usr/local ; echo n ; echo n) | (cd /tmp/fpcinst ; ./install.sh) \
     && rm -Rf /tmp/fpcinst
 
-RUN yum clean all -y
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV LC_CTYPE=en_US.utf8
+ENV LC_CTYPE=C.UTF-8
 
 CMD ["bash"]

--- a/dists/linux/dockerenv.sh
+++ b/dists/linux/dockerenv.sh
@@ -21,17 +21,10 @@ done
 targetarch="${ARCH-$(uname -m)}"
 
 if [ "$targetarch" == "x86_64" ]; then
-	imagename="usdx/buildenv:centos7"
-	from="centos:7"
+	imagename="usdx/buildenv:jessie"
+	from="debian/eol:jessie"
 	fpcpackage="https://sourceforge.net/projects/freepascal/files/Linux/3.2.2/fpc-3.2.2.x86_64-linux.tar"
 	prefixcmd="linux64"
-	epelpkgs="cmake3 ninja-build patchelf"
-elif [ "$targetarch" == "i386" ] || [ "$targetarch" == "i686" ]; then
-	imagename="usdx/buildenv:centos7-i386"
-	from="i386/centos:7"
-	fpcpackage="https://sourceforge.net/projects/freepascal/files/Linux/3.2.2/fpc-3.2.2.i386-linux.tar"
-	prefixcmd="linux32"
-	epelpkgs=""
 else
 	echo "Unsupported architecture: $targetarch"
 	exit 1
@@ -40,7 +33,6 @@ fi
 replacements="
 	s!%%from%%!$from!g;
 	s!%%fpcpackage%%!$fpcpackage!g;
-	s!%%epelpkgs%%!$epelpkgs!g;
 "
 
 if [ "$only_dockerfile" = 1 ] ; then


### PR DESCRIPTION
This PR switches the Linux/AppImage Docker build environment from CentOS 7 to Debian Jessie for x86_64 builds.

At the same time, it removes the old i386 AppImage builder path from `dockerenv.sh`, to get rid of CentOS 7 entirely.

## Why

CentOS 7 ships GCC 4.8, which is too old for newer FFmpeg releases that require more complete C11 support. Moving the AppImage builder to Debian Jessie drops that toolchain limitation.

The i386 AppImage path still depended on CentOS 7, so it is removed rather than kept on the old build baseline.

Related to #984.

## How

- Change the x86_64 Docker base image from `centos:7` to `debian/eol:jessie`
- Update the Dockerfile template from `yum`/EPEL packages to `apt-get` packages
- Remove the unsupported `i386` / `i686` branch from `dockerenv.sh`
- Include `dockerenv.sh` and `Dockerfile.in` in the Linux dependency cache key so CI rebuilds the cached prefix when the Docker builder image changes