### PR TITLE
Fix Score Screen Regression

### DIFF
--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -597,7 +597,6 @@ begin
           and with Texture type colorized
           also we don't need to swap for one player position }
         if (P <> 1) and
-           (Theme.Score.PlayerStatic[P, I].Typ = Texture_Type_Colorized) and
            (Length(Theme.Score.PlayerStatic[P, I].Color) >= 2) and
            (copy(Theme.Score.PlayerStatic[P, I].Color, 1, 2) = 'P' + IntToStr(PlayerNum)) then
         begin
@@ -613,6 +612,12 @@ begin
           PlayerStaticTextures[P, I, 2].Tex.Y := Statics[PlayerStatic[P, I]].Texture.Y;
           PlayerStaticTextures[P, I, 2].Tex.W := Statics[PlayerStatic[P, I]].Texture.W;
           PlayerStaticTextures[P, I, 2].Tex.H := Statics[PlayerStatic[P, I]].Texture.H;
+          if (Theme.Score.PlayerStatic[P, I].Typ <> TEXTURE_TYPE_COLORIZED) then
+          begin
+            PlayerStaticTextures[P, I, 2].Tex.ColR := R;
+            PlayerStaticTextures[P, I, 2].Tex.ColG := G;
+            PlayerStaticTextures[P, I, 2].Tex.ColB := B;
+          end;
         end;
       end;
     end;

--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -690,28 +690,8 @@ end;
 //TODO: adapt for players 7 to 12
 procedure TScreenScore.SwapToScreen(Screen: integer);
 var
-  P, I, J, Max: integer;
+  P, I, Max: integer;
   Col: TRGB;
-
-  function FindPlayerIndexForThemeSlot(const ThemeSlot, TargetScreen: integer): integer;
-  var
-    PlayerIdx: integer;
-  begin
-    Result := -1;
-
-    if Length(PlayerPositionMap) = 0 then
-      Exit;
-
-    for PlayerIdx := Low(PlayerPositionMap) to High(PlayerPositionMap) do
-    begin
-      if (PlayerPositionMap[PlayerIdx].Position = ThemeSlot) and
-         ((TargetScreen = PlayerPositionMap[PlayerIdx].Screen) or PlayerPositionMap[PlayerIdx].BothScreens) then
-      begin
-        Result := PlayerIdx;
-        Exit;
-      end;
-    end;
-  end;
 begin
 
   case PlayersPlay of
@@ -736,15 +716,10 @@ begin
     for I:= 0 to Max - 1 do
     begin
 
-      J := FindPlayerIndexForThemeSlot(I + 1 + Max, Screen);
-      if (J <> -1) and (J <= High(Ini.PlayerColor)) then
-        Col := GetPlayerColor(Ini.PlayerColor[J])
-      else if (Screen = 2) and (I + Max <= High(Ini.PlayerColor)) then
+      if (Screen = 2) then
         Col := GetPlayerColor(Ini.PlayerColor[I + Max])
-      else if (I <= High(Ini.PlayerColor)) then
-        Col := GetPlayerColor(Ini.PlayerColor[I])
       else
-        Continue;
+        Col := GetPlayerColor(Ini.PlayerColor[I]);
 
       if (copy(Theme.Score.TextName[I + 1 + Max].Color, 1, 2) = 'P' + IntToStr(I + 1)) then
       begin
@@ -830,17 +805,6 @@ begin
       for I := 0 to High(PlayerStatic[P]) do
       begin
         Statics[PlayerStatic[P, I]].Texture := PlayerStaticTextures[P, I, Screen].Tex;
-        if (Theme.Score.PlayerStatic[P, I].Typ <> Texture_Type_Colorized) then
-        begin
-          J := FindPlayerIndexForThemeSlot(P, Screen);
-          if (J <> -1) and (J <= High(Ini.PlayerColor)) then
-          begin
-            Col := GetPlayerColor(Ini.PlayerColor[J]);
-            Statics[PlayerStatic[P, I]].Texture.ColR := Col.R;
-            Statics[PlayerStatic[P, I]].Texture.ColG := Col.G;
-            Statics[PlayerStatic[P, I]].Texture.ColB := Col.B;
-          end;
-        end;
       end;
 
     { box statics }


### PR DESCRIPTION
#1090 was merged to fix the issue in #1030 about the avatar frames being the wrong color on the second screen. It did fix the avatar frames, but introduced a regression in the glass score box, which now appear to "glow" with the player's color (see screenshot).

The method introduced in #1090 to adjust the avatar frame color was flawed and unnecessarily complex. It does not fix the root cause of #1030, which is a bug in the texture loading logic. Instead, it attempts to adjust the color of the player textures on every draw by looking up the player's color, but it does not distinguish between textures which are supposed to be set to the player's color from those that are not (e.g. the glass score box).

The first commit in this PR reverts #1090, and the second commit implements a proper fix for #1030 at its root, when the player textures are loaded.

<img width="1821" height="640" alt="screenshot0001" src="https://github.com/user-attachments/assets/dffd7823-4009-46b7-8c8a-496a7e2c2b55" />
