### PR TITLE
Store full player profiles in F-key templates

### DIFF
--- a/game/languages/English.ini
+++ b/game/languages/English.ini
@@ -1081,11 +1081,11 @@ Q = Quit UltraStar Deluxe
 ; ID_010: UScreenName                                   ;
 ;-------------------------------------------------------;
 [ID_010]
-Title = Player Names
+Title = Player Profiles
 Description = Select number of players, and set names, avatars, player colors and difficulty levels
 ;-------------------------------------------------------;
 SEC_001 = General
-RETURN = Confirm players' names and continue to song selection
+RETURN = Confirm player profiles and continue to song selection
 TAB = Toggle help
 PRINT = Take screenshot
 F11 = Toggle fullscreen
@@ -1098,9 +1098,9 @@ ARROWKEYS = Navigate through options
 ;-------------------------------------------------------;
 SEC_020 = Edit
 BACKSPACE = Delete last character of selected name field
-ALT_F1F12 = Save current player name in one of Template 1-12
-SHIFT_F1F12 = Save current player name in one of Template 1-12
-F1F12 = Load Template 1-12 player name into selected field
+ALT_F1F12 = Save current player profile to Template 1-12
+SHIFT_F1F12 = Save current player profile to Template 1-12
+F1F12 = Load Template 1-12 into current player profile
 ;-------------------------------------------------------;
 SEC_030 = Shortcuts
 Q = Quit UltraStar Deluxe
@@ -1126,8 +1126,8 @@ TAB = Toggle help
 PRINT = Take screenshot
 F11 = Toggle fullscreen
 ALT_RETURN = Toggle fullscreen (upscaled)
-BACKSPACE = Back to Player Names
-ESC = Back to Player Names
+BACKSPACE = Back to Player Profiles
+ESC = Back to Player Profiles
 ;-------------------------------------------------------;
 SEC_010 = Navigation
 ARROWKEYS = Navigate through options

--- a/game/languages/English.ini
+++ b/game/languages/English.ini
@@ -230,6 +230,10 @@ SING_LEGEND_ESC=Back
 SING_PLAYER_DESC=Player setup
 SING_PLAYER_WHEREAMI=Sing » Player setup
 SING_PLAYER_ENTER_NAME=Enter name
+NAME_TEMPLATE_NAME_SAVED=Name saved
+NAME_TEMPLATE_NAME_LOADED=Name loaded
+NAME_TEMPLATE_PROFILE_SAVED=Profile saved
+NAME_TEMPLATE_PROFILE_LOADED=Profile loaded
 
 SING_DIFFICULTY_DESC=Select difficulty
 SING_DIFFICULTY_WHEREAMI=Sing » Difficulty
@@ -1098,9 +1102,10 @@ ARROWKEYS = Navigate through options
 ;-------------------------------------------------------;
 SEC_020 = Edit
 BACKSPACE = Delete last character of selected name field
-ALT_F1F12 = Save current player profile to Template 1-12
-SHIFT_F1F12 = Save current player profile to Template 1-12
-F1F12 = Load Template 1-12 into current player profile
+SHIFT_F1F12 = Save current player name to Template 1-12
+F1F12 = Load Template 1-12 player name into selected field
+CTRL_SHIFT_F1F12 = Save current player profile to Template 1-12
+CTRL_F1F12 = Load Template 1-12 into current player profile
 ;-------------------------------------------------------;
 SEC_030 = Shortcuts
 Q = Quit UltraStar Deluxe

--- a/game/languages/English.ini
+++ b/game/languages/English.ini
@@ -1568,15 +1568,13 @@ ARROWKEYS = Navigate through options
 ;-------------------------------------------------------;
 SEC_020 = Edit
 BACKSPACE = Delete last character of selected name field
-ALT_F1F12 = Save current player name in one of Template 1-12
+SHIFT_F1F12 = Save current player name in one of Template 1-12
 F1F12 = Load Template 1-12 player name into selected field
 ;-------------------------------------------------------;
 SEC_030 = Shortcuts
 CTRL_R = Shuffle player names
 CTRL_UP = Rotate up through team colors (when team name is selected)
 CTRL_DOWN = Rotate down through team colors (when team name is selected)
-ALT_F1F12 = Save current player name in one of template 1-12
-F1F12 = Load template 1-12 player name into selected field
 ;-------------------------------------------------------;
 ; ID_032: UScreenPartyRounds                            ;
 ;-------------------------------------------------------;
