### PR TITLE
Add pitch diagnostics in options screen and show correct pitch in editor

### DIFF
--- a/src/base/URecord.pas
+++ b/src/base/URecord.pas
@@ -45,6 +45,8 @@ uses
 const
   BaseToneFreq = 440; // A4 concert pitch of 440 Hz
   NumHalftones = 49;  // C2 to C6 (1046.5023 Hz)
+  ToneStringOctaveOffset = 2;
+  MaxToneCandidates = 5;
 
 type
   // pitch detection algorithm (PDA)
@@ -57,6 +59,13 @@ type
   TDelayArray       = array[0..NumHalftones-1] of integer;
   TCorrelationArray = array[0..NumHalftones-1] of real;
 
+  TToneCandidate = record
+    ToneAbs: integer;
+    Confidence: single;
+    Correlation: real;
+    Frequency: real;
+  end;
+
   TCaptureBuffer = class
     private
       fVoiceStream: TAudioVoiceStream; // stream for voice passthrough
@@ -64,8 +73,11 @@ type
       fAudioFormat: TAudioFormatInfo;
       Frequencies: TFrequencyArray;
       Delays: TDelayArray;
+      fToneCandidates: array[0..MaxToneCandidates-1] of TToneCandidate;
+      fToneCandidateCount: integer;
 
       function GetToneString: string; // converts a tone to its string representation;
+      function GetToneCandidate(Index: integer): TToneCandidate;
 
       procedure BoostBuffer(Buffer: PByteArray; Size: integer);
       procedure ProcessNewBuffer(Buffer: PByteArray; BufferSize: integer);
@@ -73,6 +85,7 @@ type
       procedure StartCapture(Format: TAudioFormatInfo);
       procedure StopCapture();
 
+      procedure ResetToneDiagnostics;
       procedure SetFrequenciesAndDelays;
       // we call it to analyze sound by checking AMDF
       function AnalyzePitch(PDA: TPDAType): boolean;
@@ -80,6 +93,7 @@ type
       function AverageMagnitudeDifference(): TCorrelationArray;
       function CircularAverageMagnitudeDifference(): TCorrelationArray;
       function ArrayIndexOfMinimum(const AValues: array of real): Integer;
+      procedure UpdateToneCandidatesSimple(const Correlation: TCorrelationArray);
     public
       AnalysisBuffer:  array[0..4095] of smallint; // newest 4096 samples (MUST BE POWER OF TWO!)
       AnalysisBufferSize: integer; // number of samples of BufferArray to analyze
@@ -91,6 +105,9 @@ type
       ToneValid: boolean;    // true if Tone contains a valid value (otherwise it contains noise)
       Tone:      integer;    // tone relative to one octave (e.g. C2=C3=C4). Range: 0-11
       ToneAbs:   integer;    // absolute (full range) tone (e.g. C2<>C3). Range: 0..NumHalftones-1
+      RawToneValid: boolean;
+      RawTone:      integer;
+      RawToneAbs:   integer;
 
       // methods
       constructor Create;
@@ -105,6 +122,8 @@ type
 
       function MaxSampleVolume: single;
       property ToneString: string READ GetToneString;
+      property ToneCandidateCount: integer read fToneCandidateCount;
+      property ToneCandidates[Index: integer]: TToneCandidate read GetToneCandidate;
       property AudioFormat: TAudioFormatInfo READ fAudioFormat;
   end;
 
@@ -211,6 +230,7 @@ type
   PSmallIntArray = ^TSmallIntArray;
 
   function AudioInputProcessor(): TAudioInputProcessor;
+  function ToneAbsToString(const ToneAbs: integer): string;
 
 implementation
 
@@ -275,6 +295,7 @@ begin
   LogBuffer := TMemoryStream.Create;
   fAnalysisBufferLock := SDL_CreateMutex();
   AnalysisBufferSize := Length(AnalysisBuffer);
+  ResetToneDiagnostics;
 end;
 
 destructor TCaptureBuffer.Destroy;
@@ -298,6 +319,28 @@ begin
   SDL_UnlockMutex(fAnalysisBufferLock);
 end;
 
+procedure TCaptureBuffer.ResetToneDiagnostics;
+begin
+  fToneCandidateCount := 0;
+  FillChar(fToneCandidates, SizeOf(fToneCandidates), 0);
+  RawToneValid := false;
+  RawTone := -1;
+  RawToneAbs := -1;
+end;
+
+function TCaptureBuffer.GetToneCandidate(Index: integer): TToneCandidate;
+begin
+  if (Index >= 0) and (Index < fToneCandidateCount) then
+    Result := fToneCandidates[Index]
+  else
+  begin
+    Result.ToneAbs := -1;
+    Result.Confidence := 0;
+    Result.Correlation := 0;
+    Result.Frequency := 0;
+  end;
+end;
+
 procedure TCaptureBuffer.Clear;
 begin
   if assigned(LogBuffer) then
