### PR TITLE
Fix editor Alt+V playback state without MIDI support

### DIFF
--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -1153,10 +1153,14 @@ begin
     end;
     if (SDL_ModState = KMOD_LALT) then
     begin
+      {$IFDEF UseMIDIPort}
       PlaySentenceMidi := true;
-      {$IFDEF UseMIDIPort} MidiTime  := USTime.GetTime;
+      MidiTime  := USTime.GetTime;
       MidiStart := AudioPlayback.Position;
-      MidiStop  := PlayStopTime; {$ENDIF}
+      MidiStop  := PlayStopTime;
+      {$ELSE}
+      PlaySentenceMidi := false;
+      {$ENDIF}
     end;
     PlaySentence := true;
     AudioPlayback.Play;
@@ -1941,7 +1945,11 @@ begin
     begin
       CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 1;
       CurrentNote[CurrentTrack] := 0;
+      {$IFDEF UseMIDIPort}
       PlaySentenceMidi := true;
+      {$ELSE}
+      PlaySentenceMidi := false;
+      {$ENDIF}
       PlayVideo := false;
       StopVideoPreview;
       {$IFDEF UseMIDIPort} MidiTime  := USTime.GetTime;
@@ -1963,7 +1971,11 @@ begin
     begin
       CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[CurrentNote[CurrentTrack]].Color := 1;
       CurrentNote[CurrentTrack] := 0;
+      {$IFDEF UseMIDIPort}
       PlaySentenceMidi := true;
+      {$ELSE}
+      PlaySentenceMidi := false;
+      {$ENDIF}
       PlayVideo := false;
       StopVideoPreview;
       {$IFDEF UseMIDIPort} MidiTime := USTime.GetTime;


### PR DESCRIPTION
Split out from #1211.

When `UseMIDIPort` is disabled, the editor still has the generic `PlaySentenceMidi` state flag, but the code that advances and clears MIDI playback is compiled out. Some editor paths set `PlaySentenceMidi := true` unconditionally, including Alt+V playback, which can leave stale playback state active in non-MIDI builds.

This PR guards those `PlaySentenceMidi := true` assignments behind `UseMIDIPort` and explicitly keeps the flag false when MIDI support is unavailable.

No behavior should change for MIDI-enabled builds (which now is all the builds in the CI).