@@ -1685,7 +1683,6 @@ ARROWKEYS = Navigate through options
 ;-------------------------------------------------------;
 SEC_020 = Edit
 BACKSPACE = Delete last character of selected name field
-ALT_F1F12 = Save current player name in one of Template 1-12
 SHIFT_F1F12 = Save current player name in one of Template 1-12
 F1F12 = Load Template 1-12 player name into selected field
 ;-------------------------------------------------------;

--- a/game/themes/Modern.ini
+++ b/game/themes/Modern.ini
@@ -2733,6 +2733,16 @@ Inherits = DefaultLegendText
 X = 630
 Text = SING_LEGEND_CONTINUE
 
+[NameTemplateStatusText]
+X = 780
+Y = 20
+Z = 1
+Font = 0
+Style = 0
+Size = 20
+Align = 2
+Color = White
+
 [NameSelectPlayerCount]
 Inherits = DefaultSelectSlide
 Text = NAME_PLAYERS_COUNT

--- a/src/base/UIni.pas
+++ b/src/base/UIni.pas
@@ -90,6 +90,8 @@ const
   // Switch colors for players 2 and 4, since player 2 line color is used
   // for the second part in duet, and yellow (4) looks better than red (2)
   DefaultPlayerColors: array[0..IMaxPlayerCount-1] of integer = (1, 4, 3, 2, 5, 6, 7, 8, 9, 10, 11, 12);
+  NAME_TEMPLATE_AVATAR_UNSET = '-';
+  NAME_TEMPLATE_LEVEL_UNSET = -1;
   IPlayers:     array[0..4] of UTF8String = ('1', '2', '3', '4', '6');
   IPlayersVals: array[0..4] of integer    = ( 1 ,  2 ,  3 ,  4 ,  6 );
 
@@ -134,6 +136,9 @@ type
       // Templates for Names Mod
       NameTeam:       array[0..2] of UTF8String;
       NameTemplate:   array[0..(IMaxPlayerCount-1)] of UTF8String;
+      NameTemplateColor:  array[0..(IMaxPlayerCount-1)] of integer;
+      NameTemplateAvatar: array[0..(IMaxPlayerCount-1)] of UTF8String;
+      NameTemplateLevel:  array[0..(IMaxPlayerCount-1)] of integer;
 
       // Filename of the opened iniFile
       Filename:       IPath;
@@ -1535,7 +1540,12 @@ begin
   for I := 0 to 2 do
     NameTeam[I] := IniFile.ReadString('NameTeam', 'T'+IntToStr(I+1), 'Team'+IntToStr(I+1));
   for I := 0 to 11 do
+  begin
     NameTemplate[I] := IniFile.ReadString('NameTemplate', 'Name'+IntToStr(I+1), 'Template'+IntToStr(I+1));
+    NameTemplateColor[I] := IniFile.ReadInteger('NameTemplateColor', 'Name'+IntToStr(I+1), 0);
+    NameTemplateAvatar[I] := IniFile.ReadString('NameTemplateAvatar', 'Name'+IntToStr(I+1), NAME_TEMPLATE_AVATAR_UNSET);
+    NameTemplateLevel[I] := IniFile.ReadInteger('NameTemplateLevel', 'Name'+IntToStr(I+1), NAME_TEMPLATE_LEVEL_UNSET);
+  end;
 
   // Players
   Players := ReadArrayIndex(IPlayers, IniFile, 'Game', 'Players', 0);
@@ -2124,10 +2134,27 @@ begin
     for I := 0 to High(NameTeam) do
       IniFile.WriteString('NameTeam', 'T' + IntToStr(I+1), NameTeam[I]);
     for I := 0 to High(NameTemplate) do
+    begin
       IniFile.WriteString('NameTemplate', 'Name' + IntToStr(I+1), NameTemplate[I]);
+      if (NameTemplateColor[I] > 0) then
+        IniFile.WriteInteger('NameTemplateColor', 'Name' + IntToStr(I+1), NameTemplateColor[I])
+      else
+        IniFile.DeleteKey('NameTemplateColor', 'Name' + IntToStr(I+1));
+      if (NameTemplateAvatar[I] <> NAME_TEMPLATE_AVATAR_UNSET) then
+        IniFile.WriteString('NameTemplateAvatar', 'Name' + IntToStr(I+1), NameTemplateAvatar[I])
+      else
+        IniFile.DeleteKey('NameTemplateAvatar', 'Name' + IntToStr(I+1));
+      if (NameTemplateLevel[I] <> NAME_TEMPLATE_LEVEL_UNSET) then
+        IniFile.WriteInteger('NameTemplateLevel', 'Name' + IntToStr(I+1), NameTemplateLevel[I])
+      else
+        IniFile.DeleteKey('NameTemplateLevel', 'Name' + IntToStr(I+1));
+    end;
   finally
     IniFile.Free;
   end;
