### PR TITLE
Fix Screen Transitions for Songs with #START

### DIFF
--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -977,7 +977,7 @@ begin
       begin
         // Important: do not yet start the triggered timer by a call to
         // LyricsState.GetCurrentTime()
-        VideoFrameTime := CurrentSong.VideoGAP + CurrentSong.Start;
+        VideoFrameTime := CurrentSong.VideoGAP;
       end;
       try
         ScreenSing.fCurrentVideo.GetFrame(VideoFrameTime);


### PR DESCRIPTION
There was a minor performance regression introduced by #1203, where songs with a video *and* a `#START` value in the .txt can cause lag when started from the song selection screen. Often times the screen transition appears choppy or is missed entirely.

#1203 changed it so that the video file is seeked twice: first at the beginning of the transition, and then after the transition is complete. This was unnecessary, and seeking the video is a relatively expensive operation, often blocking the main thread for a long time. This PR reverts the line of code to how it was before #1203 (only seeking the video once, when the screen transition is finished).