### PR TITLE
Fix Score Screen Bug When Changing From 4 to 6 Players

### DIFF
--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -3735,6 +3735,8 @@ begin
   OpenFile(Ini.Theme);
 
   // Score
+  Score.Free;
+  Score := TThemeScore.Create;
   ThemeLoadBasic(Score, 'Score');
 
   ThemeLoadText(Score.TextArtist, 'ScoreTextArtist');


### PR DESCRIPTION
To reproduce this bug, do the following:
1. Go to the player selection screen
2. Select 4 players, then press enter.
3. Go back to the player selection screen, select 6 players, then press enter
4. Play any song to finish (you can just Esc out of it immediately)
5. Score screen looks like the screenshot below

The root cause of this bug is in the theme loading. The game reloads the score theme and score screen every time the player selection changes. However, score theme object is not actually *re*loaded. The loading function just *adds* to the existing theme object. So when we change to 6 players, the old theme information for 4 players remains in the theme object, which causes the glitch on the score screen.

This PR fixes the bug by fully reloading the score theme object as was intended.

<img width="1280" height="720" alt="screenshot0002" src="https://github.com/user-attachments/assets/84b782d0-8a66-47e6-a789-902419cff96c" />
