### PR TITLE
Fix missing editor note textures when opening editor first

### DIFF
--- a/src/base/UGraphic.pas
+++ b/src/base/UGraphic.pas
@@ -298,6 +298,8 @@ procedure Reinitialize3D;
 procedure SwapBuffers;
 
 procedure LoadTextures;
+procedure LoadSingScreenTextures(ForceReload: boolean = false);
+procedure UnloadSingScreenTextures;
 procedure InitializeScreen;
 procedure LoadLoadingScreen;
 procedure LoadScreens(Title: string);
@@ -323,7 +325,11 @@ uses
   Classes,
   UDisplay,
   UCommandLine,
-  UPathUtils;
+  UPathUtils,
+  UThemes;
+
+var
+  SingScreenTexturesLoaded: boolean = false;
 
 procedure LoadFontTextures;
 begin
@@ -425,6 +431,101 @@ begin
   end;
 
   Log.LogStatus('Loading Textures - Done', 'LoadTextures');
+end;
+
+procedure UnloadSingScreenTextures;
+var
+  I: integer;
+begin
+  for I := 1 to UIni.IMaxPlayerCount do
+  begin
+    FreeTexture(Tex_Left[I]);
+    FreeTexture(Tex_Mid[I]);
+    FreeTexture(Tex_Right[I]);
+    FreeTexture(Tex_plain_Left[I]);
+    FreeTexture(Tex_plain_Mid[I]);
+    FreeTexture(Tex_plain_Right[I]);
+    FreeTexture(Tex_BG_Left[I]);
+    FreeTexture(Tex_BG_Mid[I]);
+    FreeTexture(Tex_BG_Right[I]);
+    FreeTexture(Tex_Left_Rap[I]);
+    FreeTexture(Tex_Mid_Rap[I]);
+    FreeTexture(Tex_Right_Rap[I]);
+    FreeTexture(Tex_plain_Left_Rap[I]);
+    FreeTexture(Tex_plain_Mid_Rap[I]);
+    FreeTexture(Tex_plain_Right_Rap[I]);
+    FreeTexture(Tex_BG_Left_Rap[I]);
+    FreeTexture(Tex_BG_Mid_Rap[I]);
+    FreeTexture(Tex_BG_Right_Rap[I]);
+    FreeTexture(Tex_ScoreBG[I - 1]);
+  end;
+
+  FreeTexture(Tex_Left_Inv);
+  FreeTexture(Tex_Mid_Inv);
+  FreeTexture(Tex_Right_Inv);
+  FreeTexture(Tex_Left_Rap_Inv);
+  FreeTexture(Tex_Mid_Rap_Inv);
+  FreeTexture(Tex_Right_Rap_Inv);
+  SingScreenTexturesLoaded := false;
+end;
+
+procedure LoadSingScreenTextures(ForceReload: boolean);
+var
+  I: integer;
+  Col: TRGB;
+  Color: cardinal;
+begin
+  if ForceReload then
+    UnloadSingScreenTextures
+  else if SingScreenTexturesLoaded then
+    Exit;
+
+  for I := 1 to UIni.IMaxPlayerCount do
+  begin
+    Col := GetPlayerColor(Ini.SingColor[I - 1]);
+    Color := (Trunc(255 * Col.R) shl 16) or
+             (Trunc(255 * Col.G) shl  8) or
+              Trunc(255 * Col.B);
+
+    Tex_Left[I]         := Texture.LoadTexture(Skin.GetTextureFileName('GrayLeft'),  TEXTURE_TYPE_COLORIZED, Color);
+    Tex_Mid[I]          := Texture.LoadTexture(Skin.GetTextureFileName('GrayMid'),   TEXTURE_TYPE_COLORIZED, Color);
+    Tex_Right[I]        := Texture.LoadTexture(Skin.GetTextureFileName('GrayRight'), TEXTURE_TYPE_COLORIZED, Color);
+
+    Tex_plain_Left[I]   := Texture.LoadTexture(Skin.GetTextureFileName('NotePlainLeft'),  TEXTURE_TYPE_COLORIZED, Color);
+    Tex_plain_Mid[I]    := Texture.LoadTexture(Skin.GetTextureFileName('NotePlainMid'),   TEXTURE_TYPE_COLORIZED, Color);
+    Tex_plain_Right[I]  := Texture.LoadTexture(Skin.GetTextureFileName('NotePlainRight'), TEXTURE_TYPE_COLORIZED, Color);
+
+    Tex_BG_Left[I]      := Texture.LoadTexture(Skin.GetTextureFileName('NoteBGLeft'),  TEXTURE_TYPE_COLORIZED, Color);
+    Tex_BG_Mid[I]       := Texture.LoadTexture(Skin.GetTextureFileName('NoteBGMid'),   TEXTURE_TYPE_COLORIZED, Color);
+    Tex_BG_Right[I]     := Texture.LoadTexture(Skin.GetTextureFileName('NoteBGRight'), TEXTURE_TYPE_COLORIZED, Color);
+
+    Tex_Left_Rap[I]         := Texture.LoadTexture(Skin.GetTextureFileName('GrayLeftRap'),  TEXTURE_TYPE_COLORIZED, Color);
+    Tex_Mid_Rap[I]          := Texture.LoadTexture(Skin.GetTextureFileName('GrayMidRap'),   TEXTURE_TYPE_COLORIZED, Color);
+    Tex_Right_Rap[I]        := Texture.LoadTexture(Skin.GetTextureFileName('GrayRightRap'), TEXTURE_TYPE_COLORIZED, Color);
+
+    Tex_plain_Left_Rap[I]   := Texture.LoadTexture(Skin.GetTextureFileName('NotePlainLeftRap'),  TEXTURE_TYPE_COLORIZED, Color);
+    Tex_plain_Mid_Rap[I]    := Texture.LoadTexture(Skin.GetTextureFileName('NotePlainMidRap'),   TEXTURE_TYPE_COLORIZED, Color);
+    Tex_plain_Right_Rap[I]  := Texture.LoadTexture(Skin.GetTextureFileName('NotePlainRightRap'), TEXTURE_TYPE_COLORIZED, Color);
+
+    Tex_BG_Left_Rap[I]      := Texture.LoadTexture(Skin.GetTextureFileName('NoteBGLeftRap'),  TEXTURE_TYPE_COLORIZED, Color);
+    Tex_BG_Mid_Rap[I]       := Texture.LoadTexture(Skin.GetTextureFileName('NoteBGMidRap'),   TEXTURE_TYPE_COLORIZED, Color);
+    Tex_BG_Right_Rap[I]     := Texture.LoadTexture(Skin.GetTextureFileName('NoteBGRightRap'), TEXTURE_TYPE_COLORIZED, Color);
+
+    Tex_ScoreBG[I - 1] := Texture.LoadTexture(Skin.GetTextureFileName('ScoreBG'), TEXTURE_TYPE_COLORIZED, Color);
+  end;
+
+  Col := GetPlayerColor(Ini.SingColor[0]);
+  Color := (Trunc(255 * (1 - Col.R)) shl 16) or
+           (Trunc(255 * (1 - Col.G)) shl  8) or
+            Trunc(255 * (1 - Col.B));
+
+  Tex_Left_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayLeft'), TEXTURE_TYPE_COLORIZED, Color);
+  Tex_Mid_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayMid'), TEXTURE_TYPE_COLORIZED, Color);
+  Tex_Right_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayRight'), TEXTURE_TYPE_COLORIZED, Color);
+  Tex_Left_Rap_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayLeftRap'), TEXTURE_TYPE_COLORIZED, Color);
+  Tex_Mid_Rap_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayMidRap'), TEXTURE_TYPE_COLORIZED, Color);
+  Tex_Right_Rap_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayRightRap'), TEXTURE_TYPE_COLORIZED, Color);
+  SingScreenTexturesLoaded := true;
 end;
 
 const