+
+  if FileExists(Filename.ToNative) then
+    LastReadNames := FileAge(Filename.ToNative);
 end;
 
 

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -312,6 +312,7 @@ type
   TThemeName = class(TThemeBasic)
     PlayerButtonName:          TThemeButton;
     PlayerButtonAvatar:        TThemeButton;
+    TemplateStatus:            TThemeText;
 
     PlayerScrollAvatar: record
       NumAvatars: integer;
@@ -1512,6 +1513,7 @@ begin
 
       ThemeLoadButton(Name.PlayerButtonName, 'NamePlayerButtonName');
       ThemeLoadButton(Name.PlayerButtonAvatar, 'NamePlayerButtonAvatar');
+      ThemeLoadText(Name.TemplateStatus, 'NameTemplateStatusText');
 
       IniFile := ResolveThemeFile('NamePlayerScrollAvatar');
       Name.PlayerScrollAvatar.NumAvatars := IniFile.ReadInteger('NamePlayerScrollAvatar', 'Count', 5);

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -247,15 +247,28 @@ begin
 end;
 
 function TScreenName.ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean; out SuppressKey: boolean): boolean;
+var
+  ModState: word;
 begin
   Result := inherited;
+  SuppressKey := false;
   // only suppress special keys for now
   case PressedKey of
     // Templates for Names Mod
     SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F7, SDLK_F8, SDLK_F9, SDLK_F10, SDLK_F11, SDLK_F12:
-     begin
-       SuppressKey := true;
-     end;
+      begin
+        ModState := SDL_GetModState;
+
+        // Leave Alt- and Command-modified function keys to the OS/application.
+        if (ModState and (KMOD_ALT or KMOD_GUI)) <> 0 then
+          Result := false
+        // Name templates keep their original name-field context. Ctrl adds a
+        // separate full-profile shortcut that works from any control.
+        else if ((ModState and KMOD_CTRL) <> 0) or Button[PlayerName].Selected then
+          SuppressKey := true
+        else
+          Result := false;
+      end;
   end;
 end;
 
