### PR TITLE
use mipmapping when gpu-scaling textures

### DIFF
--- a/src/base/UTexture.pas
+++ b/src/base/UTexture.pas
@@ -342,7 +342,7 @@ begin
   glGenTextures(1, @ActTex);
 
   glBindTexture(GL_TEXTURE_2D, ActTex);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
@@ -360,6 +360,7 @@ begin
   begin
     glTexImage2D(GL_TEXTURE_2D, 0, 3, newWidth, newHeight, 0, GL_RGB, GL_UNSIGNED_BYTE, TexSurface.pixels);
   end;
+  glGenerateMipmap(GL_TEXTURE_2D);
 
   // setup texture struct
   with Result do


### PR DESCRIPTION
I knew there was something missing from #1165. I knew the cover images on my local builds weren't that blocky, but pardon me not finding that particular needle in an almost-6000 line diff haystack on the first try. note that these are pretty bad examples as these covers are actually quite large, it looks _much_ better on 1080p (especially the text is much sharper then)

GL_LINEAR (old code)
<img width="800" height="600" alt="screenshot0071" src="https://github.com/user-attachments/assets/5599317b-644a-4d00-95f7-6d80929ebd58" />

GL_LINEAR_MIPMAP_LINEAR (this PR)
<img width="800" height="600" alt="screenshot0072" src="https://github.com/user-attachments/assets/2da300d8-5b3a-48b9-b0b3-e6db58f7dadb" />


NB: #1213 appears to also also do something to UTexture in a similar regard, but it's more advanced and I don't exactly know what some of the things in there are doing. The best link I can give you is https://github.com/dgruss/USDX/commit/66dd9098c4e28b2964a6daa15e14c0a44871874c#diff-43d61e4155c65a983e9091e0c5297c03e075a69b6946addbe9bf608222b23061 also screenshotted below, because I don't trust github to keep that working in case of a force-push:
<img width="843" height="716" alt="2026-05-29-134840_843x768_scrot" src="https://github.com/user-attachments/assets/b36d3d72-acf8-4542-8403-484022aec1b8" />

I'm open to integrating the relevant bits into this PR. I don't know if I can blindly call glGenerateMipmaps but I've been running with this for probably over 3 years now.