### PR TITLE
Fix editor pitch marker crash on zero-length notes

### DIFF
--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -1572,8 +1572,9 @@ end;
 
 function TLine.HasLength(out Len: integer): boolean;
 begin
+  Len := 0;
   Result := false;
-  if Length(Notes) >= 0 then
+  if Length(Notes) > 0 then
   begin
     Len := EndBeat - Notes[0].StartBeat;
     Result := (Len > 0);
@@ -1596,7 +1597,10 @@ end;
 
 function TLine.GetLength(): integer;
 begin
-  Result := ifthen(Length(Notes) < 0, 0, EndBeat - Notes[0].StartBeat);
+  if Length(Notes) > 0 then
+    Result := EndBeat - Notes[0].StartBeat
+  else
+    Result := 0;
 end;
 
 function FindNote(beat: integer): TPos;

--- a/src/screens/UScreenEditConvert.pas
+++ b/src/screens/UScreenEditConvert.pas
@@ -579,7 +579,9 @@ begin
   // song info
   Song := TSong.Create();
   Song.Clear();
-  Song.BPM := BPM*4;
+  Song.BPM := BPM * 4;
+  if Song.BPM < MIN_BPM then
+    Song.BPM := MIN_BPM;
   SetLength(Notes, 0);
 
   // extract notes

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -6153,7 +6153,9 @@ begin
 
   CurrentSound := AudioInputProcessor.Sound[0];
   CurrentSound.AnalyzeBuffer;
-  if (CurrentSound.ToneString <> '-') then
+  if (CurrentSound.ToneString <> '-') and
+     ((GetTimeFromBeat(CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat) -
+       GetTimeFromBeat(CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat)) <> 0) then
   begin
     Count := trunc((720 / (GetTimeFromBeat(CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat) - GetTimeFromBeat(CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat)))*(AudioPlayback.Position - GetTimeFromBeat(CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat)));
     DrawPlayerTrack(CurrentSound.Tone, Count, CurrentNote[CurrentTrack]);

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -6154,8 +6154,7 @@ begin
   CurrentSound := AudioInputProcessor.Sound[0];
   CurrentSound.AnalyzeBuffer;
   if (CurrentSound.ToneString <> '-') and
-     ((GetTimeFromBeat(CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat) -
-       GetTimeFromBeat(CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat)) <> 0) then
+     CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].HasLength() then
   begin
     Count := trunc((720 / (GetTimeFromBeat(CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].EndBeat) - GetTimeFromBeat(CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat)))*(AudioPlayback.Position - GetTimeFromBeat(CurrentSong.Tracks[CurrentTrack].Lines[CurrentSong.Tracks[CurrentTrack].CurrentLine].Notes[0].StartBeat)));
     DrawPlayerTrack(CurrentSound.Tone, Count, CurrentNote[CurrentTrack]);


### PR DESCRIPTION
As reported in #1347, the editor may crash on some systems when opening a line with a 0-length note and having mic input.

While I have not been able to reproduce this on Windows 11, the code looks suspicious as it has a potential division by zero. This PR just skips the code part (draw the mic input) if it would divide by zero on that path. With this, I hope, it fixes #1347. But it is a reasonable change either way, we should get rid of potential div by zeros.