@@ -274,59 +287,82 @@ function TScreenName.ParseInput(PressedKey: cardinal; CharCode: UCS4Char; Presse
 
   procedure HandleNameTemplate(const index: integer);
   var
-    isAlternate: boolean;
+    IsProfile: boolean;
+    IsSave: boolean;
     TemplateAvatar: integer;
     J: integer;
   begin
-    isAlternate := (SDL_ModState and (KMOD_LSHIFT + KMOD_RSHIFT + KMOD_LALT + KMOD_RALT)) <> 0;
+    if (SDL_ModState and (KMOD_ALT or KMOD_GUI)) <> 0 then
+      Exit;
 
-    if isAlternate then
+    IsProfile := (SDL_ModState and KMOD_CTRL) <> 0;
+    IsSave := (SDL_ModState and KMOD_SHIFT) <> 0;
+
+    if IsSave then
     begin
       PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
       Ini.NameTemplate[index] := Button[PlayerName].Text[0].Text;
-      Ini.NameTemplateColor[index] := Num[PlayerIndex];
-      Ini.NameTemplateAvatar[index] := PlayerAvatarButtonMD5[PlayerAvatars[PlayerIndex]];
-      Ini.NameTemplateLevel[index] := PlayerLevel[PlayerIndex];
+
+      if IsProfile then
+      begin
+        Ini.NameTemplateColor[index] := Num[PlayerIndex];
+        Ini.NameTemplateAvatar[index] := PlayerAvatarButtonMD5[PlayerAvatars[PlayerIndex]];
+        Ini.NameTemplateLevel[index] := PlayerLevel[PlayerIndex];
+      end;
+
       for J := 0 to High(PlayerNames) do
         Ini.Name[J] := PlayerNames[J];
       Ini.SaveNames;
       AudioPlayback.PlaySound(SoundLib.Change);
-      ShowTemplateStatus('Saved', index);
+
+      if IsProfile then
+        ShowTemplateStatus(Language.Translate('NAME_TEMPLATE_PROFILE_SAVED'), index)
+      else
+        ShowTemplateStatus(Language.Translate('NAME_TEMPLATE_NAME_SAVED'), index);
     end
     else
     begin
       Button[PlayerName].Text[0].Text := Ini.NameTemplate[index];
       PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
 
-      if (Ini.NameTemplateColor[index] > 0) and
-        (Ini.NameTemplateColor[index] <= Length(IPlayerColorTranslated)) then
+      if IsProfile then
       begin
-        PlayerColorButton(Ini.NameTemplateColor[index]);
+        if (Ini.NameTemplateColor[index] > 0) and
+          (Ini.NameTemplateColor[index] <= Length(IPlayerColorTranslated)) then
+        begin
+          PlayerColorButton(Ini.NameTemplateColor[index]);
+        end;
+
+        if (Ini.NameTemplateAvatar[index] <> NAME_TEMPLATE_AVATAR_UNSET) then
+        begin
+          TemplateAvatar := GetArrayIndex(PlayerAvatarButtonMD5, Ini.NameTemplateAvatar[index]);
+          if (TemplateAvatar < 0) then
+            TemplateAvatar := 0;
+
+          PlayerAvatars[PlayerIndex] := TemplateAvatar;
+          AvatarTarget := TemplateAvatar;
+          AvatarCurrent := TemplateAvatar;
+          isScrolling := false;
+          SetPlayerAvatar(PlayerIndex);
+        end;
+
+        if (Ini.NameTemplateLevel[index] >= 0) and
+          (Ini.NameTemplateLevel[index] <= High(IDifficultyTranslated)) then
+        begin
+          PlayerLevel[PlayerIndex] := Ini.NameTemplateLevel[index];
+          SelectsS[PlayerSelectLevel].SetSelectOpt(PlayerLevel[PlayerIndex]);
+        end;
+
+        RefreshProfile();
+        SetInteraction(Interaction);
       end;
 
-      if (Ini.NameTemplateAvatar[index] <> NAME_TEMPLATE_AVATAR_UNSET) then
-      begin
-        TemplateAvatar := GetArrayIndex(PlayerAvatarButtonMD5, Ini.NameTemplateAvatar[index]);
-        if (TemplateAvatar < 0) then
-          TemplateAvatar := 0;
-
-        PlayerAvatars[PlayerIndex] := TemplateAvatar;
-        AvatarTarget := TemplateAvatar;
-        AvatarCurrent := TemplateAvatar;
-        isScrolling := false;
-        SetPlayerAvatar(PlayerIndex);
-      end;
-
-      if (Ini.NameTemplateLevel[index] >= 0) and
-        (Ini.NameTemplateLevel[index] <= High(IDifficultyTranslated)) then
-      begin
-        PlayerLevel[PlayerIndex] := Ini.NameTemplateLevel[index];
-        SelectsS[PlayerSelectLevel].SetSelectOpt(PlayerLevel[PlayerIndex]);
-      end;
-
-      RefreshProfile();
       AudioPlayback.PlaySound(SoundLib.Change);
-      ShowTemplateStatus('Loaded', index);
+
+      if IsProfile then
+        ShowTemplateStatus(Language.Translate('NAME_TEMPLATE_PROFILE_LOADED'), index)
+      else
+        ShowTemplateStatus(Language.Translate('NAME_TEMPLATE_NAME_LOADED'), index);
     end;
   end;
 
@@ -335,8 +371,7 @@ begin
   if (PressedDown) then
   begin // Key Down
 
-    SDL_ModState := SDL_GetModState and (KMOD_LSHIFT + KMOD_RSHIFT
-    + KMOD_LCTRL + KMOD_RCTRL + KMOD_LALT  + KMOD_RALT);
+    SDL_ModState := SDL_GetModState and (KMOD_SHIFT or KMOD_CTRL or KMOD_ALT or KMOD_GUI);
 
     if (not Button[PlayerName].Selected) then
     begin
@@ -876,7 +911,7 @@ begin
   Theme.Name.SelectPlayerLevel.showArrows := true;
   PlayerSelectLevel := AddSelectSlide(Theme.Name.SelectPlayerLevel, LevelIndex, IDifficultyTranslated);
 
-  TemplateStatusText := AddText(780, 20, 0, 0, 0, 0, 20, 1, 1, 1, 2, '', false, 0, 1, false);
+  TemplateStatusText := AddText(Theme.Name.TemplateStatus);
   Text[TemplateStatusText].Visible := false;
   TemplateStatusUntil := 0;
 

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -86,6 +86,11 @@ type
 
       PlayerAvatarButton: array of integer;
       PlayerAvatarButtonMD5: array of UTF8String;
+
+      TemplateStatusText: integer;
+      TemplateStatusUntil: cardinal;
+
+      procedure ShowTemplateStatus(const Status: UTF8String; Index: integer);
     public
       Goto_SingScreen: boolean; //If true then next Screen in SingScreen
       
@@ -248,15 +253,17 @@ begin
   case PressedKey of
     // Templates for Names Mod
     SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F7, SDLK_F8, SDLK_F9, SDLK_F10, SDLK_F11, SDLK_F12:
-     if (Button[PlayerName].Selected) then
      begin
        SuppressKey := true;
-     end
-     else
-     begin
-       Result := false;
      end;
   end;
+end;
+
+procedure TScreenName.ShowTemplateStatus(const Status: UTF8String; Index: integer);
+begin
+  Text[TemplateStatusText].Text := Status + ' F' + IntToStr(Index + 1);
+  Text[TemplateStatusText].Visible := true;
+  TemplateStatusUntil := SDL_GetTicks() + 1500;
 end;
 
 function TScreenName.ParseInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean): boolean;
