### PR TITLE
Fix song list mouse hitboxes and tag refresh

### DIFF
--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -44,6 +44,7 @@ uses
   ULanguage,
   UMenu,
   UMenuEqualizer,
+  UMenuInteract,
   UMusic,
   UPath,
   URenderer,
@@ -85,6 +86,7 @@ type
 
       procedure StartMusicPreview();
       procedure StartVideoPreview();
+      function GetSongButtonMouseOverArea(ButtonIndex: integer): TMouseOverRect;
     public
       TextArtist:   integer;
       TextTitle:    integer;
@@ -1495,8 +1497,7 @@ begin
     // hover cover
     for B := 0 to High(Button) do begin
       if (Button[B].Visible) then begin
-        // TODO: you have to specifically hover the cover image. see SetListScroll
-        if InRegion(X, Y, Button[B].GetMouseOverArea) then begin
+        if InRegion(X, Y, GetSongButtonMouseOverArea(B)) then begin
           if (Interaction <> B) then begin
             // play current hover
             isScrolling := false;
@@ -1509,6 +1510,27 @@ begin
         end;
       end;
     end;
+  end;
+end;
+
+function TScreenSong.GetSongButtonMouseOverArea(ButtonIndex: integer): TMouseOverRect;
+var
+  B: integer;
+  ListIndex: integer;
+begin
+  Result := Button[ButtonIndex].GetMouseOverArea;
+
+  if (TSongMenuMode(Ini.SongMenu) = smList) then
+  begin
+    ListIndex := -1;
+    for B := 0 to ButtonIndex do
+    begin
+      if (Button[B].Visible) then
+        Inc(ListIndex);
+    end;
+
+    if (ListIndex >= 0) and (ListIndex <= High(StaticList)) then
+      Result := StaticsList[StaticList[ListIndex]].GetMouseOverArea;
   end;
 end;
 
@@ -1539,7 +1561,7 @@ begin
       begin
         if (Button[B].Visible) then
         begin
-          if InRegion(X, Y, Button[B].GetMouseOverArea) then
+          if InRegion(X, Y, GetSongButtonMouseOverArea(B)) then
           begin
             ParseInput(SDLK_RETURN, 0, true)
           end;
@@ -1556,7 +1578,7 @@ begin
     begin
       if (Button[B].Visible) then
       begin
-        if InRegion(X, Y, Button[B].GetMouseOverArea) then
+        if InRegion(X, Y, GetSongButtonMouseOverArea(B)) then
         begin
           if (Interaction <> B) then
           begin
@@ -1616,7 +1638,7 @@ begin
         // test the 3 front buttons for click
         for I := 0 to 2 do
         begin
-          if InRegion(X, Y, Button[Btn].GetMouseOverArea) then
+          if InRegion(X, Y, GetSongButtonMouseOverArea(Btn)) then
           begin
             // song cover clicked
             if (I = 1) then
@@ -1665,7 +1687,7 @@ begin
         for I := 0 to 4 do
         begin
 
-          if InRegion(X, Y, Button[Btn].GetMouseOverArea) then
+          if InRegion(X, Y, GetSongButtonMouseOverArea(Btn)) then
           begin
             // song cover clicked
             if (I = 2) then
@@ -2818,10 +2840,12 @@ begin
 
     //Set Visibility of Rap Icons
     Statics[ListRapIcon[I]].Texture.Alpha := Alpha;
-    Statics[ListRapIcon[I]].Visible := CatSongs.Song[SongID[I]].hasRap and not RapToFreestyle;
+    Statics[ListRapIcon[I]].Visible := CatSongs.Song[SongID[I]].hasRap and
+      ((SongID[I] <> Interaction) or not RapToFreestyle);
 
     Statics[ListRapToFreestyleIcon[I]].Texture.Alpha := Alpha;
-    Statics[ListRapToFreestyleIcon[I]].Visible := CatSongs.Song[SongID[I]].hasRap and RapToFreestyle;
+    Statics[ListRapToFreestyleIcon[I]].Visible := CatSongs.Song[SongID[I]].hasRap and
+      (SongID[I] = Interaction) and RapToFreestyle;
 
     // Set texts
     Text[ListTextArtist[I]].Alpha := Alpha;
@@ -2904,12 +2928,12 @@ begin
       Text[ListTextArtist[I]].Visible := true;
       Text[ListTextTitle[I]].Visible  := true;
       Text[ListTextYear[I]].Visible   := true;
-      Statics[ListVideoIcon[I]].Visible  := true;
-      Statics[ListMedleyIcon[I]].Visible := true;
-      Statics[ListCalcMedleyIcon[I]].Visible := true;
-      Statics[ListDuetIcon[I]].Visible := true;
-      Statics[ListRapIcon[I]].Visible := true;
-      Statics[ListRapToFreestyleIcon[I]].Visible := true;
+      Statics[ListVideoIcon[I]].Visible  := false;
+      Statics[ListMedleyIcon[I]].Visible := false;
+      Statics[ListCalcMedleyIcon[I]].Visible := false;
+      Statics[ListDuetIcon[I]].Visible := false;
+      Statics[ListRapIcon[I]].Visible := false;
+      Statics[ListRapToFreestyleIcon[I]].Visible := false;
     end;
 
     Text[TextArtist].Visible := false;
@@ -2940,6 +2964,8 @@ begin
     AudioPlayback.Stop;
 
   PreviewOpened := -1;
+  DuetChange := false;
+  RapToFreestyle := false;
 
   // reset video playback engine
   fCurrentVideo := nil;
@@ -3006,6 +3032,12 @@ begin
   isScrolling := false;
   SetJoker;
   SetStatics;
+
+  if (TSongMenuMode(Ini.SongMenu) = smList) then
+  begin
+    SetScroll;
+    SetScrollRefresh;
+  end;
 end;
 
 procedure TScreenSong.OnShowFinish;


### PR DESCRIPTION
### Problem

- Mouse hover only recognizes the song's cover image instead of the entire list row.
- Song tags can initially flash, appear late, or retain incorrect visibility when the list opens.
- Rap and `R->F` tags can be displayed incorrectly for the selected song.

### Fix

This PR fixes mouse interaction and tag rendering issues in the song selection screen.

- Uses the themed list row element for list-view mouse hover hitboxes, so hovering anywhere on a song row focuses that song.
- Routes roulette and chessboard song hit testing through the same helper for consistent behavior.
- Ensures list row tags are populated immediately on show, avoiding delayed video/medley/duet/rap tag display or incorrect flashing of these tags.
- Shows the R->F tag for shown rap songs only when rap-to-freestyle is enabled.

Fixes #1270. (the other part has been fixed already)