### PR TITLE
do not automagically 'correct' or 'adjust' where spaces are

### DIFF
--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -4313,7 +4313,6 @@ var
 
 begin
   FixTimings;
-  LyricsCorrectSpaces;
 
   if not (CurrentSong.isDuet) then
   begin


### PR DESCRIPTION
do not automagically 'correct' or 'adjust' where spaces are if we're doing operations that involve entire sentences

how to reproduce what this PR addresses:
1. have a txt that has the spaces _before_ words
2. Ctrl^Del an entire sentence
3. Save

expected result (=result with this PR): the only diff between the old txt and the new txt is a bunch of notes + a linebreak being removed, and _maybe_ adjusting 1 other linebreak*

actual result (=result without this PR): ALL spaces in front of words are gone, in ALL sentences. It also places a stray space after the last note of any sentence.

I know we all have our preferences and stuff, but this automagic "fixing" has no business being done when deleting sentences, or copypasting them, or even keeping only 1 track of a duet. the only edge cases I could identify were dividing a sentence (=inserting a linebreak) and joining a sentence (=deleting a linebreak), and even if it's hypothetically not completely useless there:
* dividing a sentence: any stray space isn't going to affect singing anyway, most likely something will need to be capitalized anyway (or not, because some people deliberately _don't_ capitalize if it's really just a very long sentence)
* joining a sentence: you're going to need to manually uncapitalize something anyway, it's what, 2-3 extra keystrokes to fix the spacing how _you_ want it

There is a discussion to be had about perhaps reintroducing some actually working behaviour when inserting/deleting a linebreak, but even then any new implementation should only edit the two surrounding notes at most, as opposed to currently the entire song.

\* = `FixTimings` is also problematic in this context. It _should_ fix _some_ timings, but only the ones near points that I'm editing. I intend to make a separate issue for this later