@@ -268,18 +275,58 @@ function TScreenName.ParseInput(PressedKey: cardinal; CharCode: UCS4Char; Presse
   procedure HandleNameTemplate(const index: integer);
   var
     isAlternate: boolean;
+    TemplateAvatar: integer;
+    J: integer;
   begin
-    isAlternate := (SDL_ModState = KMOD_LSHIFT) or (SDL_ModState = KMOD_RSHIFT);
-    isAlternate := isAlternate or (SDL_ModState = KMOD_LALT); // legacy key combination
+    isAlternate := (SDL_ModState and (KMOD_LSHIFT + KMOD_RSHIFT + KMOD_LALT + KMOD_RALT)) <> 0;
 
     if isAlternate then
     begin
+      PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
       Ini.NameTemplate[index] := Button[PlayerName].Text[0].Text;
+      Ini.NameTemplateColor[index] := Num[PlayerIndex];
+      Ini.NameTemplateAvatar[index] := PlayerAvatarButtonMD5[PlayerAvatars[PlayerIndex]];
+      Ini.NameTemplateLevel[index] := PlayerLevel[PlayerIndex];
+      for J := 0 to High(PlayerNames) do
+        Ini.Name[J] := PlayerNames[J];
+      Ini.SaveNames;
+      AudioPlayback.PlaySound(SoundLib.Change);
+      ShowTemplateStatus('Saved', index);
     end
     else
     begin
       Button[PlayerName].Text[0].Text := Ini.NameTemplate[index];
       PlayerNames[PlayerIndex] := Button[PlayerName].Text[0].Text;
+
+      if (Ini.NameTemplateColor[index] > 0) and
+        (Ini.NameTemplateColor[index] <= Length(IPlayerColorTranslated)) then
+      begin
+        PlayerColorButton(Ini.NameTemplateColor[index]);
+      end;
+
+      if (Ini.NameTemplateAvatar[index] <> NAME_TEMPLATE_AVATAR_UNSET) then
+      begin
+        TemplateAvatar := GetArrayIndex(PlayerAvatarButtonMD5, Ini.NameTemplateAvatar[index]);
+        if (TemplateAvatar < 0) then
+          TemplateAvatar := 0;
+
+        PlayerAvatars[PlayerIndex] := TemplateAvatar;
+        AvatarTarget := TemplateAvatar;
+        AvatarCurrent := TemplateAvatar;
+        isScrolling := false;
+        SetPlayerAvatar(PlayerIndex);
+      end;
+
+      if (Ini.NameTemplateLevel[index] >= 0) and
+        (Ini.NameTemplateLevel[index] <= High(IDifficultyTranslated)) then
+      begin
+        PlayerLevel[PlayerIndex] := Ini.NameTemplateLevel[index];
+        SelectsS[PlayerSelectLevel].SetSelectOpt(PlayerLevel[PlayerIndex]);
+      end;
+
+      RefreshProfile();
+      AudioPlayback.PlaySound(SoundLib.Change);
+      ShowTemplateStatus('Loaded', index);
     end;
   end;
 
@@ -643,7 +690,7 @@ end;
 procedure TScreenName.RefreshProfile();
 var
   ITmp: array of UTF8String;
-  Count, Max, I, J, Index: integer;
+  Count, I, J, Index: integer;
   Used: boolean;
 begin
   // no-avatar for current player
@@ -660,11 +707,8 @@ begin
 
   PlayerColorButton(Num[PlayerIndex]);
 
-  Max := Length(IPlayerColorTranslated) - Count + 1;
-  SetLength(ITmp, Max);
-
   APlayerColor := nil;
-  SetLength(APlayerColor, Max);
+  ITmp := nil;
 
   Index := 0;
   for I := 0 to High(IPlayerColorTranslated) do      //for every color
@@ -673,7 +717,7 @@ begin
 
     for J := 0 to Count -1 do      //for every active player
     begin
-      if (Num[J] - 1 = I) and (J <> PlayerIndex) then   //check if color is already used for not current player
+      if (Num[J] - 1 = I) and (J <> PlayerIndex) and (Num[PlayerIndex] <> I + 1) then   //check if color is already used for not current player
       begin
         Used := true;
         break;
@@ -682,6 +726,8 @@ begin
 
     if not (Used) then
     begin
+      SetLength(ITmp, Index + 1);
+      SetLength(APlayerColor, Index + 1);
       ITmp[Index] := IPlayerColorTranslated[I];
       APlayerColor[Index] := I + 1;
       Index := Index + 1;
@@ -829,6 +875,10 @@ begin
   Theme.Name.SelectPlayerLevel.oneItemOnly := true;
   Theme.Name.SelectPlayerLevel.showArrows := true;
   PlayerSelectLevel := AddSelectSlide(Theme.Name.SelectPlayerLevel, LevelIndex, IDifficultyTranslated);
+
+  TemplateStatusText := AddText(780, 20, 0, 0, 0, 0, 20, 1, 1, 1, 2, '', false, 0, 1, false);
+  Text[TemplateStatusText].Visible := false;
+  TemplateStatusUntil := 0;
 
   isScrolling := false;
 
@@ -1099,6 +1149,9 @@ begin
   end;
 
   SetAvatarScroll;
+
+  if Text[TemplateStatusText].Visible and (SDL_GetTicks() > TemplateStatusUntil) then
+    Text[TemplateStatusText].Visible := false;
 
   // set current name = name in list
   Text[PlayerCurrentText[PlayerIndex]].Text := Button[PlayerName].Text[0].Text;

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -262,9 +262,10 @@ begin
         // Leave Alt- and Command-modified function keys to the OS/application.
         if (ModState and (KMOD_ALT or KMOD_GUI)) <> 0 then
           Result := false
-        // Name templates keep their original name-field context. Ctrl adds a
-        // separate full-profile shortcut that works from any control.
-        else if ((ModState and KMOD_CTRL) <> 0) or Button[PlayerName].Selected then
+        // Plain F11 remains fullscreen unless the name field is selected.
+        // The other name and profile shortcuts work from any control.
+        else if ((ModState and (KMOD_CTRL or KMOD_SHIFT)) <> 0) or
+          (PressedKey <> SDLK_F11) or Button[PlayerName].Selected then
           SuppressKey := true
         else
           Result := false;

--- a/src/screens/UScreenPartyPlayer.pas
+++ b/src/screens/UScreenPartyPlayer.pas
@@ -241,20 +241,25 @@ begin
 end;
 
 function TScreenPartyPlayer.ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean; out SuppressKey: boolean): boolean;
