### PR TITLE
Check pitch threshold across full buffer

### DIFF
--- a/src/base/URecord.pas
+++ b/src/base/URecord.pas
@@ -378,9 +378,9 @@ begin
   LockAnalysisBuffer();
   try
 
-    // find maximum volume of first 1024 samples
+    // find maximum volume across the analysis buffer
     MaxVolume := 0;
-    for SampleIndex := 0 to 1023 do
+    for SampleIndex := 0 to AnalysisBufferSize - 1 do
     begin
       Volume := Abs(AnalysisBuffer[SampleIndex]) / -Low(Smallint);
       if Volume > MaxVolume then


### PR DESCRIPTION
- Check the pitch detection volume threshold across the full analysis buffer instead of only the first 1024 samples.
- Removes the arbitrary early-buffer limit where a valid note could be ignored if the singer was quiet only in that slice.
- Keeps the configured threshold values and pitch detection flow otherwise unchanged.
- Quiet singers may find that more fragments are picked up now.