### PR TITLE
Improve rap note contrast in the editor

### DIFF
--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -1646,8 +1646,16 @@ begin
           ntFreestyle: glColor4f(1, 1, 1, 0.35);
           ntNormal: glColor4f(1, 1, 1, 0.85);
           ntGolden: Glcolor4f(1, 1, 0.3, 0.85);
-          ntRap: glColor4f(1, 1, 1, 0.85);
-          ntRapGolden: Glcolor4f(1, 1, 0.3, 0.85);
+          ntRap:
+            if (Color = P1_INVERTED) then
+              glColor4f(1, 1, 1, 0.75)
+            else
+              glColor4f(1, 1, 1, 0.5);
+          ntRapGolden:
+            if (Color = P1_INVERTED) then
+              Glcolor4f(1, 1, 0.3, 0.75)
+            else
+              Glcolor4f(1, 1, 0.3, 0.5);
         end; // case
 
         // left part
@@ -1866,4 +1874,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
- Make rap and rap golden notes more translucent in the editor so black note text stays slightly more readable
- Keep selected rap notes less translucent than unselected ones so the current note can be recognized more easily
- Gameplay note rendering is unchanged

### Before (difficult to see which note is selected)

<img width="1920" height="1080" alt="Screenshot_2026-05-14_23-52-18" src="https://github.com/user-attachments/assets/06877a52-915f-4956-89aa-7f9866adc714" />

### After (Regular, easier to recognize which note is selected)
<img width="1920" height="1080" alt="Screenshot_2026-05-15_00-05-05" src="https://github.com/user-attachments/assets/7e2bf070-e30e-4a56-bbeb-19a069467327" />

### After (Golden, again, a bit easier to recognize)
<img width="1920" height="1080" alt="Screenshot_2026-05-15_00-05-23" src="https://github.com/user-attachments/assets/4b4798b5-4e7b-4ab9-8187-52d51dec9d32" />