@@ -1038,6 +1139,7 @@ begin
   FreeAndNil(ScreenPartyTournamentWin);
   FreeAndNil(ScreenStatMain);
   FreeAndNil(ScreenStatDetail);
+  UnloadSingScreenTextures;
 end;
 
 end.

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -5180,6 +5180,7 @@ begin
   PlaySentenceMidi := false;
   Text[TextInfo].Text := '';
   Log.LogStatus('Initializing', 'TEditScreen.OnShow');
+  LoadSingScreenTextures;
   Xmouse := 0;
   VolumeDragSlideId := -1;
 

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -441,7 +441,6 @@ constructor TScreenSingView.Create;
 var
   Col: array [1..UIni.IMaxPlayerCount] of TRGB;
   I: integer;
-  Color: cardinal;
   procedure setColor(var avatarFrame: TThemeStatic; color: TRGB);
   begin
     avatarFrame.ColR := color.R;
@@ -584,51 +583,7 @@ begin
   setColorAndAssignStatics(Theme.Sing.Duet6PP5, StaticP5DuetSixP, TextP5DuetSixP, Col[5]);
   setColorAndAssignStatics(Theme.Sing.Duet6PP6, StaticP6DuetSixP, TextP6DuetSixP, Col[6]);
 
-  // Sing Bars
-  // P1-6
-  for I := 1 to UIni.IMaxPlayerCount do
-  begin
-    Color := RGBFloatToInt(Col[I].R, Col[I].G, Col[I].B);
-
-	// Color := $002222; //light blue
-  // Color := $10000 * Round(0.22*255) + $100 * Round(0.39*255) + Round(0.64*255); //dark blue
-
-    Tex_Left[I]         := Texture.LoadTexture(Skin.GetTextureFileName('GrayLeft'),  TEXTURE_TYPE_COLORIZED, Color);
-    Tex_Mid[I]          := Texture.LoadTexture(Skin.GetTextureFileName('GrayMid'),   TEXTURE_TYPE_COLORIZED, Color);
-    Tex_Right[I]        := Texture.LoadTexture(Skin.GetTextureFileName('GrayRight'), TEXTURE_TYPE_COLORIZED, Color);
-
-    Tex_plain_Left[I]   := Texture.LoadTexture(Skin.GetTextureFileName('NotePlainLeft'),  TEXTURE_TYPE_COLORIZED, Color);
-    Tex_plain_Mid[I]    := Texture.LoadTexture(Skin.GetTextureFileName('NotePlainMid'),   TEXTURE_TYPE_COLORIZED, Color);
-    Tex_plain_Right[I]  := Texture.LoadTexture(Skin.GetTextureFileName('NotePlainRight'), TEXTURE_TYPE_COLORIZED, Color);
-
-    Tex_BG_Left[I]      := Texture.LoadTexture(Skin.GetTextureFileName('NoteBGLeft'),  TEXTURE_TYPE_COLORIZED, Color);
-    Tex_BG_Mid[I]       := Texture.LoadTexture(Skin.GetTextureFileName('NoteBGMid'),   TEXTURE_TYPE_COLORIZED, Color);
-    Tex_BG_Right[I]     := Texture.LoadTexture(Skin.GetTextureFileName('NoteBGRight'), TEXTURE_TYPE_COLORIZED, Color);
-
-    Tex_Left_Rap[I]         := Texture.LoadTexture(Skin.GetTextureFileName('GrayLeftRap'),  TEXTURE_TYPE_COLORIZED, Color);
-    Tex_Mid_Rap[I]          := Texture.LoadTexture(Skin.GetTextureFileName('GrayMidRap'),   TEXTURE_TYPE_COLORIZED, Color);
-    Tex_Right_Rap[I]        := Texture.LoadTexture(Skin.GetTextureFileName('GrayRightRap'), TEXTURE_TYPE_COLORIZED, Color);
-
-    Tex_plain_Left_Rap[I]   := Texture.LoadTexture(Skin.GetTextureFileName('NotePlainLeftRap'),  TEXTURE_TYPE_COLORIZED, Color);
-    Tex_plain_Mid_Rap[I]    := Texture.LoadTexture(Skin.GetTextureFileName('NotePlainMidRap'),   TEXTURE_TYPE_COLORIZED, Color);
-    Tex_plain_Right_Rap[I]  := Texture.LoadTexture(Skin.GetTextureFileName('NotePlainRightRap'), TEXTURE_TYPE_COLORIZED, Color);
-
-    Tex_BG_Left_Rap[I]      := Texture.LoadTexture(Skin.GetTextureFileName('NoteBGLeftRap'),  TEXTURE_TYPE_COLORIZED, Color);
-    Tex_BG_Mid_Rap[I]       := Texture.LoadTexture(Skin.GetTextureFileName('NoteBGMidRap'),   TEXTURE_TYPE_COLORIZED, Color);
-    Tex_BG_Right_Rap[I]     := Texture.LoadTexture(Skin.GetTextureFileName('NoteBGRightRap'), TEXTURE_TYPE_COLORIZED, Color);
-
-    //## backgrounds for the scores ##
-    Tex_ScoreBG[I - 1] := Texture.LoadTexture(Skin.GetTextureFileName('ScoreBG'), TEXTURE_TYPE_COLORIZED, Color);
-  end;
-
-  // Inversions of first player colors used to mark selected note in editor
-  Color := RGBFloatToInt(1 - Col[1].R, 1 - Col[1].G, 1 - Col[1].B);
-  Tex_Left_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayLeft'), TEXTURE_TYPE_COLORIZED, Color);
-  Tex_Mid_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayMid'), TEXTURE_TYPE_COLORIZED, Color);
-  Tex_Right_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayRight'), TEXTURE_TYPE_COLORIZED, Color);
-  Tex_Left_Rap_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayLeftRap'), TEXTURE_TYPE_COLORIZED, Color);
-  Tex_Mid_Rap_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayMidRap'), TEXTURE_TYPE_COLORIZED, Color);
-  Tex_Right_Rap_Inv := Texture.LoadTexture(Skin.GetTextureFileName('GrayRightRap'), TEXTURE_TYPE_COLORIZED, Color);
+  LoadSingScreenTextures(true);
 
   StaticPausePopup := ScreenSing.AddStatic(Theme.Sing.PausePopUp);
 
