### PR TITLE
Refresh active playlists during song preview

### DIFF
--- a/src/base/UPlaylist.pas
+++ b/src/base/UPlaylist.pas
@@ -81,6 +81,7 @@ type
       procedure   LoadPlayLists;
       function    LoadPlayList(Index: Cardinal; const Filename: IPath): Boolean;
       function    ReloadPlayList(Index: Cardinal): Boolean;
+      function    ApplyPlayList(Index: Integer): Boolean;
       procedure   SavePlayList(Index: Cardinal);
 
       procedure   RestoreSongOrder;
@@ -211,7 +212,7 @@ begin
   Playlists[Index].Filename := Filename;
   Playlists[Index].Name := '';
   Playlists[Index].FixedOrder := False;
-  Playlists[Index].LastRead := FileAge(Filename.ToNative);
+  Playlists[Index].LastRead := FileAge(FilenameAbs.ToNative);
 
   //Read Until End of File
   while TextStream.ReadLine(Line) do
@@ -334,26 +335,30 @@ begin
     Log.LogError('Could not write Playlistfile "' + Playlists[Index].Name + '"');
   end;
   TextStream.Free;
+  Playlists[Index].LastRead := FileAge(PlaylistFile.ToNative);
 end;
 
 {**
  * Display a Playlist in CatSongs
  *}
-procedure TPlayListManager.SetPlayList(Index: Integer; SongID: Integer = -1);
+function TPlayListManager.ApplyPlayList(Index: Integer): Boolean;
 var
-  I, SongIdx, TargetSongID, RandomVisibleIndex, VisibleCount: Integer;
+  I, SongIdx: Integer;
 begin
+  Result := False;
+
   if (Index < 0) or (Index > High(PlayLists)) then
-    exit;
+    Exit;
 
   RestoreSongOrder;
 
   if Playlists[Index].FixedOrder then
-    ApplyPlaylistOrder(Index)
+  begin
+    ApplyPlaylistOrder(Index);
+    ScreenSong.SyncCoversToSongs;
+  end
   else
     SongOrderDirty := False;
-
-  ScreenSong.SyncCoversToSongs;
 
   //Hide all Songs
   for I := 0 to high(CatSongs.Song) do
@@ -396,6 +401,16 @@ begin
     ScreenSong.ShowCatTLCustom(Format(Theme.Playlist.CatText,[Playlists[Index].Name + '  [Fixed Order: On]']))
   else
     ScreenSong.ShowCatTLCustom(Format(Theme.Playlist.CatText,[Playlists[Index].Name + '  [Fixed Order: Off]']));
+
+  Result := True;
+end;
+
+procedure TPlayListManager.SetPlayList(Index: Integer; SongID: Integer = -1);
+var
+  I, SongIdx, TargetSongID, RandomVisibleIndex, VisibleCount: Integer;
+begin
+  if not ApplyPlayList(Index) then
+    Exit;
 
   ScreenSong.ResetRandomSongState;
 

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -78,6 +78,8 @@ type
       LastPreviewStartTime: integer;
       LastChangeSoundTime: integer;
       LastScrollStopTime: integer;
+      LastPlaylistReloadTime: integer;
+      PreviewEndReloaded: boolean;
 
       RandomSongOrder: CardinalArray;
       NextRandomSongIdx: cardinal;
@@ -85,6 +87,7 @@ type
 
       procedure StartMusicPreview();
       procedure StartVideoPreview();
+      function ReloadCurrentPlaylist(ForceCheck: boolean): boolean;
     public
       TextArtist:   integer;
       TextTitle:    integer;
@@ -346,6 +349,7 @@ const
   MAX_TIME_MOUSE_SELECT = 800;
   CHANGE_SOUND_THROTTLE_MS = 200;
   PREVIEW_DEBOUNCE_MS = 150;
+  PLAYLIST_RELOAD_INTERVAL_MS = 10000;
 
 // ***** Public methods ****** //
 function TScreenSong.EnsureMedleyData(SongIndex: integer; MinSource: TMedleySource): boolean;
@@ -1954,6 +1958,8 @@ begin
   LastPreviewStartTime := 0;
   LastChangeSoundTime := 0;
   LastScrollStopTime := 0;
+  LastPlaylistReloadTime := 0;
+  PreviewEndReloaded := false;
 
   NextRandomSongIdx := High(cardinal);
   NextRandomSearchIdx := High(cardinal);
@@ -2135,6 +2141,7 @@ begin
   StopMusicPreview();
   StopVideoPreview();
   PreviewOpened := -1;
