### PR TITLE
Fix highscore plugin player level

### DIFF
--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -347,7 +347,7 @@ begin
     SendInfo.ScoreLineInt := player[index].ScoreLineInt;
     SendInfo.ScoreGoldenInt := player[index].ScoreGoldenInt;
     SendInfo.MD5Song := ScreenSing.Act_MD5Song;
-    SendInfo.Level := ScreenSing.Act_Level;
+    SendInfo.Level := player[index].Level;
 
     if (Value = 1) then
       SendScore(SendInfo, Website);

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -104,6 +104,7 @@ type
     removeVoice: boolean;
     fShowWebcam: boolean;
 
+    // TODO: delete this?
     Act_MD5Song: string;
 
     MedleyStart, MedleyEnd: real;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -104,7 +104,6 @@ type
     removeVoice: boolean;
     fShowWebcam: boolean;
 
-    Act_Level: integer;
     Act_MD5Song: string;
 
     MedleyStart, MedleyEnd: real;
@@ -923,7 +922,6 @@ begin
 
   // Send Score
   Act_MD5Song := CurrentSong.MD5;
-  Act_Level := Player[0].Level;
 
   // start timer
   CountSkipTimeSet;
@@ -1920,7 +1918,7 @@ begin
         Send := false;
         TotalScore := player[PlayerIndex - 1].ScoreTotalInt;
 
-        case (Act_Level) of
+        case (player[PlayerIndex - 1].Level) of
           0: if (TotalScore >= DataBase.NetworkUser[IndexWeb].UserList[IndexUser].AutoScoreEasy)
               and (DataBase.NetworkUser[IndexWeb].UserList[IndexUser].AutoMode = 1)
               and (DataBase.NetworkUser[IndexWeb].UserList[IndexUser].AutoPlayer = PlayerIndex - 1) then
@@ -1948,7 +1946,7 @@ begin
           SendInfo.ScoreLineInt := player[PlayerIndex - 1].ScoreLineInt;
           SendInfo.ScoreGoldenInt := player[PlayerIndex - 1].ScoreGoldenInt;
           SendInfo.MD5Song := Act_MD5Song;
-          SendInfo.Level := Act_Level;
+          SendInfo.Level := player[PlayerIndex - 1].Level;
 
           SendStatus := DllMan.WebsiteSendScore(SendInfo);
 
@@ -1986,7 +1984,7 @@ begin
         Save := false;
         TotalScore := player[PlayerIndex - 1].ScoreTotalInt;
 
-        case (Act_Level) of
+        case (player[PlayerIndex - 1].Level) of
           0: if (TotalScore >= DataBase.NetworkUser[IndexWeb].UserList[IndexUser].AutoScoreEasy)
               and (DataBase.NetworkUser[IndexWeb].UserList[IndexUser].AutoMode = 2)
               and (DataBase.NetworkUser[IndexWeb].UserList[IndexUser].AutoPlayer = PlayerIndex - 1) then
@@ -2014,7 +2012,7 @@ begin
           SendInfo.ScoreLineInt := player[PlayerIndex - 1].ScoreLineInt;
           SendInfo.ScoreGoldenInt := player[PlayerIndex - 1].ScoreGoldenInt;
           SendInfo.MD5Song := Act_MD5Song;
-          SendInfo.Level := Act_Level;
+          SendInfo.Level := player[PlayerIndex - 1].Level;
 
           WebName := DataBase.NetworkUser[IndexWeb].Website;
           EncryptText := DllMan.WebsiteEncryptScore(SendInfo);


### PR DESCRIPTION
IMPORTANT: it is really hard for me to test if this actually works. but I have noticed in the past that it was _sometimes_ submitting as the wrong level, but only if I played with others, never when I played alone. I think this is the cause of it? But it's not trivial for me to actually test this.

You'll also noticed I added a todo and in general these bits of the code can probably do with a bit of cleanup/deduplication, but I don't have the time to address all of that right now.

But at least this PR should hopefully put an end to some of the suspiciously-high scores I've seen sometimes.