@@ -716,37 +671,8 @@ begin
 end;
 
 destructor TScreenSingView.Destroy;
-var
-  I: integer;
 begin
-  for I := 1 to UIni.IMaxPlayerCount do
-  begin
-    FreeTexture(Tex_Left[I]);
-    FreeTexture(Tex_Mid[I]);
-    FreeTexture(Tex_Right[I]);
-    FreeTexture(Tex_plain_Left[I]);
-    FreeTexture(Tex_plain_Mid[I]);
-    FreeTexture(Tex_plain_Right[I]);
-    FreeTexture(Tex_BG_Left[I]);
-    FreeTexture(Tex_BG_Mid[I]);
-    FreeTexture(Tex_BG_Right[I]);
-    FreeTexture(Tex_Left_Rap[I]);
-    FreeTexture(Tex_Mid_Rap[I]);
-    FreeTexture(Tex_Right_Rap[I]);
-    FreeTexture(Tex_plain_Left_Rap[I]);
-    FreeTexture(Tex_plain_Mid_Rap[I]);
-    FreeTexture(Tex_plain_Right_Rap[I]);
-    FreeTexture(Tex_BG_Left_Rap[I]);
-    FreeTexture(Tex_BG_Mid_Rap[I]);
-    FreeTexture(Tex_BG_Right_Rap[I]);
-    FreeTexture(Tex_ScoreBG[I - 1]);
-  end;
-  FreeTexture(Tex_Left_Inv);
-  FreeTexture(Tex_Mid_Inv);
-  FreeTexture(Tex_Right_Inv);
-  FreeTexture(Tex_Left_Rap_Inv);
-  FreeTexture(Tex_Mid_Rap_Inv);
-  FreeTexture(Tex_Right_Rap_Inv);
+  UnloadSingScreenTextures;
   inherited;
 end;
 
@@ -1367,4 +1293,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
There is a bug where note textures are not loaded in the editor that occurs when opening the editor before starting to play any song

### Screenshot of Bug

<img width="1920" height="1080" alt="Screenshot_2026-05-14_23-46-31" src="https://github.com/user-attachments/assets/7d08724e-a67e-4f44-9d90-bda0e5101089" />

### Fix

- Move sing note texture loading/unloading into shared `UGraphic` helpers
- Load those textures when the editor opens, so notes render correctly even if the sing screen was never created
- Reuse the same helpers from the sing screen to avoid duplicate texture lifecycle code