### PR TITLE
Refactor Players 2/12: Add generic Modern player layout templates

### DIFF
--- a/game/themes/Modern.ini
+++ b/game/themes/Modern.ini
@@ -468,6 +468,114 @@ H = 8
 
 # O N E  P L A Y E R   M O D E # # # # # # # # # # # # # # # # # # # #
 #PlayerOne
+[SingPlayerTemplateStatic]
+Inherits = SingDefaultAvatarFrame
+Color = P1Dark
+
+[SingPlayerTemplateText]
+Inherits = SingDefaultPlayerText
+
+[SingPlayerTemplateStatic2]
+Inherits = SingDefaultScoreBG
+Color = P1Dark
+
+[SingPlayerTemplateTextScore]
+Inherits = SingDefaultPlayerTextScore
+
+[SingPlayerTemplateSingBar]
+Inherits = SingDefaultSingBar
+
+[SingPlayerTemplateAvatar]
+Inherits = SingDefaultAvatar
+
+[SingPlayerGrid]
+# Left edge of the sing lane area.
+LaneAreaX = 20
+# Top edge of the sing lane area.
+LaneAreaY = 110
+# Top edge of the sing lane area when top lyrics space is not reserved.
+LaneAreaYNoLyrics = 50
+# Width of the sing lane area shared by all player columns.
+LaneAreaW = 760
+# Lane area height when top lyrics space is reserved (duet/reserved layout).
+LaneAreaHReserved = 365
+# Lane area height when top lyrics space is not reserved.
+LaneAreaHNoLyrics = 425
+# Horizontal gap between player columns.
+LaneColumnGap = 20
+# Additional vertical gap between player rows.
+LaneRowGap = 20
+# Extra inset applied to the note grid to the left of the lane column.
+LaneGridLeftInset = 0
+# Base note-line spacing reference for vertical scaling.
+LaneBaseLineSpacing = 15
+# Number of horizontal guide lines drawn per slot.
+LaneGuideLineCount = 9
+# Guide-line index used as the note row anchor (0-based from the top).
+LaneRowAnchorGuideIndex = 7
+# Reference lane width for widget/note scaling calculations.
+WidgetScaleReferenceW = 300
+# Per-player widget scale reduction factor.
+WidgetScalePerPlayer = 0.02
+# Minimum widget scale factor.
+WidgetScaleMin = 0.82
+
+[SingPlayerWidgetPlacement]
+# Minimum avatar frame width after scaling.
+MinFrameW = 26
+# Minimum avatar frame height after scaling.
+MinFrameH = 26
+# Minimum score box width after scaling.
+MinScoreW = 56
+# Minimum score box height after scaling.
+MinScoreH = 18
+# Horizontal offset from lane left edge to header group start.
+HeaderLeftOffset = 0
+# Vertical offset from row anchor to header group.
+HeaderTopOffsetBase = 148
+# Extra header vertical offset per additional row.
+HeaderTopOffsetPerExtraRow = 0
+# Minimum inset of avatar texture inside its frame (X).
+AvatarInsetMinX = 1
+# Minimum inset of avatar texture inside its frame (Y).
+AvatarInsetMinY = 1
+# Base horizontal gap between avatar frame and player name.
+NameGapX = 10
+# Minimum horizontal gap between avatar frame and player name.
+NameGapMinX = 8
+# Base horizontal text padding for player name.
+NamePaddingX = 6
+# Minimum horizontal text padding for player name.
+NamePaddingMinX = 4
+# Base vertical text padding for player name.
+NamePaddingY = 6
+# Minimum vertical text padding for player name.
+NamePaddingMinY = 3
+# Minimum width allocated to player name text.
+NameMinW = 24
+# Minimum height allocated to player name text.
+NameMinH = 14
+# Minimum font size for player name text.
+NameMinSize = 10
+# Max fraction of lane width reserved for score box.
+ScoreWidthFractionOfLane = 0.36
+# Base vertical gap between player name and oscilloscope.
+OscilloscopeGapY = 4
+# Minimum vertical gap between player name and oscilloscope.
+OscilloscopeGapMinY = 2
+# Minimum oscilloscope width.
+OscilloscopeMinW = 40
+# Minimum oscilloscope height.
+OscilloscopeMinH = 8
+# Solo mode popup Y offset.
+PopupYOffsetSolo = 65
+# Duet mode popup Y offset.
+PopupYOffsetDuet = 40
+# Solo mode popup font size.
+PopupFontSizeSolo = 18
+# Duet mode popup font size.
+PopupFontSizeDuet = 14
+
 [SingP1Static]
 Inherits = SingDefaultAvatarFrame
 Color = P1Dark
