### PR TITLE
Add repository-backed GitHub wiki sync

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,60 @@
+name: Sync Wiki
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/sync-wiki.yml"
+      - "wiki/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wiki-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync repository wiki files to GitHub Wiki
+    runs-on: ubuntu-latest
+    if: github.repository == 'UltraStar-Deluxe/USDX'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate wiki token
+        env:
+          WIKI_TOKEN: ${{ secrets.WIKI_TOKEN }}
+        run: |
+          if [ -z "$WIKI_TOKEN" ]; then
+            echo "::error::Set a WIKI_TOKEN repository secret with write access to the GitHub wiki."
+            exit 1
+          fi
+
+      - name: Checkout wiki
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: .wiki-repo
+          token: ${{ secrets.WIKI_TOKEN }}
+
+      - name: Copy wiki source
+        run: |
+          rsync -a --delete --exclude='.git/' wiki/ .wiki-repo/
+
+      - name: Commit wiki changes
+        working-directory: .wiki-repo
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "Wiki is already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Sync wiki from repository"
+          git push

--- a/PIPELINE.md
+++ b/PIPELINE.md
@@ -11,3 +11,9 @@ To get a new one:
 * Repository access = Only select repositories (`mxe`)
 * Permissions: readonly for Actions on the `mxe` repository
 * And then in the [USDX repository actions secrets](https://github.com/UltraStar-Deluxe/USDX/settings/secrets/actions) the token needs to be a `Repository secret` named `MXEACTIONSREADACCESSTOKEN`
+
+## Wiki sync
+The GitHub wiki source is mirrored in the `wiki/` directory of this repository.
+Changes to `wiki/**` on `master` are copied to the GitHub wiki by the `Sync Wiki` workflow.
+
+Create a repository secret named `WIKI_TOKEN` with write access to `UltraStar-Deluxe/USDX.wiki`. The default `GITHUB_TOKEN` is scoped to the main repository and should not be relied on for pushing to the wiki Git remote.

--- a/wiki/Command-Line-Parameters.md
+++ b/wiki/Command-Line-Parameters.md
@@ -1,0 +1,52 @@
+_Note: This is currently broken / in development._
+
+
+Command-line parameters are passed to the game adding it to the path of a
+shortcut or starting the game within the console.
+
+The following parameters are possible. They can be joined in any possible way.
+
+- `-help` : Show help and exit
+
+- `-check-songs` : Check all songs at startup and log any issues
+
+- `-Benchmark`         : Create a benchmark.log file with start timings.
+
+- `-NoLog`    	       : Do not create any .log files
+
+- `-Joypad`            : Start with joypad support
+
+- `-Language <ID>`     : Load language [ID] on startup.
+                         Example: `-Language german`
+
+- `-Songpath <PATH>`   : Same as config Songpath.
+                         Example: `-SongPath "C:\Ultrastar Songs"`
+
+- `-ConfigFile <FILE>` : Load configuration file [File] instead of config.ini.
+                         The path to the file has to exist.
+                         Example: `-ConfigFile config.SongCreation.ini`
+
+- `-ScoreFile <FILE>`  : Use [File] instead of Ultrastar.db
+                         The path to the file has to exist.
+                         Example: `-ScoreFile HouseParty.db`
+
+- `-FullScreen`        : Start the game in full screen mode
+
+- `-Depth {16|32}`     : Force depth to 16 or 32. Example: `-Depth 16`
+
+- `-Resolution <ID|RESOLUTION>`   : Force resolution. Either by ID (matching an entry of the possible resolution list)
+                                    or custom resolution (with the format of `WIDTHxHEIGHT`).
+                                    Example: `-Resolution 800x600`
+
+- `-Screens {1|2}`     : Force 1 or 2 screens. Example: `-Screens 2`
+
+Some Examples:
+
+Start with a resolution of 1024x768, a depth of 32 bit and in full screen mode:  
+`ultrastar.exe -Resolution 1024x768 -Depth 32 -Fullscreen`
+
+Start without logging and with polish language  
+`ultrastar.exe -NoLog -Language polish`
+
+Start with a customs configuration file and score database:  
+`ultrastar.exe -ConfigFile "C:\Ultrastar\Configs\PartyConfig.ini" -ScoreFile "C:\Ultrastar\Scores\PartyScores.db"`

--- a/wiki/Compiling-UltraStar-Deluxe.md
+++ b/wiki/Compiling-UltraStar-Deluxe.md
@@ -1,0 +1,1 @@
+All compilation instructions have moved to the [README](https://github.com/UltraStar-Deluxe/USDX#readme)

--- a/wiki/Configuration-‐-Editor-piano-mode.md
+++ b/wiki/Configuration-‐-Editor-piano-mode.md
@@ -1,0 +1,44 @@
+In the Editor, `F6` toggles a piano mode, where part of the keyboard can be used to enter pitches directly.
+Pressing a key will immediately set the pitch for that note.
+In piano mode, the `Play Audio+Clicks functionality` is on `Enter` instead of `P`.
+
+### QWERTZ
+By default it maps to QWERTZ.
+See the QWERTY section and the QWERT part is identical.
+
+### QWERTY
+If you wish to use QWERTY, find and replace the relevant parts with:
+```ini
+[KeyBindings]
+PianoKeysLow=92,97,122,115,120,100,99,118,103,98,104,110,109,107,44,108,46,59,47
+PianoKeysHigh=49,113,50,119,51,101,114,53,116,54,121,117,56,105,57,111,48,112,91,61,93
+```
+
+It uses these keys:
+
+```
++----+----+----+    +----+----+    +----+----+----+    +----+
+| 1  | 2  | 3  |    | 5  | 6  |    | 8  | 9  | 0  |    | =  |
++-+----+----+----+----+----+----+----+----+----+----+----+----+
+  | Q  | W  | E  | R  | T  | Y  | U  | I  | O  | P  | [  | ]  |
+  +----+----+----+----+----+----+----+----+----+----+----+----+
+    | A  | S  | D  |    | G  | H  |    | K  | L  | ;  |
+    +-+----+----+----+----+----+----+----+----+----+--+
+      | Z  | X  | C  | V  | B  | N  | M  | ,  | .  |
+      +----+----+----+----+----+----+----+----+----+
+```
+
+And maps them to these notes:
+```
++----+----+----+    +----+----+    +----+----+----+    +----+
+| F# | G# | A# |    | C# | D# |    | F# | G# | A# |    | C# |
++-+----+----+----+----+----+----+----+----+----+----+----+----+
+  | G2 | A2 | B  | C3 | D  | E  | F  | G  | A  | B  | C4 | D4 |
+  +----+----+----+----+----+----+----+----+----+----+----+----+
+    | F# | G# | A# |    | C# | D# |    | F# | G# | A# |
+    +-+----+----+----+----+----+----+----+----+----+--+
+      | G1 | A  | B  | C2 | D  | E  | F  | G2 | A2 |
+      +----+----+----+----+----+----+----+----+----+
+```
+
+The slight overlap between the two rows is deliberate, to prevent having to jump rows too often.

--- a/wiki/Controls.md
+++ b/wiki/Controls.md
@@ -1,0 +1,137 @@
+#### General
+|Keys | Action|
+| :--- | :--- |
+| [F11] | switch on the fly between windowed fullscreen and window mode |
+| [Alt] + [Enter] | switch to real fullscreen (including changing resolution) and window mode |
+| [Tab] | show/hide help |
+| [PrintScreen] | Take a screenshot. It will be saved in the `screenshots` directory. |
+
+#### Shortcuts for sing screen
+|Keys | Action|
+| :--- | :--- |
+| S | Skip intro/long break |
+| R | restart song from beginning |
+| A | toggle video aspect ratio between letterbox, crop and stretch |
+| V | switch between video, visualisation and background |
+| W | if configured and enabled, show webcam video instead as background |
+| T | toggle time displaying between total, remaining and already played time |
+| [Ctrl] + Arrow Left/Right | seek 5 seconds backward / forward |
+| [Ctrl] + [Tab] | switch visualization / camera mode |
+| [Spacebar] or P | pause / play |
+| [Esc] or [Backspace] | cancel current song or end early |
+
+#### Shortcuts for song selection screen
+|Keys | Action|
+| :--- | :--- |
+| J | open the "Search for a Song" interface |
+| [Enter] | confirm song, search or menu selection |
+| [Escape] | go to the previous screen |
+| S | play selected song as medley (if medley tags are set, use these, otherwise use calculated values - can be forced using shift key) |
+| D | play up to 5 random songs as medleys (if there are songs available with medley tags set, only use these, otherwise use calculated values - can be forced using shift key) |
+| E | open selected song in song editor |
+| F | add song to medley list |
+| M | open the song menu |
+| P | choose a playlist for song selection |
+| R | select a random song/category |
+| [Alt] + [_Character_] | jump to artist with the first letter/digit _Character_ \(A to Z, 0 to 9\) |
+| [Alt] + [Shift] + [_Character_] | jump to title with the first letter/digit _Character_ \(A to Z, 0 to 9\) |
+| [Page down] | jump to first artist with the next letter/digit |
+| [Page up] | jump to last artist with the previous letter/digit | 
+| [Spacebar] | when a duet song is selected, switch first and second voice |
+
+#### Player selection screen
+|Keys | Action|
+| :--- | :--- |
+| [Shift] + F[1..12] | Save player name |
+| F[1..12] | Load player name |
+
+#### Joypad / Controller
+|Axis | Action|
+| :--- | :--- |
+| D-Pad | Navigation (+switching to non-mouse mode) |
+| Left Stick | Mouse (+switching to mouse mode if not already) |
+| Right Stick | Navigation |
+
+##### Keyboard mode
+|Buttons | Action|
+| :--- | :--- |
+| A / Button 1 | Simulates [Enter] |
+| B / Button 2 | Simulates [Escape] |
+| Y / Button 3 | Simulates [M] |
+| X / Button 4 | Simulates [R] |
+
+##### Mouse mode
+|Buttons | Action|
+| :--- | :--- |
+| A / Button 1 | Simulates _Left Mouse Button_ |
+| B / Button 2 | Simulates _Right Mouse Button_ |
+| Left/Right Stick Button | Simulates _Middle Mouse Button_ |
+| Start | Simulates [Enter] |
+| Select | Simulates [Escape] |
+
+#### Shortcuts for song editor
+|Keys | Action|
+| :--- | :--- | 
+| Arrow Left/Right	| select previous/next syllable                                                             |
+| Arrow Down/Up	| select previous/next syllable                                                         |
+| [Ctrl] + Arrow Right/Left	| move only beginning of note to earlier/later                         |
+| [Alt] + Arrow Right/Left	| move only ending of note to earlier/later                            |
+| [Shift] + Arrow Up/Down	| change pitch of selected note                                        |
+| [Shift] + Arrow Right/Left	| move the note (beginning and ending) to earlier/later            |
+|	                                                                                          |
+| =	| increase BPM                                                                              |
+| -	| decrease BPM                                                                              |
+| F	| toggle note freestyle/normal                                                              |
+| G	| toggle note golden/normal                                                                 |
+| T	| auto-fix timings of all sentence switching                                                |
+| C	| capitalize letter at the beginning of all lines                                           |
+| [Shift] + C	    | correct all spaces                                                          |
+| V	| play audio + video and follow the lyrics                                                  |
+|	                                                                                          |
+| [Ctrl] + C	    | copy current sentence                                                       |
+| [Ctrl] + V	    | paste current sentence (lyrics+notes)                                       |
+| [Ctrl] + [Shift] + V | paste lyrics only                                                        |
+| [Ctrl] [Alt] + V  | paste notes only                                                            |
+| [Ctrl] + Z	    | **undo last change**                                                        |
+| S	| save changes                                                                              |
+| R	| reload file without saving                                                                |
+| P	| play current sentence audio                                                               |
+| [Shift] + P	| play current sentence midi                                                        |
+| [Ctrl] + [Shift] + P | play current sentence audio and midi                                      |
+|	                                                                                          |
+| A | set/clear medley start beat                                                             |
+| [Shift] + A | set/clear medley end beat                                                     |
+| J | jump to medley start beat                                                               |
+| [Shift] + J | jump to medley end beat                                                       |
+| [Alt] + J | play medley (starting from medley start, ending at medley end)                  |
+|	                                                                                          |
+| I | jump to preview start                                                                   |
+| [Alt] + I | play audio starting from the preview start                                      |
+| [Shift] + I | set/clear preview start at the current note's time                            |
+|	                                                                                            |
+| [Shift] + D | divide BPM by 2 but keep correct timings                                      |
+| [Shift] + M | multiply BPM by 2 but keep correct timings                                    |
+|	                                                                                          |
+| double click on a note	|split note in two parts on the beat at mouse cursor location          |
+| select and drag a note up/down	|change pitch of a note                                        |
+| select and drag a note left/right	|move the beginning beat of the note to earlier / later    |
+|	                                                                                          |
+| [Ctrl] + [Del]	 | delete current note                                                      |
+| [+ on numberpad] | Increase tone of all notes by 1                                           |
+| [- on numberpad] | Decrease tone of all notes by 1                                           |
+| [Shift] + [+ on numberpad] | Increase tone of all notes by octave                                      |
+| [Shift] + [- on numberpad] | Decrease tone of all notes by octave                                      |
+| [F4]             | enter or leave text edit mode                                            |
+| . | moves text to right in current sentence                                               |
+|	                                                                                          |
+| 4	| copy 4 sentence                                                                             |
+| 5 | copy 5 sentence	                                                                              |
+|	                                                                                              |
+| 7	| lower video gap by 1                                                                      |
+| [Shift] + 7	| lower video gap by 10                                                           |
+| [Ctrl] + 7	| lower video gap by 100                                                          |
+| 8 | increase video gap                                                                        |
+| [Shift] + 8	| increase video gap by 10                                                        |
+| [Ctrl] + 8	| increase video gap by 100                                                       |
+| 9	| decrease GAP                                                                              |
+| 0	| increase GAP                                                                              |

--- a/wiki/Customization.md
+++ b/wiki/Customization.md
@@ -1,0 +1,7 @@
+This page links to various resources to customize your UltraStar Deluxe installation with.
+Be aware that you might need to re-install them after a game update, either because the update removed them or because they're not compatible with a new version.
+
+# Avatars
+Place the image files in the `avatars` directory.
+
+* [Avatar collection by marwin89](https://github.com/marwin89/Vocaluxe-Ultrastar-Profile-Add-On)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,5 @@
+# Hey, listen!
+
+The docs need a TON of work! Please ask on [Discord](https://discord.gg/qfS2b7VwDG) or [the issue tracker](https://github.com/UltraStar-Deluxe/USDX/issues) and suggest anything you think should be in here. We devs know way too much detailed technical stuff and it's hard to pick up what people actually want to know - so any requests for documentation are really welcomed.
+
+On this page, you will find various UltraStar Deluxe documentation.

--- a/wiki/Loudness-Normalization.md
+++ b/wiki/Loudness-Normalization.md
@@ -1,0 +1,30 @@
+## Introduction to ReplayGain
+It is desirable for each song in USDX to have equal loudness, so the audio volume does not need to be frequently adjusted while playing. However, the loudness of audio files may vary significantly.
+
+To solve this problem, USDX supports ReplayGain during playback of a song's `#MP3`/`#AUDIO` file. ReplayGain works by scanning a file ahead of time and "tagging" it with metadata that contains a volume adjustment. During playback, USDX will read the file's tag and apply the requested volume adjustment automatically. This ensures that all files play back at the same perceived volume.
+
+ReplayGain is not enabled by default in USDX. To enable it, navigate to Tools->Options->Sound, and set the ReplayGain setting to 'On'.
+
+## Adding ReplayGain Tags to Your UltraStar Library
+USDX will read the ReplayGain tags of your audio files, but it won't write them. This means you will need another program to scan your audio files and write the ReplayGain tags, so they can later be read by USDX.
+
+### USDB Syncer
+Recent versions of the [USDB Syncer](https://github.com/bohning/usdb_syncer) support ReplayGain tag writing. However, ReplayGain is not enabled by default. To enable it, navigate to Tools->Settings, and set the "Normalization" setting to "ReplayGain".
+
+When enabled, the Syncer will automatically scan downloaded audio files for loudness and write the ReplayGain tags.
+
+### Full Library Scanning
+For ReplayGain to work properly, your *entire* library needs to have tags. It's not good enough to write ReplayGain tags to newly added songs only. If you already have a large existing UltraStar library, you will need to write ReplayGain tags to those files too.
+
+The easiest way to perform a full library scan is by using [UltraStar Manager](https://github.com/UltraStar-Deluxe/UltraStar-Manager), which has a built-in ReplayGain scanner since version 2.1.0. To add ReplayGain tags to your entire library, use Ctrl + A to highlight all songs, then right click and select "Calculate Song ReplayGain" from the context menu.
+
+The full library scan only needs to be performed once. In the future, when you add new songs to your UltraStar library, the Syncer will handle ReplayGain for you automatically.
+
+## Adjusting the Volume of Game Sounds
+After enabling ReplayGain, you may notice that the game-provided sounds such as the background music and menu sound effects have become loud relative to the singing music. To normalize the sound, ReplayGain generally *reduces* the volume of the audio tracks. But no ReplayGain adjustment is applied to the game-provided sounds.
+
+To counteract this effect, USDX has separate volume settings for the game-provided sounds. If you use ReplayGain, it recommended to adjust the following settings in Tools->Options->Sound:
+- BG Music Volume: Set to 40%
+- SFX Volume: Set to 60%
+
+This restores the dynamics between the music and the game-provided sounds when using ReplayGain.

--- a/wiki/Lua-plugins.md
+++ b/wiki/Lua-plugins.md
@@ -1,0 +1,30 @@
+USDX supports plugins written in lua. These must be placed with a `.usdx` extension in the `plugins` directory.
+
+They're mostly used in Party Mode, but they _can_ be used outside of Party Mode like so:
+```
+-- minimum time between runs in milliseconds
+local Delay = 1000
+
+local LastDraw = 0
+
+function plugin_init()
+  register('Dummy plugin', '1.00', 'PluginAuthor')
+  hDraw = Usdx.Hook('Display.Draw', 'MyEveryFrameFunction')
+  return true
+end
+
+function MyEveryFrameFunction()
+  -- whatever you put in here runs every frame, hence the limiter
+  local Now = Usdx.Time()
+  if LastDraw + Delay > Now then
+    return
+  end
+
+  -- whatever you put between here and the end of the function runs _close enough_ to once a second
+
+  LastDraw = Now
+end
+```
+
+Available globals inside plugins:
+- `current_filename`: absolute path to the plugin file

--- a/wiki/Minimum-Requirements.md
+++ b/wiki/Minimum-Requirements.md
@@ -1,0 +1,10 @@
+* 1GHz CPU
+* OpenGL 1.2 support with current graphics card drivers installed
+* 200MB harddrive space + space for songs and videos
+* 512MB of free system RAM
+* for singing scores: one microphone per concurrent player
+* speakers or headphones for sound output
+
+Note: when using a TV screen for displaying, set it to Gaming Mode and turn off any "image enhancements" to reduce latency.
+For various microphones on windows, it is necessary to set the windows audio recording device setting to "2 channels, 44100Hz, (CD Quality)" to be able to use both microphones in game.
+There currently is no device plug&play support. Thus, a game restart is required after new audio devices are connected to be able to use them.

--- a/wiki/Party-Mode.md
+++ b/wiki/Party-Mode.md
@@ -1,0 +1,41 @@
+The party mode feature in UltraStar Deluxe allows play with up to 8-12 Players in 2 or 3 teams. Enter the party mode from main menu via the item "Party".
+
+##Settings for the party game
+- **Difficulty**: Pick the level of difficulty from: Easy, Medium and Hard.
+- **Playlist mode**: Defines which songs should be available. You can choose from 'All Songs', 'Folder' or Playlist':
+
+**All Songs** uses every song within default the song directory.
+**Folder** uses every song within a subdirectory created underneath the song directory.
+**Playlist** includes every song within a previously created playlist.
+
+##Team Selection
+- **Number of teams**: Set the amount of teams, either 2 or 3.
+- **Teams**: Choose the number of singers for each team, type in their names in each player name box and get them a cool team name. Then continue.
+
+##Round Selection
+- **Number of rounds**: Select the number of rounds to be played (between 2 and 7).
+- **Singing Mode**: Set the mode of each round or leave "Random".
+
+##Integrated modes are:
+
+**Duel** - Like the classic mode, players sing together and the player with the highest score at the end of the song wins the round.
+
+**Blind Mode** – The same as duel mode, but without the pitch bars being displayed on the screen.
+
+**Until 5000** - The same as duel mode, but the first player who gets 5000 points wins.
+
+**Team Duel** - If there is more than one player, you can choose team duel. While singing a red bar indicates when to exchange microphone and players within the teams. The next player will be displayed below the scores.
+Random - A random mode from all available modes will be defined for that round.
+
+- Continue to overview of players, rounds and current scores.
+
+##Party Mode: Rounds
+Starting with Round 1 the players who must challenge each other are displayed at the bottom of the screen, a small description reminds the mode of that specific round. Now the players have to prepare themselves and get their mics.
+
+##Song Selection
+You can't select a song directly. When starting party mode you chose a "pool of songs" from which USdx now chooses a random song. Each team can now decide if they want to sing that song or if they want to use a joker.
+
+##The joker card
+Each team has 5 jokers which can be taken by the party menu (M) or via the key which represents the team number (1-3). Taking a joker forces USdx to choose another song randomly. Once no team has a joker any more, the players will have no choice and are forced to sing the chosen song.
+
+The best team wins!

--- a/wiki/Theme-changes.md
+++ b/wiki/Theme-changes.md
@@ -1,0 +1,94 @@
+This page lists various breaking and non-breaking theme changes that providers of custom themes will want to incorporate.
+
+### 2025.12.0
+The way the options screens work has been reworked.
+
+All elements that start with any of these names should be entirely removed:
+* `OptionsGame`
+* `OptionsGraphics`
+* `OptionsSound`
+* `OptionsInput`
+* `OptionsLyrics`
+* `OptionsThemes`
+* `OptionsRecord`
+* `OptionsAdvanced`
+* `OptionsNetwork`
+* `OptionsWebcam`
+* `OptionsJukebox`
+
+Copy (and if desired: modify) all elements that start with these names from `Deluxe.ini` or `Modern.ini`:
+* `OptionsSub`
+* `OptionsNetworkLegend`
+
+### 2026.2.0
+
+Themes now support extending (across themes) and inheritance (within a theme).
+
+#### Extending
+Instead of duplicating an entire theme, a theme only needs to:
+* `[Theme].BaseTheme = Modern` (or any other theme that does _not_ define `BaseTheme`)
+* Define the _changed_ elements _completely_ with all attributes.
+* Define any elements you want to _disable_ with a single attribute `Enabled = 0`.
+  This only works on _optional_ elements, these usually end in `*Text1/2/3/...` or `*Static1/2/3/...`.
+
+#### Inheritance
+Basically instead of doing this:
+<details>
+<summary>Theme code with lots of duplication</summary>
+
+```
+[MainButtonSolo]
+X = 95
+Y = 270
+W = 150
+H = 50
+Tex = Button
+Color = ColorLight
+DColor = ColorDark
+Type = Transparent
+Texts = 1
+Reflection = 1
+ReflectionSpacing = 15
+DeSelectReflectionSpacing = 280
+Fade = 1
+FadeText = 1
+SelectH = 150
+FadeTex = ButtonFade
+FadeTexPos = 0
+
+[MainButtonMulti]
+X = 250
+Y = 270
+W = 150
+H = 50
+Tex = Button
+Color = ColorLight
+DColor = ColorDark
+Type = Transparent
+Texts = 1
+Reflection = 1
+ReflectionSpacing = 15
+DeSelectReflectionSpacing = 280
+Fade = 1
+FadeText = 1
+SelectH = 150
+FadeTex = ButtonFade
+FadeTexPos = 0
+```
+</details>
+
+you can write `MainMuttonMulti` as:
+```
+[MainButtonMulti]
+Inherits = MainButtonSolo
+X = 250
+```
+
+In this case, `MainButtonSolo` can also be defined by the `BaseTheme`.
+
+Note: `Enabled = 0` can't be inherited.
+In the above example, if you were to set `[MainButtonSolo].Enabled = 0`, this doesn't magically also disable the `MainButtonMulti`.
+
+### 2026.3.0
+
+Any theme element whose name starts with `SongCarousel`, `SongSlotMachine`, `SongSlide` or `SongMosaic` is obsolete.

--- a/wiki/config.ini.md
+++ b/wiki/config.ini.md
@@ -1,0 +1,29 @@
+Some settings are currently only available through setting/changing them in config.ini. This mostly affects newer settings, as the themes are currently too tightly coupled.
+
+## Location
+
+The config file can also be set explicitly with the `-ConfigFile` command-line parameter. Relative paths passed to `-ConfigFile` are resolved relative to the executable directory.
+
+### Linux
+
+When UltraStar Deluxe runs from a local build or portable tree, and the executable directory contains a `languages` directory and is writable, `config.ini` is read from and written to the executable directory.
+
+Otherwise, `config.ini` is stored in `.ultrastardx/config.ini` below the user's home directory. The home directory is resolved from the passwd entry for the current user. If that is unavailable, the `HOME` environment variable is used as fallback.
+
+For most installations this means:
+
+```text
+~/.ultrastardx/config.ini
+```
+
+Flatpak installations use the Flatpak app data directory instead:
+
+```text
+~/.var/app/eu.usdx.UltraStarDeluxe/.ultrastardx/config.ini
+```
+
+```
+[Advanced]
+DefaultSingMode=Instrumental # starts every song in instrumental mode
+DefaultSingMode=Regular # default, behavior as it was
+```


### PR DESCRIPTION
This PR:
- Adds the current GitHub wiki pages under `wiki/` so wiki changes can be reviewed through normal PRs.
- Adds a `Sync Wiki` GitHub Actions workflow that mirrors `wiki/**` to `UltraStar-Deluxe/USDX.wiki`.
- Documents the wiki sync setup in `PIPELINE.md`.
- Updates the `config.ini` wiki page with the Linux config path lookup behavior.

## Maintainer Instructions (to set this up)
Before merging or before the first sync run, add a repository secret named `WIKI_TOKEN`.

`WIKI_TOKEN` must be a token that can push to:

`https://github.com/UltraStar-Deluxe/USDX.wiki.git`

After this PR is merged, the checked-in `wiki/` directory becomes the source of truth. The workflow uses `rsync --delete`, so direct edits made only in the GitHub wiki are overwritten by the next sync unless they are first copied back into `wiki/`.

The workflow runs on pushes to `master` that change `wiki/**` or `.github/workflows/sync-wiki.yml`. It can also be started manually from the Actions tab via `workflow_dispatch`.

## Longer-term Direction
This keeps the existing GitHub wiki working, while allowing wiki changes through normal PRs.

GitHub Pages may still be the better long-term solution. It would avoid the separate `.wiki.git` repository and the extra `WIKI_TOKEN`. I did not do that here because it is a larger migration: existing wiki links, URL structure, and the fate of the old wiki would need a maintainer decision.


I could not properly test this PR and I'm not sure how to proceed here. Merging and seeing if it works? Not sure if that's the right approach...


This PR would allow addressing issues #1159 (with a small addition in the wiki), #660, and #80 (if we decide wiki is the one place for documentation and not some tex / pdf.