### PR TITLE
Make OpenCV webcam support optional again

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -64,8 +64,9 @@ Optional libraries:
   This should support newer platforms like PulseAudio and PipeWire.
   Might not be able to detect the number of channels correctly when used with PulseAudio.
   Might fix issues experienced when using PortAudio on certain distributions.
-* OpenCV 3+ is required to build the webcam wrapper.
-  Current builds use the wrapper-backed OpenCV bindings on every platform.
+* `--with-opencv`: Enable webcam support with OpenCV. By default, configure
+  auto-detects OpenCV 3+ and disables webcam support if OpenCV is not found.
+* `--without-opencv`: Build without webcam support even if OpenCV is installed.
 
 ## Compiling on Linux using flatpak-builder
 - The manifest for our Flathub releases is in a different repository:

--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,32 @@ AC_ARG_WITH([local-projectM-presets],
 		    [use the presets from game/visuals/ @<:@default=no@:>@])],
     [with_local_projectM_presets=$withval], [with_local_projectM_presets="no"])
 
+# add OpenCV option
+AC_ARG_WITH([opencv],
+    [AS_HELP_STRING([--with-opencv],
+      [enable webcam support with OpenCV @<:@default=check@:>@])],
+    [with_OpenCV=$withval], [with_OpenCV="check"])
+
+# Backward-compatible spelling for the OpenCV package name used by PKG_HAVE.
+AC_ARG_WITH([OpenCV], [],
+    [with_OpenCV=$withval], [])
+
+AC_ARG_WITH([opencv-cxx-api],
+    [AS_HELP_STRING([--with-opencv-cxx-api],
+      [(deprecated) alias for --with-opencv])],
+    [case "$withval" in
+        yes)  with_OpenCV=yes ;;
+        no)   with_OpenCV=no ;;
+        auto) with_OpenCV=check ;;
+        *)    AC_MSG_ERROR([bad value "$withval" for --with-opencv-cxx-api]) ;;
+     esac], [])
+
+case "$with_OpenCV" in
+    yes|no|check|nocheck) ;;
+    auto) with_OpenCV=check ;;
+    *) AC_MSG_ERROR([bad value "$with_OpenCV" for --with-opencv; use yes, no, check, auto, or nocheck]) ;;
+esac
+
 # print misc options header
 AC_ARG_WITH([cfg-dummy2], [
 Development options:])
@@ -139,15 +165,6 @@ if [[ "$FPC_VERSION_MAJOR" -lt 3 ]]; then
 !!! version 3.0.0, but only version $FPC_VERSION was found.
 !!! Please install a newer fpc version.
 ]) 
-fi
-
-# On Windows, the OpenCV C-wrapper is required for compiling with current OpenCV.
-# Keep explicit user values, but auto-enable when no value was provided.
-if [[ "$with_opencv_cxx_api" = auto ]]; then
-   case "$FPC_PLATFORM" in
-      win32|win64) with_opencv_cxx_api=yes ;;
-      *)           with_opencv_cxx_api=no ;;
-   esac
 fi
 
 # find and test the C compiler (for C-libs and wrappers)
@@ -365,48 +382,72 @@ opencv_core_standalone=no
 opencv_imgproc_standalone=no
 opencv_videoio_standalone=no
 OpenCV_WRAPPER_LIBS=
-if [[ "$cxx_works" = yes ]] ; then
-    AX_CXX_COMPILE_STDCXX([11], [], [optional])
-    CMAKE_FIND_PACKAGE([OpenCV], [CXX], [GNU], , [OpenCV_HAVE=yes], [OpenCV_HAVE=no])
-    if [[ "$OpenCV_HAVE" != yes ]] ; then
-        PKG_HAVE([OpenCV], [opencv4], no)
-        if [[ "$OpenCV_HAVE" != yes ]] ; then
-            PKG_HAVE([OpenCV], [opencv >= 3.0.0], yes)
-            OpenCV_CXXFLAGS=`$PKG_CONFIG --cflags "opencv >= 3.0.0"`
+OpenCV_PKG=
+opencv_USE_CWRAPPER=no
+if [[ x$with_OpenCV != xno ]] ; then
+    if [[ "$cxx_works" = yes ]] ; then
+        AX_CXX_COMPILE_STDCXX([11], [], [optional])
+        if [[ x$with_OpenCV = xnocheck ]] ; then
+            OpenCV_HAVE=yes
         else