@@ -685,6 +793,242 @@ Text = SONG_SCORE_WHEREAMI
 #end of main stuff
 
 # # # # # # # # # # # # # # # # # # One Player Score # # # # # # # # # # # #
+[ScorePlayerSlotArea]
+AreaX = 20
+AreaY = 110
+AreaW = 760
+AreaH = 420
+ExtraColsBias = 1
+
+# Score player template used for all dynamic score screen layouts.
+[ScorePlayerTemplateTextName]
+X = 197
+Y = 280
+Font = 0
+Style = 1
+Size = 40
+Text = P1
+Color = White
+Align = 0
+
+# Rating
+[ScorePlayerTemplateStaticRatingPicture]
+X = 385
+Y = 165
+H = 75
+W = 75
+
+[ScorePlayerTemplateTextScore]
+X = 422
+Y = 235
+W = 100
+Color = White
+Font = 0
+Style = 0
+Size = 27
+Text = Tone Deaf
+Align = 1
+
+# Note Score
+[ScorePlayerTemplateStaticBoxDark]
+Tex = ScoreBar_box_dark
+X = 200
+Y = 327
+W = 22
+H = 20
+Color = P1Dark
+Type = Colorized
+
+[ScorePlayerTemplateTextNotes]
+X = 227
+Y = 322
+Color = White
+Font = 0
+Style = 0
+Size = 30
+Text = SING_NOTES
+Align = 0
+
+[ScorePlayerTemplateTextNotesScore]
+X = 487
+Y = 322
+Color = White
+Font = 0
+Style = 0
+Size = 30
+Align = 2
+Text = 0
+
+# A simple line
+[ScorePlayerTemplateStatic1]
+Tex = ScoreLine
+X = 200
+Y = 351
+W = 287
+H = 1
+Color = White
+Type = Colorized
+
+# Line Bonus
+[ScorePlayerTemplateStaticBoxLight]
+Inherits = ScorePlayerTemplateStaticBoxDark
+Tex = ScoreBar_box_light
+Y = 358
+Color = P1Light
+
+[ScorePlayerTemplateTextLineBonus]
+Inherits = ScorePlayerTemplateTextNotes
+Y = 352
+Text = SING_PHRASE_BONUS
+
+[ScorePlayerTemplateTextLineBonusScore]
+Inherits = ScorePlayerTemplateTextNotesScore
+Y = 352
+
+# A simple line
+[ScorePlayerTemplateStatic2]
+Inherits = ScorePlayerTemplateStatic1
+Y = 382
+
+# Golden Notes
+[ScorePlayerTemplateStaticBoxLightest]
+Inherits = ScorePlayerTemplateStaticBoxDark
+Tex = ScoreBar_box_lightest
+Y = 390
+Color = P1Lightest
+
+[ScorePlayerTemplateTextGoldenNotes]
+Inherits = ScorePlayerTemplateTextNotes
+Y = 383
+Text = SING_GOLDEN_NOTES
+
+[ScorePlayerTemplateTextGoldenNotesScore]
+Inherits = ScorePlayerTemplateTextNotesScore
+Y = 383
+
+[ScorePlayerTemplateTextTotal]
+X = 237
+Y = 454
+Color = White
+Font = 0
+Style = 0
+Size = 30
+Text = SING_TOTAL
+Align = 0
+Reflection = 1
+ReflectionSpacing = 26
+
+[ScorePlayerTemplateTextTotalScore]
+X = 487
+Y = 444
+Color = White
+Font = 0
+Style = 0
+Size = 42
+Align = 2
+Text = 0
+Reflection = 1
+ReflectionSpacing = 24
+
+#ScoreBar
+[ScorePlayerTemplateStaticBackLevel]
+Tex = ScoreLevel
+X = 503
+Y = 168
+W = 95
+H = 310
+Color = P1Lightest
+Type = Colorized
+
+[ScorePlayerTemplateStaticBackLevelRound]
+Tex = ScoreLevelRound
+X = 503
+Y = 138
+W = 95
+H = 8
+Color = P1Lightest
+Type = Colorized
+
+[ScorePlayerTemplateStaticLevel]
+Tex = ScoreLevel
+X = 503
+Y = 400
+W = 95
+H = 10
+Color = P1Dark
+Type = Colorized
+
+[ScorePlayerTemplateStaticLevelRound]
+Tex = ScoreLevelRound
+X = 503
+Y = 392
+W = 95
+H = 8
+Color = P1Dark
+Type = Colorized
+
+[ScorePlayerTemplateStatic3]
+Tex = ScoreEndCap
+X = 499
+Y = 478
+W = 110
+H = 30
+z = 0.9
+Color = P1Dark
+Type = Colorized
+Reflection = 1
+ReflectionSpacing = 0
+
+[ScorePlayerTemplateStatic4]
+Tex = ScoreGlassBox
+X = 499
+Y = 148
+W = 113
+H = 331
+z = 0.89
+Color = White
+Type = Transparent
+
+[ScorePlayerTemplateStatic5]
+Tex = P
+X = 200
+Y = 455
+W = 26
+H = 23
+Color = P1Dark
+Type = Colorized
+Reflection = 1
+ReflectionSpacing = 31
+
+[ScorePlayerTemplateText1]
+Text = P1
+X = 204
+Y = 458
+Size = 18
+Font = 0
+Style = 1
+Color = White
+Type = Colorized
+Reflection = 1
+ReflectionSpacing = 40
+
+[ScorePlayerTemplateAvatar]
+X = 203
+Y = 168
+W = 104
+H = 104
+Z = 1
+
+[ScorePlayerTemplateStatic6]
+X = 195
+Y = 160
+W = 120
+H = 120
+Z = 0.9
+Tex = AvatarFrame2
+Color = P1Dark
+Type = Transparent
+
 [ScoreTextName1]
 X = 197
 Y = 280