@@ -305,6 +348,7 @@ begin
   LockAnalysisBuffer();
   FillChar(AnalysisBuffer[0], Length(AnalysisBuffer) * SizeOf(SmallInt), 0);
   UnlockAnalysisBuffer();
+  ResetToneDiagnostics;
 end;
 
 procedure TCaptureBuffer.ProcessNewBuffer(Buffer: PByteArray; BufferSize: integer);
@@ -374,6 +418,7 @@ begin
   ToneValid := false;
   ToneAbs := -1;
   Tone    := -1;
+  ResetToneDiagnostics;
 
   LockAnalysisBuffer();
   try
@@ -420,6 +465,67 @@ begin
   Result := LMinIdx;
 end;
 
+procedure TCaptureBuffer.UpdateToneCandidatesSimple(const Correlation: TCorrelationArray);
+const
+  WeightEpsilon = 1.0e-9;
+var
+  Weights: array[0..NumHalftones-1] of double;
+  idx: integer;
+  candidateIdx: integer;
+  bestIdx: integer;
+  totalWeight: double;
+begin
+  fToneCandidateCount := 0;
+  FillChar(fToneCandidates, SizeOf(fToneCandidates), 0);
+
+  for idx := 0 to NumHalftones-1 do
+  begin
+    if Correlation[idx] > 0 then
+      Weights[idx] := 1.0 / (Correlation[idx] + WeightEpsilon)
+    else if Correlation[idx] < 0 then
+      Weights[idx] := 1.0 / (Abs(Correlation[idx]) + WeightEpsilon)
+    else
+      Weights[idx] := 0;
+  end;
+
+  for candidateIdx := 0 to MaxToneCandidates-1 do
+  begin
+    bestIdx := -1;
+    for idx := 0 to NumHalftones-1 do
+    begin
+      if Weights[idx] <= 0 then
+        Continue;
+      if (bestIdx = -1) or (Weights[idx] > Weights[bestIdx]) then
+        bestIdx := idx;
+    end;
+    if bestIdx < 0 then
+      Break;
+
+    fToneCandidates[fToneCandidateCount].ToneAbs := bestIdx;
+    fToneCandidates[fToneCandidateCount].Frequency := Frequencies[bestIdx];
+    fToneCandidates[fToneCandidateCount].Correlation := Correlation[bestIdx];
+    fToneCandidates[fToneCandidateCount].Confidence := Weights[bestIdx];
+    Weights[bestIdx] := -1;
+    Inc(fToneCandidateCount);
+  end;
+
+  if (fToneCandidateCount = 0) and (ToneAbs >= 0) then
+  begin
+    fToneCandidates[0].ToneAbs := ToneAbs;
+    fToneCandidates[0].Frequency := Frequencies[ToneAbs];
+    fToneCandidates[0].Correlation := 0;
+    fToneCandidates[0].Confidence := 1;
+    fToneCandidateCount := 1;
+  end;
+
+  totalWeight := 0;
+  for idx := 0 to fToneCandidateCount-1 do
+    totalWeight := totalWeight + fToneCandidates[idx].Confidence;
+  if (totalWeight > 0) and (fToneCandidateCount > 0) then
+    for idx := 0 to fToneCandidateCount-1 do
+      fToneCandidates[idx].Confidence := fToneCandidates[idx].Confidence / totalWeight;
+end;
+
 procedure TCaptureBuffer.SetFrequenciesAndDelays;
 var
   ToneIndex:   integer;
@@ -456,7 +562,21 @@ begin
       end;
   end;
 
+  if ToneAbs < 0 then
+  begin
+    RawToneValid := false;
+    RawTone := -1;
+    RawToneAbs := -1;
+    UpdateToneCandidatesSimple(Correlation);
+    Result := false;
+    Exit;
+  end;
+
   Tone := ToneAbs mod 12;
+  RawToneValid := true;
+  RawTone := Tone;
+  RawToneAbs := ToneAbs;
+  UpdateToneCandidatesSimple(Correlation);
   Result := true;
 end;
 
@@ -539,10 +659,17 @@ const
     'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'
   );
 
+function ToneAbsToString(const ToneAbs: integer): string;
+begin
+  if ToneAbs < 0 then
+    Exit('-');
+  Result := ToneStrings[ToneAbs mod 12] + IntToStr(ToneAbs div 12 + ToneStringOctaveOffset);
+end;
+
 function TCaptureBuffer.GetToneString: string;
 begin
   if (ToneValid) then