+  PreviewEndReloaded := false;
 
   //SetScrollRefresh;
 end;
@@ -2943,6 +2950,8 @@ begin
 
   // reset video playback engine
   fCurrentVideo := nil;
+  PreviewEndReloaded := false;
+  LastPlaylistReloadTime := SDL_GetTicks;
 
   // reset Medley-Playlist
   SetLength(PlaylistMedley.Song, 0);
@@ -3031,6 +3040,7 @@ begin
       PlaylistMan.SetPlayList(PlaylistMan.CurPlayList, NextSongID);
     end;
   end;
+  LastPlaylistReloadTime := SDL_GetTicks;
 
   FilterDuetsInPartyMode; // in party mode
 
@@ -3068,6 +3078,113 @@ begin
   end;
 end;
 
+function TScreenSong.ReloadCurrentPlaylist(ForceCheck: boolean): boolean;
+var
+  CurrentSongRef: TSong;
+  PreviewSongRef: TSong;
+  NewInteraction: integer;
+  NewPreviewOpened: integer;
+  NowTicks: integer;
+
+  function FindSongRefIndex(SongRef: TSong): integer;
+  var
+    I: integer;
+  begin
+    Result := -1;
+    if not Assigned(SongRef) or (Length(CatSongs.Song) = 0) then
+      Exit;
+
+    for I := Low(CatSongs.Song) to High(CatSongs.Song) do
+    begin
+      if CatSongs.Song[I] = SongRef then
+      begin
+        Result := I;
+        Exit;
+      end;
+    end;
+  end;
+
+begin
+  Result := false;
+
+  if not Assigned(PlayListMan) then
+    Exit;
+
+  if (PlayListMan.CurPlayList < 0) or
+     (PlayListMan.CurPlayList > High(PlayListMan.Playlists)) or
+     (CatSongs.CatNumShow <> -3) then
+    Exit;
+
+  NowTicks := SDL_GetTicks;
+  if not ForceCheck then
+  begin
+    if isScrolling or
+       ((LastPlaylistReloadTime <> 0) and
+        (NowTicks - LastPlaylistReloadTime < PLAYLIST_RELOAD_INTERVAL_MS)) then
+      Exit;
+  end;
+  LastPlaylistReloadTime := NowTicks;
+
+  CurrentSongRef := nil;
+  PreviewSongRef := nil;
+  if (Length(CatSongs.Song) > 0) then
+  begin
+    if (Interaction >= Low(CatSongs.Song)) and (Interaction <= High(CatSongs.Song)) then
+      CurrentSongRef := CatSongs.Song[Interaction];
+
+    if (PreviewOpened >= Low(CatSongs.Song)) and (PreviewOpened <= High(CatSongs.Song)) then
+      PreviewSongRef := CatSongs.Song[PreviewOpened];
+  end;
+
+  if not PlayListMan.ReloadPlayList(Cardinal(PlayListMan.CurPlayList)) then
+    Exit;
+
+  if not PlayListMan.ApplyPlayList(PlayListMan.CurPlayList) then
+    Exit;
+
+  NewPreviewOpened := FindSongRefIndex(PreviewSongRef);
+  if (NewPreviewOpened >= 0) and CatSongs.Song[NewPreviewOpened].Visible then
+    PreviewOpened := NewPreviewOpened
+  else if (PreviewOpened <> -1) then
+  begin
+    StopMusicPreview();
+    StopVideoPreview();
+    PreviewOpened := -1;
+    PreviewEndReloaded := false;
+  end;
+
+  NewInteraction := FindSongRefIndex(CurrentSongRef);
+  if (NewInteraction >= 0) and CatSongs.Song[NewInteraction].Visible then
+  begin
+    Interaction := NewInteraction;
+    FixSelected;
+    SetScrollRefresh;
+    Result := true;
+    Exit;
+  end;
+
+  StopMusicPreview();
+  StopVideoPreview();
+  PreviewOpened := -1;
+  PreviewEndReloaded := false;
+
+  if CatSongs.VisibleSongs > 0 then
+  begin
+    NewInteraction := CatSongs.FindNextVisible(Interaction);
+    if NewInteraction = -1 then
+      NewInteraction := CatSongs.FindPreviousVisible(Interaction);
+
+    if NewInteraction <> -1 then
+      Interaction := NewInteraction;
+
+    FixSelected;
+    SetScrollRefresh;
+    LastScrollStopTime := SDL_GetTicks;
+  end;
+
+  Result := true;
+end;
+
 function TScreenSong.FinishedMusic: boolean;
 begin
 
@@ -3085,6 +3202,7 @@ var
 begin
 
   FadeMessage();
