### PR TITLE
Prefer PortAudio playback for Linux AppImage builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,8 +82,8 @@ External Libraries:])
 # add portmixer option
 AC_ARG_WITH([portaudio],
     [AS_HELP_STRING([--with-portaudio],
-      [enable audio capture with PortAudio @<:@default=check@:>@])],
-    [with_portmixer=$withval], [with_portaudio="check"])
+      [enable audio capture/playback with PortAudio @<:@default=check@:>@])],
+    [with_portaudio=$withval], [with_portaudio="check"])
 
 AC_ARG_WITH([portmixer],
     [AS_HELP_STRING([--with-portmixer],

--- a/dists/linux/dl.sh
+++ b/dists/linux/dl.sh
@@ -52,6 +52,7 @@ deps+=('wayland-protocols,https://gitlab.freedesktop.org/wayland/wayland-protoco
 deps+=('xkbcommon,https://github.com/xkbcommon/libxkbcommon/archive/refs/tags/xkbcommon-1.13.1.tar.gz,f487d1e7f5e362b8971e23e354d9eb4bdc51e453')
 deps+=('SDL2,https://www.libsdl.org/release/SDL2-2.32.10.tar.gz,ce98fa93e31836a751feca374ab28a0770b63c16')
 deps+=('SDL2_image,https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.8.12.tar.gz,d7075e3fe8c1780c5d239c69371ab19089209ea0')
+deps+=('portaudio,https://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz,b7e9b9c53d993f6d110487ef56a3d4529d21b2f1')
 deps+=('sqlite,https://sqlite.org/2026/sqlite-autoconf-3530100.tar.gz,f5828a709d18bb4857cec8ddb4298c47a9143892')
 
 if older 2.15 nasm --version ; then

--- a/dists/linux/tasks.sh
+++ b/dists/linux/tasks.sh
@@ -547,7 +547,7 @@ task_usdx() {
 	start_build ../../.. UltraStar Deluxe
 	local OUTPUT="$root/build/$ARCH"
 	bash ./autogen.sh
-	./configure --prefix=/usr PKG_CONFIG_PATH="$PKG_CONFIG_PATH" CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" CC="$CC" CXX="$CXX" --enable-debug --without-portaudio --with-libprojectM --with-local-projectM-presets
+	./configure --prefix=/usr PKG_CONFIG_PATH="$PKG_CONFIG_PATH" CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" CC="$CC" CXX="$CXX" --enable-debug --with-portaudio --with-libprojectM --with-local-projectM-presets
 	sleep 1
 	make LDFLAGS="-O2 --sort-common --as-needed -z relro" INSTALL_DATADIR="../share/ultrastardx"
 	rm -rf "$OUTPUT"
@@ -637,6 +637,8 @@ if [ "$1" == "all_deps" ]; then
 	task_sdl2
 	echo
 	task_sdl2_image
+	echo
+	task_portaudio
 	echo
 
 	task_sqlite

--- a/src/switches.inc
+++ b/src/switches.inc
@@ -83,8 +83,8 @@
   {$DEFINE UseBASSPlayback}
   {$DEFINE UseBASSInput}
 {$ELSEIF Defined(HavePortaudio)}
+  {$DEFINE UsePortaudioPlayback}
   {$DEFINE UseSDLPlayback}
-  {.$DEFINE UsePortaudioPlayback}
   {$DEFINE UsePortaudioInput}
   {$IFDEF HavePortmixer}
     {$DEFINE UsePortmixer}

--- a/src/ultrastardx.dpr
+++ b/src/ultrastardx.dpr
@@ -279,14 +279,14 @@ uses
 {$IFDEF UseSDLInput}
   UAudioInput_SDL           in 'media\UAudioInput_SDL.pas',
 {$ENDIF}
-{$IFDEF UseSDLPlayback}
-  UAudioPlayback_SDL        in 'media\UAudioPlayback_SDL.pas',
-{$ENDIF}
 {$IFDEF UsePortaudioInput}
   UAudioInput_Portaudio     in 'media\UAudioInput_Portaudio.pas',
 {$ENDIF}
 {$IFDEF UsePortaudioPlayback}
   UAudioPlayback_Portaudio  in 'media\UAudioPlayback_Portaudio.pas',
+{$ENDIF}
+{$IFDEF UseSDLPlayback}
+  UAudioPlayback_SDL        in 'media\UAudioPlayback_SDL.pas',
 {$ENDIF}
 {$IFDEF UseFFmpegDecoder}
   UAudioDecoder_FFmpeg      in 'media\UAudioDecoder_FFmpeg.pas',


### PR DESCRIPTION
Fixes #1148.

This changes Linux/AppImage audio playback to use PortAudio when available, with SDL playback still compiled as a fallback.

## Changes

- Fix `--with-portaudio` so it actually sets `with_portaudio`.
- Add PortAudio to the Linux AppImage dependency download/build flow.
- Configure the AppImage build with `--with-portaudio`.
- Enable `UsePortaudioPlayback` when PortAudio is available.
- Register PortAudio playback before SDL playback so it is preferred.

## Rationale

The issue reporter confirmed that the AUR build works smoothly because it uses PortAudio, while the AppImage stutters with SDL/PipeWire on their system. Matching the AppImage playback backend to the working AUR path should avoid the SDL/PipeWire behavior while keeping SDL available as fallback. Keeping this as a draft for feedback about **whether we actually want to switch the AppImage to PortAudio for better compatibility** ?