-            OpenCV_CXXFLAGS=`$PKG_CONFIG --cflags opencv4`
+            CMAKE_FIND_PACKAGE([OpenCV], [CXX], [GNU], , [OpenCV_HAVE=yes], [OpenCV_HAVE=no])
+            if [[ "$OpenCV_HAVE" != yes ]] ; then
+                saved_with_OpenCV=$with_OpenCV
+                with_OpenCV=check
+                PKG_HAVE([OpenCV], [opencv4], no)
+                if [[ "$OpenCV_HAVE" = yes ]] ; then
+                    OpenCV_PKG=opencv4
+                else
+                    PKG_HAVE([OpenCV], [opencv >= 3.0.0], no)
+                    if [[ "$OpenCV_HAVE" = yes ]] ; then
+                        OpenCV_PKG="opencv >= 3.0.0"
+                    fi
+                fi
+                with_OpenCV=$saved_with_OpenCV
+                if [[ x$OpenCV_PKG != x ]] ; then
+                    OpenCV_CXXFLAGS=`$PKG_CONFIG --cflags "$OpenCV_PKG"`
+                fi
+            fi
         fi
+        if [[ "$OpenCV_HAVE" = yes ]] ; then
+            opencv_USE_CWRAPPER=yes
+            use_cxx=yes
+            for lib in $OpenCV_LIBS ; do
+                case "${lib##*/}" in
+                *opencv_core*|*opencv_imgproc*|*opencv_videoio*)
+                    OpenCV_WRAPPER_LIBS="$OpenCV_WRAPPER_LIBS $lib"
+                    ;;
+                *opencv_*)
+                    ;;
+                *)
+                    OpenCV_WRAPPER_LIBS="$OpenCV_WRAPPER_LIBS $lib"
+                    continue
+                    ;;
+                esac
+                case "${lib##*/}" in
+                *opencv_core*)    opencv_core_standalone=yes ;;
+                *opencv_imgproc*) opencv_imgproc_standalone=yes ;;
+                *opencv_videoio*) opencv_videoio_standalone=yes ;;
+                *) continue ;;
+                esac
+                case "$lib" in
+                -L)  LIBS="$LIBS $lib" ;;
+                */*) LIBS="$LIBS -L${lib%/*}" ;;
+                esac
+            done
+            AC_SUBST(OpenCV_CXXFLAGS)
+            AC_SUBST(OpenCV_LIBS)
+            AC_SUBST(OpenCV_WRAPPER_LIBS)
+        elif [[ x$with_OpenCV = xyes ]] ; then
+            AC_MSG_FAILURE([OpenCV was requested but not found])
+        else
+            AC_MSG_NOTICE([OpenCV not found; webcam support disabled])
+        fi
+    elif [[ x$with_OpenCV = xyes -o x$with_OpenCV = xnocheck ]] ; then
+        AC_MSG_FAILURE([Need C++ compiler to build the OpenCV wrapper])
+    else
+        AC_MSG_NOTICE([C++ compiler is not available; webcam support disabled])
     fi
-    opencv_USE_CWRAPPER=yes
-    use_cxx=yes
-    for lib in $OpenCV_LIBS ; do
-        case "${lib##*/}" in
-        *opencv_core*|*opencv_imgproc*|*opencv_videoio*)
-            OpenCV_WRAPPER_LIBS="$OpenCV_WRAPPER_LIBS $lib"
-            ;;
-        *opencv_*)
-            ;;
-        *)
-            OpenCV_WRAPPER_LIBS="$OpenCV_WRAPPER_LIBS $lib"
-            continue
-            ;;
-        esac
-        case "${lib##*/}" in
-        *opencv_core*)    opencv_core_standalone=yes ;;
-        *opencv_imgproc*) opencv_imgproc_standalone=yes ;;
-        *opencv_videoio*) opencv_videoio_standalone=yes ;;
-        *) continue ;;
-        esac
-        case "$lib" in
-        -L)  LIBS="$LIBS $lib" ;;
-        */*) LIBS="$LIBS -L${lib%/*}" ;;
-        esac
-    done
-    AC_SUBST(OpenCV_CXXFLAGS)
-    AC_SUBST(OpenCV_LIBS)
-    AC_SUBST(OpenCV_WRAPPER_LIBS)
-else
-    AC_MSG_FAILURE([Need C++ compiler to build the required OpenCV wrapper])
 fi
 AC_SUBST_DEFINE(USE_OPENCV_CWRAPPER, $opencv_USE_CWRAPPER)
 AC_SUBST(USE_OPENCV_CWRAPPER, $opencv_USE_CWRAPPER)

--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -102,7 +102,6 @@ uses
   SysUtils,
   Math,
   dglOpenGL,
-  opencv_core,
   TextGL,
   UDrawTexture,
   UGraphic,

--- a/src/base/UWebcam.pas
+++ b/src/base/UWebcam.pas
@@ -35,15 +35,18 @@ interface
 
 uses
   Classes,
-  UTexture,
+  UTexture
+  {$IFDEF UseOpenCVWrapper},
   sdl2,
   opencv_highgui,
   opencv_core,
   opencv_imgproc,
-  opencv_types;
+  opencv_types
+  {$ENDIF};
 
 type
 
+{$IFDEF UseOpenCVWrapper}
   TWebcam = class
     private
       IsEnabled:     Boolean;
@@ -74,6 +77,19 @@ type
       function FrameEffect(Nr_Effect: integer; Frame: PIplImage): PIplImage;
       function FrameAdjust(Frame: PIplImage): PIplImage;
    end;
+{$ELSE}
+  TWebcam = class
+    public
+      Capture: Pointer;
+      TextureCam: TTexture;
+
+      constructor Create;
+      procedure Start;
+      procedure Release;
+      procedure Restart;
+      procedure GetWebcamFrame();
+   end;
+{$ENDIF}
 
 var
   Webcam:    TWebcam;
@@ -81,6 +97,7 @@ var
 
 implementation
 
+{$IFDEF UseOpenCVWrapper}
 uses
   dglOpenGL,
   SysUtils,
@@ -440,5 +457,37 @@ begin
 end;
 
 //----------
+
+{$ELSE}
+
+constructor TWebcam.Create;
+begin
+  inherited;
+  Capture := nil;
+  TextureCam.TexNum := 0;
+end;
+
+procedure TWebcam.Start;
+begin
+  Capture := nil;
+end;
+
+procedure TWebcam.Release;
+begin
+  Capture := nil;
+  TextureCam.TexNum := 0;
+end;
+
+procedure TWebcam.Restart;
+begin
+  Release;
+  Start;
+end;
+
+procedure TWebcam.GetWebcamFrame();
+begin
+end;
+
+{$ENDIF}
 
 end.

--- a/src/ultrastardx.dpr
+++ b/src/ultrastardx.dpr
@@ -340,10 +340,12 @@ uses
   UWebSDK                 in 'webSDK\UWebSDK.pas',
   //curlobj                 in 'webSDK\cURL\src\curlobj.pas',
 
+  {$IFDEF UseOpenCVWrapper}
   opencv_highgui          in 'lib\openCV3\opencv_highgui.pas',
   opencv_core             in 'lib\openCV3\opencv_core.pas',
   opencv_imgproc          in 'lib\openCV3\opencv_imgproc.pas',
   opencv_types            in 'lib\openCV3\opencv_types.pas',
+  {$ENDIF}
 
   UMenuStaticList in 'menu\UMenuStaticList.pas',
   UWebcam                 in 'base\UWebcam.pas',


### PR DESCRIPTION
With #1238 we (accidentally) made OpenCV a requirement rather than an optional dependency for builds with webcam support.

This PR fixes this by:
- adding `--with-opencv` / `--without-opencv` configure handling with default auto-detection
- disabling webcam support cleanly when OpenCV is not found
- keeping explicit `--with-opencv` behavior strict, failing if OpenCV is unavailable
- and updating compiling docs for the new OpenCV behavior