-    Result := ToneStrings[Tone] + IntToStr(ToneAbs div 12 + 2)
+    Result := ToneAbsToString(ToneAbs)
   else
     Result := '-';
 end;

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -419,7 +419,7 @@ type
       procedure Refresh;
       procedure CopyToUndo; //copy current lines, mouse position and headers
       procedure CopyFromUndo; //undo last lines, mouse position and headers
-      procedure DrawPlayerTrack(CurrentTone: Integer; Count: Integer; CurrentNote: Integer);
+      procedure DrawPlayerTrack(CurrentTone: Integer; Count: Integer; CurrentNote: Integer; DetectedToneAbs: Integer);
       procedure DrawInfoBar(X, Y, W, H: Integer; ColR, ColG, ColB, Alpha: real; Track: Integer);
       procedure DrawText(X, Y, W, H: real; Track: Integer; NumLines: Integer = 10);
       //video view
@@ -4570,7 +4570,7 @@ begin
 end; //if CurrentUndoLines
 end;
 
-procedure TScreenEditSub.DrawPlayerTrack(CurrentTone: Integer; Count: Integer; CurrentNote: Integer);
+procedure TScreenEditSub.DrawPlayerTrack(CurrentTone: Integer; Count: Integer; CurrentNote: Integer; DetectedToneAbs: Integer);
 var
   Rec:     TRecR;
   scale:   Integer;
@@ -4606,7 +4606,10 @@ begin
   SetFontPos(Theme.EditSub.TextCurrentTone.X, Theme.EditSub.TextCurrentTone.Y);
   SetFontSize(Theme.EditSub.TextCurrentTone.Size);
   SetFontColor(Theme.EditSub.TextCurrentTone.ColR, Theme.EditSub.TextCurrentTone.ColG, Theme.EditSub.TextCurrentTone.ColB, 1);
-  PrintText(GetNoteName(CurrentTone));
+  if (DetectedToneAbs >= 0) then
+    PrintText(ToneAbsToString(DetectedToneAbs))
+  else
+    PrintText('-');
 end;
 
 procedure TScreenEditSub.DrawInfoBar(X, Y, W, H: Integer; ColR, ColG, ColB, Alpha: real; Track: Integer);
@@ -6184,7 +6187,7 @@ begin
      CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].HasLength() then
   begin
     Count := trunc((720 / (GetTimeFromBeat(CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat) - GetTimeFromBeat(CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat)))*(AudioPlayback.Position - GetTimeFromBeat(CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat)));
-    DrawPlayerTrack(CurrentSound.Tone, Count, CurrentNote[CurrentTrack]);
+    DrawPlayerTrack(CurrentSound.Tone, Count, CurrentNote[CurrentTrack], CurrentSound.ToneAbs);
   end;
 
   GoldenRec.SpawnRec;
@@ -6268,17 +6271,17 @@ begin
   end;
 
   case Octave of
-    -3: Result := Result + SUB_MINUS + SUB_1; // subsub-contra: '''C - '''B
-    -2: Result := Result + SUB_0;             // sub-contra:     ''C - ''B
-    -1: Result := Result + SUB_1;             // contra:          'C - 'B
-     0: Result := Result + SUB_2;             // great:            C - B
-     1: Result := Result + SUB_3;             // small:            c - b
-     2: Result := Result + SUB_4;             // one-lined:       c' - b'
-     3: Result := Result + SUB_5;             // two-lined:      c'' - b''
-     4: Result := Result + SUB_6;             // three-lined:   c''' - b'''
-     5: Result := Result + SUB_7;             // four-lined:   c'''' - b''''
-     6: Result := Result + SUB_8;             // five-lined:  c''''' - b'''''
-     7: Result := Result + SUB_9;             // six-lined:  c'''''' - b''''''
+    -5: Result := Result + SUB_MINUS + SUB_1; // subsub-contra: '''C - '''B
+    -4: Result := Result + SUB_0;             // sub-contra:     ''C - ''B
+    -3: Result := Result + SUB_1;             // contra:          'C - 'B
+    -2: Result := Result + SUB_2;             // great:            C - B
+    -1: Result := Result + SUB_3;             // small:            c - b
+     0: Result := Result + SUB_4;             // one-lined:       c' - b'
+     1: Result := Result + SUB_5;             // two-lined:      c'' - b''
+     2: Result := Result + SUB_6;             // three-lined:   c''' - b'''
+     3: Result := Result + SUB_7;             // four-lined:   c'''' - b''''
+     4: Result := Result + SUB_8;             // five-lined:  c''''' - b'''''
+     5: Result := Result + SUB_9;             // six-lined:  c'''''' - b''''''
   end;
 end;
 

--- a/src/screens/UScreenOptionsRecord.pas
+++ b/src/screens/UScreenOptionsRecord.pas
@@ -379,16 +379,31 @@ end;
 procedure TVUMeter.DrawPitch;
 var
   x1, y1, x2, y2: single;