@@ -2742,6 +3086,45 @@ W = 250
 H = 35
 SkipX = 10
 SBGW = 360
+
+[NamePlayerSelectTemplateFrame]
+X = 100
+Y = 185
+W = 70
+H = 60
+Tex = AvatarFrame2
+Color = P1Dark
+Type = Transparent
+Z = 1
+
+[NamePlayerSelectTemplateText]
+X = 135
+Y = 248
+Font = 0
+Style = 1
+Size = 16
+Align = 1
+Color = White
+Z = 1
+
+[NamePlayerSelectTemplateAvatar]
+X = 105
+Y = 190
+W = 60
+H = 51
+Z = 1
+
+[NamePlayerSelectGrid]
+GridX = 30
+GridY = 185
+GridW = 760
+GridH = 155
+MinimumVisibleSlots = 2
+MaximumColumns = 12
+RowVerticalSpreadDivisor = 1.5
+MaxScaleUpTo2Players = 1.35
+MaxScaleUpTo4Players = 1.15
+MaxScaleDefault = 1.0
 
 [NamePlayerSelectStatic1]
 X = 100
@@ -6511,6 +6894,12 @@ Size = 20
 Align = 1
 Color = White
 
+[SongRouletteDuetSingerArea]
+X = 530
+Y = 340
+
+#############################
+
 [SongRouletteStatic2PlayersDuetSingerP2]
 Inherits = SongRouletteStatic2PlayersDuetSingerP1
 Y = 445
