### PR TITLE
Bootstrap Windows runtime files during local make builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
             git
             make
             pkgconf
+            python
             mingw-w64-x86_64-gcc
             mingw-w64-x86_64-tools
       - name: Install Dependencies
@@ -40,9 +41,7 @@ jobs:
           ./nsis-3.05-setup.exe /S
       - name: Download prebuilt DLLs
         run: |
-          python dldlls.py
-          7z x -y usdx-dlls-x86_64.zip -ogame "*.dll"
-          7z x -y usdx-dlls-x86_64.zip -osrc "config-win.inc"
+          python3 dldlls.py --ensure
         env:
           ARTIFACT_ACCESS_TOKEN: ${{ secrets.MxeActionsReadAccessToken }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,6 @@ ppaslink.sh
 # created by dldlls.py on Windows
 /usdx-dlls-x86_64.zip
 /usdx-dlls-i686.zip
+/bass24.zip
 /game/*.dll
 /game/*.debug

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -12,7 +12,7 @@ For linking and running the game, the following libraries are also required:
 - OpenCV if you want webcam support
 - projectM 4,x if you want audio visualisation support
 
-Prebuilt DLLs for SDL2, SDL2_image, FFmpeg, SQLite, PortAudio, and Lua can be found in the releases section of [our MXE fork](https://github.com/UltraStar-Deluxe/mxe). You can use the dldlls.py script to download the DLLs for the checked out code. The remaining DLLs needed for Windows builds are part of this repository.
+Prebuilt DLLs for SDL2, SDL2_image, FFmpeg, SQLite, PortAudio, and Lua can be found in the releases section of [our MXE fork](https://github.com/UltraStar-Deluxe/mxe). On Windows, `make` downloads and extracts the matching DLL archive and `src/config-win.inc` automatically when they are missing. For Lazarus or manual setups, run `python dldlls.py --ensure` from the repository root before building.
 
 ## Compiling using Lazarus
 1. Start Lazarus.

--- a/dldlls.py
+++ b/dldlls.py
@@ -1,19 +1,62 @@
 #!/usr/bin/python3
 
-import urllib.request
-import shutil
+import argparse
 import json
-import sys
 import os
+import posixpath
+import shutil
+import sys
+import urllib.request
 import zipfile
 
 sha = '355c55d2723e344c47cf353f9d47699a2ce1150a'
 filename = 'usdx-dlls-x86_64'
+archive_name = filename + '.zip'
 urlbase = 'https://api.github.com/repos/UltraStar-Deluxe/mxe/'
 headers = {
     'Accept': 'application/vnd.github+json',
     'X-GitHub-Api-Version': '2022-11-28'
     }
+
+root_dir = os.path.dirname(os.path.abspath(__file__))
+game_dir = os.path.join(root_dir, 'game')
+src_dir = os.path.join(root_dir, 'src')
+archive_path = os.path.join(root_dir, archive_name)
+bass_zip_path = os.path.join(root_dir, 'bass24.zip')
+bass_target = os.path.join(game_dir, 'bass.dll')
+config_target = os.path.join(src_dir, 'config-win.inc')
+
+required_game_dlls = [
+    'SDL2.dll',
+    'SDL2_image.dll',
+    'avcodec-62.dll',
+    'avformat-62.dll',
+    'avutil-60.dll',
+    'libdav1d.dll',
+    'libdl.dll',
+    'libfreetype-6.dll',
+    'libgcc_s_seh-1.dll',
+    'libjpeg-8.dll',
+    'libopencv_core4130.dll',
+    'libopencv_imgcodecs4130.dll',
+    'libopencv_imgproc4130.dll',
+    'libopencv_videoio4130.dll',
+    'libpng16-16.dll',
+    'libprojectM-0.dll',
+    'libsharpyuv-0.dll',
+    'libstdc++-6.dll',
+    'libtiff-6.dll',
+    'libwebp-7.dll',
+    'libwinpthread-1.dll',
+    'lua54.dll',
+    'opencvwrapper.dll',
+    'portaudio_x64.dll',
+    'projectM-cwrapper.dll',
+    'sqlite3.dll',
+    'swresample-6.dll',
+    'swscale-9.dll',
+    'zlib1.dll',
+]
 
 token = os.environ.get('ARTIFACT_ACCESS_TOKEN')
 if token == None or token.strip() == '':
@@ -21,19 +64,41 @@ if token == None or token.strip() == '':
 if token != None and token.strip() != '':
     headers['Authorization'] = 'Bearer ' + token
 
-print('Searching for binaries built from commit ' + sha)
+def ensure_dirs():
+    os.makedirs(game_dir, exist_ok=True)
+    os.makedirs(src_dir, exist_ok=True)
 
-def download_bass():
+
+def copy_zip_member(zf, member, target):
+    with zf.open(member) as src, open(target, 'wb') as dst:
+        shutil.copyfileobj(src, dst)
+
+
+def missing_runtime_files():
+    missing = []
+    if not os.path.isfile(config_target):
+        missing.append(os.path.relpath(config_target, root_dir))
+    for dll in required_game_dlls:
+        target = os.path.join(game_dir, dll)
+        if not os.path.isfile(target):
+            missing.append(os.path.relpath(target, root_dir))
+    if not os.path.isfile(bass_target):
+        missing.append(os.path.relpath(bass_target, root_dir))
+    return missing
+
+
+def download_bass(force=False):
+    ensure_dirs()
     bass_url = 'https://www.un4seen.com/files/bass24.zip'
-    zip_name = 'bass24.zip'
-    target = 'game/bass.dll'
-    with urllib.request.urlopen(bass_url) as dl, open(zip_name, 'wb') as out:
+    if not force and os.path.isfile(bass_target):
+        print('Using existing ' + os.path.relpath(bass_target, root_dir))
+        return
+    with urllib.request.urlopen(bass_url) as dl, open(bass_zip_path, 'wb') as out:
         out.write(dl.read())
-    with zipfile.ZipFile(zip_name, 'r') as zf:
+    with zipfile.ZipFile(bass_zip_path, 'r') as zf:
         member = 'x64/bass.dll'
-        with zf.open(member) as src, open(target, 'wb') as dst:
-            dst.write(src.read())
-    print('Downloaded ' + member + ' to ' + target)
+        copy_zip_member(zf, member, bass_target)
+    print('Downloaded ' + member + ' to ' + os.path.relpath(bass_target, root_dir))
 
 
 def search_releases():
@@ -62,6 +127,7 @@ def search_releases():
     print('No release matches')
     return None
 
+
 def search_artifacts():
     pagesuffix = ''
     page = 1
@@ -83,16 +149,79 @@ def search_artifacts():
     print('No workflow artifact matches')
     return None
 
-download_bass()
 
-dllurl = search_releases()
-if dllurl == None and token != None:
-    dllurl = search_artifacts()
-if dllurl == None:
-    sys.exit(1)
-print('Downloading from ' + dllurl)
-req = urllib.request.Request(url = dllurl)
-for key in headers:
-    req.add_unredirected_header(key, headers[key])
-shutil.copyfileobj(urllib.request.urlopen(req),
-                   open(filename + '.zip', 'wb'))
+def download_dll_archive(force=False):
+    if not force and os.path.isfile(archive_path):
+        print('Using existing ' + archive_name)
+        return
+
+    print('Searching for binaries built from commit ' + sha)
+    dllurl = search_releases()
+    if dllurl == None and token != None:
+        dllurl = search_artifacts()
+    if dllurl == None:
+        sys.exit(1)
+    print('Downloading from ' + dllurl)
+    req = urllib.request.Request(url = dllurl)
+    for key in headers:
+        req.add_unredirected_header(key, headers[key])
+    with urllib.request.urlopen(req) as response, open(archive_path, 'wb') as out:
+        shutil.copyfileobj(response, out)
+
+
+def extract_dll_archive():
+    ensure_dirs()
+    extracted = 0
+    with zipfile.ZipFile(archive_path, 'r') as zf:
+        for member in zf.infolist():
+            filename_in_zip = member.filename.replace('\\', '/')
+            basename = posixpath.basename(filename_in_zip)
+            if basename == '':
+                continue
+            if basename.lower().endswith('.dll'):
+                copy_zip_member(zf, member, os.path.join(game_dir, basename))
+                extracted += 1
+            elif basename == 'config-win.inc':
+                copy_zip_member(zf, member, config_target)
+                extracted += 1
+    print('Extracted {} files from {}'.format(extracted, archive_name))
+
+
+def ensure_windows_runtime(force=False):
+    missing = missing_runtime_files()
+    if not force and not missing:
+        print('Windows runtime files are already present')
+        return
+
+    if missing:
+        print('Missing Windows runtime files:')
+        for path in missing:
+            print('  ' + path)
+
+    download_dll_archive(force=force)
+    extract_dll_archive()
+    download_bass(force=force)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Download Windows DLLs for USDX.')
+    parser.add_argument('--extract', action='store_true',
+                        help='extract DLLs to game/ and config-win.inc to src/')
+    parser.add_argument('--ensure', action='store_true',
+                        help='download and extract only when Windows runtime files are missing')
+    parser.add_argument('--force', action='store_true',
+                        help='redownload and overwrite existing runtime files')
+    args = parser.parse_args()
+
+    if args.ensure:
+        ensure_windows_runtime(force=args.force)
+        return
+
+    download_bass(force=args.force)
+    download_dll_archive(force=args.force)
+    if args.extract:
+        extract_dll_archive()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -31,6 +31,9 @@ MKDIR     ?= @MKDIR_P@
 RM        ?= rm -f
 RM_REC    ?= $(RM) -r
 
+# python interpreter used by helper scripts
+PYTHON ?= python3
+
 #################################################
 # General package configuration
 #################################################
@@ -191,6 +194,11 @@ STATIC_LIBS += $(OPENCV_CWRAPPER_LIB)
 endif
 endif
 
+WINDOWS_RUNTIME_DEPS :=
+ifeq ($(EXEEXT),.exe)
+WINDOWS_RUNTIME_DEPS := windows-runtime-deps
+endif
+
 #################################################
 # general targets
 #################################################
@@ -227,6 +235,10 @@ release-build: build
 rebuild: clean_obj
 	$(MAKE) build
 
+.PHONY: windows-runtime-deps
+windows-runtime-deps:
+	$(PYTHON) "$(top_srcdir)/dldlls.py" --ensure
+
 # Build if files changed. Always clean old data before compiling.
 # FPC does not reliably recognize changes, neither in .pas, 
 # .inc-files nor static libs (.a/.o). This might result in corrupted 
@@ -256,6 +268,7 @@ create-pathinfo:
 	echo "INSTALL_DATADIR = '$(INSTALL_DATADIR)';" > paths.inc
 
 # check if any src-file changed and rebuild
+$(USDX_BIN): | $(WINDOWS_RUNTIME_DEPS)
 $(USDX_BIN): $(USDX_PROJ) $(STATIC_LIBS) $(SRC_FILES)
 	@echo "==================================="
 	@echo "Changed files:"


### PR DESCRIPTION
Windows builds currently depend on generated runtime files that are not tracked in the repository. After `src/config-win.inc` moved out of the repository, local Windows builds fail unless developers manually pulled the DLL archive and extracted both the runtime DLLs and config include. This was already a problem with the DLLs before but they could be copied from any copy of the game or the release zip. The `config-win.inc` not, so the problem got worse and we should address this.
The solution is to make the local `make` path follow the same dependency bootstrap as CI. The CI already performs the bootstrap steps.

## Changes
- add `dldlls.py --ensure` to download and extract the Windows DLL bundle plus `src/config-win.inc` when missing
- run the helper before Windows `.exe` builds from `src/Makefile.in`
- reuse the same helper in GitHub Actions instead of separate `7z` extraction commands
- document the local Windows build behavior