### PR TITLE
Bugfix: do not call UnifyDeviceName() more than once

### DIFF
--- a/src/media/UAudioInput_Bass.pas
+++ b/src/media/UAudioInput_Bass.pas
@@ -410,11 +410,7 @@ begin
 
       BassDevice.BassDeviceID := BassDeviceID;
 
-      // BASS device names seem to be encoded with local encoding
-      // TODO: works for windows, check Linux + macOS
-      Descr := DecodeStringUTF8(DeviceInfo.name, encAuto);
-
-      BassDevice.Name := UnifyDeviceName(Descr, DeviceIndex);
+      BassDevice.Name := DeviceName;
       Log.LogStatus('Attempting to configure InputDevice "' + BassDevice.Name + '"', 'Bass.EnumDevices');
 
       // zero info-struct as some fields might not be set (e.g. freq is just set on Vista and macOS)


### PR DESCRIPTION
This PR fixes #1308.

The BASS input scan was calling `UnifyDeviceName` twice for the same mic. The way how `UnifyDeviceName` works, is that it tracks names already seen and a second call will create a duplicate of a single microphone e.g. `Microphone (2)` (for `Microphone` ).

Since #1174 startup uses a fast scan that only probes configured devices. With the BASS device name incorrectly adjusted, the saved mic assignment was not matched on startup, so the first song showed "no microphone assigned" until entering the recording settings screen.

The solution is simple, since `UnifyDeviceName` was already called in the same function and the unified name can be used right away.