### PR TITLE
SungPaused is always false, so remove it entirely

### DIFF
--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -439,8 +439,7 @@ begin
           end
           else
           begin
-            if (ScreenSing.SungPaused = false) and
-               (ScreenSing.SungToEnd) and (Length(DllMan.Websites) > 0) then
+            if (ScreenSing.SungToEnd) and (Length(DllMan.Websites) > 0) then
               InteractNext;
           end;
         end;
@@ -465,8 +464,7 @@ begin
           end
           else
           begin
-            if (ScreenSing.SungPaused = false) and
-               (ScreenSing.SungToEnd) and (Length(DllMan.Websites) > 0) then
+            if (ScreenSing.SungToEnd) and (Length(DllMan.Websites) > 0) then
               InteractPrev;
           end;
 
@@ -1266,7 +1264,7 @@ begin
   end;
 
   // Show Send Score Buttons
-  if (ScreenSing.SungPaused = false) and (ScreenSing.SungToEnd) and (Length(DllMan.Websites) > 0) then
+  if (ScreenSing.SungToEnd) and (Length(DllMan.Websites) > 0) then
   begin
     case PlayersPlay of
       1: begin

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -118,9 +118,6 @@ type
     //the song was sung to the end
     SungToEnd: boolean;
 
-    //use pause
-    SungPaused: boolean;
-
     // some settings to be set by plugins
     Settings: record
       Finish: Boolean; //< if true, screen will finish on next draw
@@ -708,7 +705,6 @@ begin
 
   //the song was sung to the end
   SungToEnd := false;
-  SungPaused := false;
 
   ClearSettings;
   Party.CallBeforeSing;
@@ -1600,7 +1596,7 @@ begin
   AudioPlayback.Stop;
   AudioPlayback.SetSyncSource(nil);
 
-  if (ScreenSong.Mode = smNormal) and (SungPaused = false) and (SungToEnd) and (Length(DllMan.Websites) > 0) then
+  if (ScreenSong.Mode = smNormal) and (SungToEnd) and (Length(DllMan.Websites) > 0) then
   begin
     AutoSendScore;
     AutoSaveScore;


### PR DESCRIPTION
The last reference I can find where this was ever `true` was when the `src/screens/UScreenSing-WIN-OE4TGRO45VM.pas` file was deleted in 090bd8a7c65e291e7627d3afd046b22ab5e9779a (over 10 years ago)

It seems to only be used for highscore plugins anyway, because the regular scores are (currently) in ScreenTop5.OnShow and only (ever?) cared about score being > 0 and whether it was sung to the end.

I want to eventually move the regular saving elsewhere (screensingcontroller), you can consider this and some other PRs to be prepwork for that, but they're also just sensible refactors on their own.