@@ -6585,6 +6974,10 @@ Y = 240
 Inherits = SongRouletteText2PlayersDuetSingerP1
 X = 630
 Y = 245
+
+[SongListDuetSingerArea]
+X = 525
+Y = 110
 
 [SongListStatic2PlayersDuetSingerP2]
 Inherits = SongListStatic2PlayersDuetSingerP1
@@ -6661,6 +7054,10 @@ Y = 435
 Inherits = SongRouletteText2PlayersDuetSingerP1
 X = 387
 Y = 440
+
+[SongChessboardDuetSingerArea]
+X = 450
+Y = 420
 
 [SongChessboardStatic2PlayersDuetSingerP2]
 Inherits = SongChessboardStatic2PlayersDuetSingerP1
@@ -9721,6 +10118,14 @@ Y = 185
 
 # O N E  P L A Y E R  M O D E # # # # # # # # # # # # # # # # # # # #
 #PlayerOne
+[SingPlayerTemplateOscilloscope]
+X = 80
+Y = 275
+H = 30
+W = 100
+
+## 4/6 Players One Screen  ##
+
 [SingP1Oscilloscope]
 X = 80
 Y = 275

--- a/game/themes/Modern.ini
+++ b/game/themes/Modern.ini
@@ -529,28 +529,20 @@ MinFrameH = 26
 MinScoreW = 56
 # Minimum score box height after scaling.
 MinScoreH = 18
-# Horizontal offset from lane left edge to header group start.
-HeaderLeftOffset = 0
 # Vertical offset from row anchor to header group.
 HeaderTopOffsetBase = 148
 # Extra header vertical offset per additional row.
 HeaderTopOffsetPerExtraRow = 0
-# Minimum inset of avatar texture inside its frame (X).
-AvatarInsetMinX = 1
-# Minimum inset of avatar texture inside its frame (Y).
-AvatarInsetMinY = 1
-# Base horizontal gap between avatar frame and player name.
-NameGapX = 10
-# Minimum horizontal gap between avatar frame and player name.
-NameGapMinX = 8
-# Base horizontal text padding for player name.
-NamePaddingX = 6
-# Minimum horizontal text padding for player name.
-NamePaddingMinX = 4
-# Base vertical text padding for player name.
-NamePaddingY = 6
-# Minimum vertical text padding for player name.
-NamePaddingMinY = 3
+# Template coordinates use this reference rectangle. Each widget is translated
+# and scaled into its generated player lane while retaining its relative offset.
+ReferenceX = 20
+ReferenceY = 275
+ReferenceW = 760
+# Horizontal anchors: 0 = lane left, 0.5 = center, 1 = lane right.
+AvatarAnchorX = 0
+NameAnchorX = 0
+ScoreAnchorX = 1
+OscilloscopeAnchorX = 0
 # Minimum width allocated to player name text.
 NameMinW = 24
 # Minimum height allocated to player name text.
@@ -559,10 +551,6 @@ NameMinH = 14
 NameMinSize = 10
 # Max fraction of lane width reserved for score box.
 ScoreWidthFractionOfLane = 0.36
-# Base vertical gap between player name and oscilloscope.
-OscilloscopeGapY = 4
-# Minimum vertical gap between player name and oscilloscope.
-OscilloscopeGapMinY = 2
 # Minimum oscilloscope width.
 OscilloscopeMinW = 40
 # Minimum oscilloscope height.


### PR DESCRIPTION
Part of splitting #1186 as bbq² told me to.

Files changed in this PR:
- game/themes/Modern.ini +405 -0

This adds reusable Modern theme templates for player-dependent sing and score elements. These templates are not the main behavior change yet; they prepare the theme file so later PRs can instantiate player blocks from one template instead of many fixed sections.
There is no user-facing / visual change anywhere from this PR - it is only preparing the theme.

(The complete chain fixes 634, 545, 732, 712.)