### PR TITLE
fix for circular referencing

### DIFF
--- a/src/base/USkins.pas
+++ b/src/base/USkins.pas
@@ -201,7 +201,7 @@ begin
       Result := S;
 end;
 
-procedure TSkin.GetSkinsByTheme(Theme: string; out Skins: TUTF8StringDynArray);
+procedure TSkin.GetSkinsByTheme(Theme: string; out Skins: UCommon.TUTF8StringDynArray);
   var
     I: Integer;
     Len: integer;


### PR DESCRIPTION
Okay, okay so, I discovered this in a [nix build](https://github.com/NixOS/nixpkgs/pull/521960) for USDX, so it may only show under THOSE conditions, but the following fix resolves it. Details below:

USkins.pas + UIni.pas form a circular implementation-uses dependency!

UIni re-exports UCommon's symbols through its own interface, so the unqualified TUTF8StringDynArray in the method implementation resolves to a _different_ type node than the one **stored** in the class interface declaration.