### PR TITLE
Fix crash on Alt+F4

### DIFF
--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -1064,15 +1064,16 @@ end;
 
 procedure FinalizeMedia;
 begin
-  // stop, close and free sounds
-  SoundLib.Free;
-
-  // release webcam
-  Webcam.Free;
-
-  // stop and close music stream
+  // Stop and release the main music streams before auxiliary sound effects.
+  // This avoids backend teardown races during shutdown.
   if (AudioPlayback <> nil) then
     AudioPlayback.Close;
+
+  // stop, close and free sounds
+  FreeAndNil(SoundLib);
+
+  // release webcam
+  FreeAndNil(Webcam);
 
   // stop any active captures
   if (AudioInput <> nil) then

--- a/src/media/UAudioPlaybackBase.pas
+++ b/src/media/UAudioPlaybackBase.pas
@@ -193,8 +193,8 @@ end;
 function TAudioPlaybackBase.Open(const Filename: IPath; const FilenameKaraoke: IPath): boolean;
 begin
   // free old MusicStream
-  MusicStream.Free;
-  KaraokeMusicStream.Free;
+  FreeAndNil(MusicStream);
+  FreeAndNil(KaraokeMusicStream);
   CurrentFileName := Filename.ToNative;
 
   MusicStream := OpenStream(Filename);


### PR DESCRIPTION
Fixes a shutdown race seen when closing the game with Alt+F4.

The media teardown now closes the main audio playback stream before freeing auxiliary media resources such as sound effects and webcam state. It also uses `FreeAndNil` for owned media objects/streams so later teardown code cannot accidentally touch stale object references.