### PR TITLE
Fix editor text shift crash on single-note lines

### DIFF
--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -2064,6 +2064,9 @@ end;
 procedure TScreenEditSub.HandleMoveTextRight(SDL_ModState: word);
 begin
   // moves text to right in current sentence
+  if CurrentNote[CurrentTrack] >= CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].HighNote then
+    Exit;
+
   CopyToUndo;
   MoveTextToRight;
   Text[TextInfo].Text := Language.Translate('EDIT_INFO_MOVE_TEXT_RIGHT');
@@ -4053,6 +4056,9 @@ var
 begin
   LineIndex := CurrentSong.Tracks[CurrentTrack].CurrentLine;
   NoteHigh := CurrentSong.Tracks[CurrentTrack].Lines[LineIndex].HighNote;
+
+  if CurrentNote[CurrentTrack] >= NoteHigh then
+    Exit;
 
   // last word
   CurrentSong.Tracks[CurrentTrack].Lines[LineIndex].Notes[NoteHigh].Text := CurrentSong.Tracks[CurrentTrack].Lines[LineIndex].Notes[NoteHigh-1].Text + CurrentSong.Tracks[CurrentTrack].Lines[LineIndex].Notes[NoteHigh].Text;


### PR DESCRIPTION
As reported in #1346, pressing . in the editor can crash the game when there is no note to shift the text to. The fix is straight-forward, namely to add bounds checks where necessary. The text shift key "." is a no-op then in this case. With that, fixes #1346.