+  OverlayY1, OverlayY2: single;
   i: integer;
   ToneBoxWidth: single;
   ToneString: string;
   ToneStringWidth, ToneStringHeight: single;
   ToneStringMaxWidth: single;
   ToneStringCenterXOffset: single;
+  CandidateLine: UTF8String;
+  CandidateCount: integer;
+  Candidate: TToneCandidate;
+  RawToneString: string;
+  InfoLine: UTF8String;
+  TextHeight: real;
+  TextY: real;
+  Alpha: single;
+  MaxCandidatesToDraw: integer;
   QuadList: TQuadList;
 const
   PitchBarInnerHSpacing = 2;
   PitchBarInnerVSpacing = 1;
+  CandidateColors: array[0..2, 0..2] of single = (
+    (1.0, 0.3, 0.2),
+    (0.2, 0.7, 1.0),
+    (0.6, 1.0, 0.4)
+  );
 begin
   SetLength(QuadList, NumHalftones + 1);
 
@@ -462,6 +477,10 @@ begin
   ///////
 
   ToneString := ScreenOptionsRecord.PreviewChannel.ToneString;
+  if ScreenOptionsRecord.PreviewChannel.RawToneValid then
+    RawToneString := ToneAbsToString(ScreenOptionsRecord.PreviewChannel.RawToneAbs)
+  else
+    RawToneString := '-';
   ToneStringHeight := ChannelBarsTotalHeight;
 
   // initialize font
@@ -478,6 +497,57 @@ begin
   SetFontPos(PosX-ToneStringWidth-ToneStringCenterXOffset, PosY + BarHeight - ToneStringHeight/2);
   SetFontColor(0, 0, 0, 1);
   PrintText(ToneString);
+
+  // draw diagnostics text inside the pitch area
+  TextHeight := BarHeight * 0.6;
+  SetFontSize(TextHeight);
+  TextY := PosY + 2.0*BarHeight - PitchBarInnerVSpacing - TextHeight;
+
+  InfoLine := Format('Raw: %s', [RawToneString]);
+  SetFontPos(PosX + PitchBarInnerHSpacing, TextY);
+  SetFontColor(0.9, 0.9, 0.9, 1);
+  PrintText(InfoLine);
+
+  CandidateCount := ScreenOptionsRecord.PreviewChannel.ToneCandidateCount;
+  if CandidateCount > 0 then
+  begin
+    CandidateLine := '';
+    for i := 0 to CandidateCount-1 do
+    begin
+      Candidate := ScreenOptionsRecord.PreviewChannel.ToneCandidates[i];
+      if Candidate.ToneAbs < 0 then
+        Continue;
+      CandidateLine := CandidateLine + Format('%s %d%%  ', [ToneAbsToString(Candidate.ToneAbs), Round(Candidate.Confidence * 100)]);
+    end;
+    if Length(CandidateLine) > 0 then
+    begin
+      TextY := TextY - TextHeight - 2;
+      SetFontPos(PosX + PitchBarInnerHSpacing, TextY);
+      PrintText(CandidateLine);
+    end;
+  end;
+
+  if (Ini.Debug = 1) and (CandidateCount > 0) then
+  begin
+    MaxCandidatesToDraw := CandidateCount - 1;
+    if MaxCandidatesToDraw > 2 then
+      MaxCandidatesToDraw := 2;
+    OverlayY1 := PosY + BarHeight + PitchBarInnerVSpacing;
+    OverlayY2 := PosY + 2.0*BarHeight - PitchBarInnerVSpacing;
+    for i := 0 to MaxCandidatesToDraw do
+    begin
+      Candidate := ScreenOptionsRecord.PreviewChannel.ToneCandidates[i];
+      if Candidate.ToneAbs < 0 then
+        Continue;
+      x1 := PosX + Candidate.ToneAbs * ToneBoxWidth + PitchBarInnerHSpacing;
+      x2 := x1 + ToneBoxWidth - 2 * PitchBarInnerHSpacing;
+      Alpha := Candidate.Confidence * 1.5;
+      if Alpha < 0.15 then Alpha := 0.15;
+      if Alpha > 0.9 then Alpha := 0.9;
+      Renderer.DrawQuad(x1, OverlayY1, 0, x2 - x1, OverlayY2 - OverlayY1,
+        CandidateColors[i,0], CandidateColors[i,1], CandidateColors[i,2], Alpha);
+    end;
+  end;
 
 end;
 


### PR DESCRIPTION
- Add raw absolute pitch diagnostics to the recording/options pitch display.
- Show detected tone candidates with confidence values for debugging pitch detection.
- Update editor note-name octave display so absolute pitch labels line up with the detector output.