+  ReloadCurrentPlaylist(false);
 
   if isScrolling then
   begin
@@ -3132,7 +3250,14 @@ begin
   //Log.LogBenchmark('SetScroll4', 5);
 
   if (AudioPlayback.Finished) then
+  begin
+    if (PreviewOpened <> -1) and not PreviewEndReloaded then
+    begin
+      PreviewEndReloaded := true;
+      ReloadCurrentPlaylist(true);
+    end;
     CoverTime := 0;
+  end;
 
   //Fading Functions, Only if Covertime is under 5 Seconds
   if (TSongMenuMode(Ini.SongMenu) in [smChessboard, smList]) then
@@ -3592,6 +3717,8 @@ var
   PreviewPos: real;
   PreviewVolume: single;
 begin
+  PreviewEndReloaded := false;
+
   if SongIndex <> -1 then
   begin
     PreviewOpened := SongIndex;


### PR DESCRIPTION
This pull request introduces a mechanism for automatically and efficiently reloading the current playlist in the song selection screen, ensuring that the playlist view stays up-to-date with underlying changes (such as file modifications), especially after a song preview ends. It also refactors playlist application logic for improved code clarity and maintainability.

**Playlist Reloading and Application Enhancements:**

* Added a new method `ReloadCurrentPlaylist` to `TScreenSong`, which reloads and reapplies the current playlist if necessary, preserving song selection and preview state when possible, and throttling reloads to avoid excessive operations. This method is now called on each draw cycle and after music preview ends. [[1]](diffhunk://#diff-691dbd6229e8e8f8b06721d72897581fc792f0a20660241e07cb39086b4e59ddR83-R92) [[2]](diffhunk://#diff-691dbd6229e8e8f8b06721d72897581fc792f0a20660241e07cb39086b4e59ddR3078-R3184) [[3]](diffhunk://#diff-691dbd6229e8e8f8b06721d72897581fc792f0a20660241e07cb39086b4e59ddR3202) [[4]](diffhunk://#diff-691dbd6229e8e8f8b06721d72897581fc792f0a20660241e07cb39086b4e59ddR3250-R3257)
* Introduced two new fields, `LastPlaylistReloadTime` and `PreviewEndReloaded`, to `TScreenSong` to track reload timing and prevent redundant reloads after preview ends. These are properly initialized and reset in relevant lifecycle events. [[1]](diffhunk://#diff-691dbd6229e8e8f8b06721d72897581fc792f0a20660241e07cb39086b4e59ddR83-R92) [[2]](diffhunk://#diff-691dbd6229e8e8f8b06721d72897581fc792f0a20660241e07cb39086b4e59ddR1959-R1960) [[3]](diffhunk://#diff-691dbd6229e8e8f8b06721d72897581fc792f0a20660241e07cb39086b4e59ddR2142) [[4]](diffhunk://#diff-691dbd6229e8e8f8b06721d72897581fc792f0a20660241e07cb39086b4e59ddR2950-R2951) [[5]](diffhunk://#diff-691dbd6229e8e8f8b06721d72897581fc792f0a20660241e07cb39086b4e59ddR3718-R3719)
* Defined a reload interval constant (`PLAYLIST_RELOAD_INTERVAL_MS`) to throttle automatic playlist reloads.

**Playlist Management Refactoring:**

* Refactored playlist application logic: extracted the logic from `SetPlayList` into a new function `ApplyPlayList` in `TPlayListManager` for better separation of concerns and reusability. `SetPlayList` now calls `ApplyPlayList` and only proceeds if successful. [[1]](diffhunk://#diff-3fd073910fc96e288a0b677d1732f8df1daaad2ff58396539c6d8f2992a0e264R84) [[2]](diffhunk://#diff-3fd073910fc96e288a0b677d1732f8df1daaad2ff58396539c6d8f2992a0e264R338-L358) [[3]](diffhunk://#diff-3fd073910fc96e288a0b677d1732f8df1daaad2ff58396539c6d8f2992a0e264R405-R415)
* Ensured that playlist file modification times are correctly updated after saving and when loading, by referencing the correct filename variable. [[1]](diffhunk://#diff-3fd073910fc96e288a0b677d1732f8df1daaad2ff58396539c6d8f2992a0e264L214-R215) [[2]](diffhunk://#diff-3fd073910fc96e288a0b677d1732f8df1daaad2ff58396539c6d8f2992a0e264R338-L358)

These changes collectively improve the user experience by keeping the playlist view in sync with underlying data changes, while also making the codebase more modular and maintainable.