### PR TITLE
Fully respect `-Screens` command line parameter

### DIFF
--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -437,7 +437,7 @@ begin;
 
   if PlayersPlay = 4 then
   begin
-    if (Ini.Screens = 1) then
+    if (Screens = 2) then
     begin
       if ScreenAct = 1 then
       begin
@@ -471,7 +471,7 @@ begin;
 
   if PlayersPlay = 6 then
   begin
-    if (Ini.Screens = 1) then
+    if (Screens = 2) then
     begin
       if (CurrentSong.isDuet) then
       begin
@@ -1249,7 +1249,7 @@ begin
   begin
     if (ScreenSing.settings.NotesVisible[0]) then
     begin
-      if (Ini.Screens = 1) then
+      if (Screens = 2) then
         SingDrawNoteLines(Nr.Left, Skin_P1_NotesB - 105, Nr.Right, 15)
       else
       begin
@@ -1260,7 +1260,7 @@ begin
 
     if (ScreenSing.settings.NotesVisible[1]) then
     begin
-      if (Ini.Screens = 1) then
+      if (Screens = 2) then
         SingDrawNoteLines(Nr.Left, Skin_P2_NotesB - 105, Nr.Right, 15)
       else
       begin
@@ -1273,7 +1273,7 @@ begin
   if (PlayersPlay = 6) and (Ini.NoteLines = 1) then begin
     if (ScreenSing.settings.NotesVisible[0]) then
     begin
-      if (Ini.Screens = 1) then
+      if (Screens = 2) then
         SingDrawNoteLines(Nr.Left, 120, Nr.Right, 12)
       else
       begin
@@ -1284,7 +1284,7 @@ begin
 
     if (ScreenSing.settings.NotesVisible[1]) then
     begin
-      if (Ini.Screens = 1) then
+      if (Screens = 2) then
         SingDrawNoteLines(Nr.Left, 245, Nr.Right, 12)
       else
       begin
@@ -1295,7 +1295,7 @@ begin
 
     if (ScreenSing.settings.NotesVisible[2]) then
     begin
-      if (Ini.Screens = 1) then
+      if (Screens = 2) then
         SingDrawNoteLines(Nr.Left, 370, Nr.Right, 12)
       else
       begin
@@ -1410,7 +1410,7 @@ begin
 
     if PlayersPlay = 4 then
     begin
-      if (Ini.Screens = 0) then
+      if (Screens = 1) then
       begin
         NotesW[I - 1] := NotesW[I - 1] * 0.9;
       end;
@@ -1466,7 +1466,7 @@ begin
 
   if (PlayersPlay = 4) then
   begin
-    if (Ini.Screens = 1) then
+    if (Screens = 2) then
     begin
       // MULTISCREEN
       if (ScreenAct = 1) then
@@ -1515,7 +1515,7 @@ begin
 
   if (PlayersPlay = 6) then
   begin
-    if (Ini.Screens = 1) then
+    if (Screens = 2) then
     begin
       // MULTISCREEN
       if (ScreenAct = 1) then

--- a/src/base/UGraphicClasses.pas
+++ b/src/base/UGraphicClasses.pas
@@ -677,7 +677,7 @@ begin
     if Player[P].LastSentencePerfect then
     begin
       // 3 and 6 players in 1 screen
-      if (Ini.Screens = 0) then
+      if (Screens = 1) then
       begin
         if (PlayersPlay = 4) then
         begin
@@ -730,7 +730,7 @@ begin
                  0,1: cScreen := 1;
                  else
                  begin
-                   if (Ini.Screens = 1) then
+                   if (Screens = 2) then
                      cScreen := 2
                    else
                      cScreen := 1;
@@ -756,7 +756,7 @@ begin
                  0,1,2: cScreen := 1;
                  else
                  begin
-                   if (Ini.Screens = 1) then
+                   if (Screens = 2) then
                      cScreen := 2
                    else
                      cScreen := 1;
@@ -767,7 +767,7 @@ begin
 
       // spawn Sparkling Stars inside calculated coordinates
       Nstars := 80;
-      if (Ini.Screens = 0) and (PlayersPlay > 3) then
+      if (Screens = 1) and (PlayersPlay > 3) then
         Nstars := 40;
 
       for I := 0 to Nstars do

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -1265,6 +1265,7 @@ var
 implementation
 
 uses
+  UGraphic,
   ULanguage,
   USkins,
   UPathUtils,
@@ -3743,7 +3744,7 @@ begin
   ThemeLoadText(Score.TextTitle, 'ScoreTextTitle');
   ThemeLoadText(Score.TextArtistTitle, 'ScoreTextArtistTitle');
 
-  if (Ini.Players < 3) or (Ini.Screens = 1) then
+  if (Ini.Players < 3) or (Screens = 2) then
     prefix := ''
   else
   begin

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -1484,7 +1484,7 @@ begin
     end;
     4:
     begin // double screen
-      if (Ini.Screens = 1) then
+      if (Screens = 2) then
       begin
         V1TwoP := true;
         V2R    := true;
@@ -1509,7 +1509,7 @@ begin
     end;
     6:
     begin // double screen
-      if (Ini.Screens = 1) then
+      if (Screens = 2) then
       begin
         if (CurrentSong.isDuet) then
         begin

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -322,7 +322,7 @@ begin
     maybeShow([StaticP1[0], StaticP1Avatar[0]]);
   end;
 
-  if (PlayersPlay = 2) or ((PlayersPlay = 4) and (Ini.Screens = 1)) then
+  if (PlayersPlay = 2) or ((PlayersPlay = 4) and (Screens = 2)) then
   begin
     if (Screen = 2) then
     begin
@@ -341,7 +341,7 @@ begin
     end;
   end;
 
-  if (PlayersPlay = 3) or ((PlayersPlay = 6) and (Ini.Screens = 1)) then
+  if (PlayersPlay = 3) or ((PlayersPlay = 6) and (Screens = 2)) then
   begin
     if (CurrentSong.isDuet) then
     begin
@@ -386,7 +386,7 @@ begin
   end;
 
   // 4 Players in 1 Screen
-  if (PlayersPlay = 4) and (Ini.Screens = 0) then
+  if (PlayersPlay = 4) and (Screens = 1) then
   begin
     if (CurrentSong.isDuet) then
     begin
@@ -409,7 +409,7 @@ begin
   end;
 
   // 6 Players in 1 Screen
-  if (PlayersPlay = 6) and (Ini.Screens = 0) then
+  if (PlayersPlay = 6) and (Screens = 1) then
   begin
     if (CurrentSong.isDuet) then
     begin


### PR DESCRIPTION
When the `config.ini` file has `Screens=1` set, but you pass `-Screens 2` on the command line, the game uses 2 screens as expected, however:
- On the sing screen, it does not use the dual screen layout for 4 and 6 players. It uses the single screen layout but just duplicates it on the second screen
- It causes very bizarre glitches on the score screen (see screenshot below)

The reason this happens is because many areas of the code refer to `Ini.Screens` instead of `UGraphic.Screens`. The [code](https://github.com/UltraStar-Deluxe/USDX/blob/738ad36f203001c6b451ad99318980440e4d8251/src/base/UGraphic.pas#L665-L668) gives priority to `-Screens` if it was passed on the command line, overriding whatever is set in the `config.ini`.

We should not be referencing `Ini.Screens` in the main game logic.
<img width="1530" height="716" alt="screenshot0004" src="https://github.com/user-attachments/assets/72f126f6-b212-490d-b5e1-3c02c5d7fb51" />