+var
+  ModState: word;
 begin
   Result := inherited;
+  SuppressKey := false;
   // only suppress special keys for now
   case PressedKey of
     // Templates for Names Mod
     SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F7, SDLK_F8, SDLK_F9, SDLK_F10, SDLK_F11, SDLK_F12:
-     if (Button[Interactions[Interaction].Num].Selected) then
-     begin
-       SuppressKey := true;
-     end
-     else
-     begin
-       Result := false;
-     end;
+      begin
+        ModState := SDL_GetModState;
+        if (ModState and (KMOD_ALT or KMOD_GUI)) <> 0 then
+          Result := false
+        else if (Interactions[Interaction].Typ = iButton) and
+          Button[Interactions[Interaction].Num].Selected then
+          SuppressKey := true
+        else
+          Result := false;
+      end;
   end;
 end;
 
@@ -286,8 +291,7 @@ function TScreenPartyPlayer.ParseInput(PressedKey: cardinal; CharCode: UCS4Char;
   var
     isAlternate: boolean;
   begin
-    isAlternate := (SDL_ModState = KMOD_LSHIFT) or (SDL_ModState = KMOD_RSHIFT);
-    isAlternate := isAlternate or (SDL_ModState = KMOD_LALT); // legacy key combination
+    isAlternate := (SDL_ModState and KMOD_SHIFT) <> 0;
 
     if isAlternate then Ini.NameTemplate[index] := Button[Interactions[Interaction].Num].Text[0].Text
     else Button[Interactions[Interaction].Num].Text[0].Text := Ini.NameTemplate[index];
@@ -296,8 +300,7 @@ begin
   Result := true;
 
   if (PressedDown) then
-    SDL_ModState := SDL_GetModState and (KMOD_LSHIFT + KMOD_RSHIFT
-        + KMOD_LCTRL + KMOD_RCTRL + KMOD_LALT  + KMOD_RALT)
+    SDL_ModState := SDL_GetModState and (KMOD_SHIFT or KMOD_CTRL)
   else
     SDL_ModState := 0;
 

--- a/src/screens/UScreenPartyTournamentPlayer.pas
+++ b/src/screens/UScreenPartyTournamentPlayer.pas
@@ -148,20 +148,25 @@ begin
 end;
 
 function TScreenPartyTournamentPlayer.ShouldHandleInput(PressedKey: cardinal; CharCode: UCS4Char; PressedDown: boolean; out SuppressKey: boolean): boolean;
+var
+  ModState: word;
 begin
   Result := inherited;
+  SuppressKey := false;
   // only suppress special keys for now
   case PressedKey of
     // Templates for Names Mod
     SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F7, SDLK_F8, SDLK_F9, SDLK_F10, SDLK_F11, SDLK_F12:
-     if (Button[Interactions[Interaction].Num].Selected) then
-     begin
-       SuppressKey := true;
-     end
-     else
-     begin
-       Result := false;
-     end;
+      begin
+        ModState := SDL_GetModState;
+        if (ModState and (KMOD_ALT or KMOD_GUI)) <> 0 then
+          Result := false
+        else if (Interactions[Interaction].Typ = iButton) and
+          Button[Interactions[Interaction].Num].Selected then
+          SuppressKey := true
+        else
+          Result := false;
+      end;
   end;
 end;
 
@@ -191,8 +196,7 @@ begin
   Result := true;
 
   if (PressedDown) then
-    SDL_ModState := SDL_GetModState and (KMOD_LSHIFT + KMOD_RSHIFT
-        + KMOD_LCTRL + KMOD_RCTRL + KMOD_LALT  + KMOD_RALT)
+    SDL_ModState := SDL_GetModState and (KMOD_SHIFT or KMOD_CTRL)
   else
     SDL_ModState := 0;
 
@@ -210,8 +214,7 @@ begin
     end;
 
     // check special keys
-    isAlternate := (SDL_ModState = KMOD_LSHIFT) or (SDL_ModState = KMOD_RSHIFT);
-    isAlternate := isAlternate or (SDL_ModState = KMOD_LALT); // legacy key combination
+    isAlternate := (SDL_ModState and KMOD_SHIFT) <> 0;
     case PressedKey of
       // Templates for Names Mod
       SDLK_F1:


### PR DESCRIPTION
Fixes #137. Also fixes #280.

This PR extends the existing F-key name templates with optional full player profiles.

- use F1-F10 and F12 to load a player name from anywhere on the player setup screen
- use F11 to load a name while the name field is selected and otherwise keep its fullscreen function (maybe we should remove F11 as a fullscreen hotkey, we have Alt+Enter anyways)
- use Shift+F1-F12 to save a player name from anywhere
- use Ctrl+F1-F12 to load and Ctrl+Shift+F1-F12 to save the player name, color, avatar, and difficulty
- leave Alt- and Command-modified function keys to the application or OS
- remove the legacy Alt+F save shortcut from normal, party, and tournament player setup
- keep focus on the current control when loading profiles
- show a short localized, theme-defined saved/loaded indicator
- refresh the color selector after loading a profile
- update the player setup help screen wording
- F-key templates in party mode remain name only