### PR TITLE
Fix cursor state toggling (during medleys)

### DIFF
--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -511,6 +511,7 @@ begin
               if SwitchVideoMode(Mode_Fullscreen) = Mode_Fullscreen then Ini.FullScreen := 1
               else Ini.FullScreen := 0;
               Ini.Save();
+              Display.SetCursor;
 
               Break;
             end;
@@ -578,9 +579,8 @@ begin
                   Ini.FullScreen := 0;
                 end;
                 Ini.Save();
+                Display.SetCursor;
               end;
-
-              //Display.SetCursor;
 
               //glViewPort(0, 0, ScreenW, ScreenH);
             end;

--- a/src/menu/UDisplay.pas
+++ b/src/menu/UDisplay.pas
@@ -45,6 +45,11 @@ uses
   UHookableEvent;
 
 type
+  TCursorScreenHideMode = (
+    cshDefault,
+    cshIgnoreSingScreen
+  );
+
   TDisplay = class
     private
       ePreDraw: THookableEvent;
@@ -116,7 +121,7 @@ type
       function ParseMouse(MouseButton: integer; BtnDown: boolean; X, Y: integer): boolean;
 
       { sets SDL_ShowCursor depending on options set in Ini }
-      procedure SetCursor;
+      procedure SetCursor(ScreenHideMode: TCursorScreenHideMode = cshDefault);
 
       { called when cursor moves, positioning of software cursor }
       procedure MoveCursor(X, Y: double);
@@ -490,47 +495,32 @@ begin
 end;
 
 { sets SDL_ShowCursor depending on options set in Ini }
-procedure TDisplay.SetCursor;
+procedure TDisplay.SetCursor(ScreenHideMode: TCursorScreenHideMode);
 var
   Cursor: Integer;
 begin
   Cursor := 0;
 
-  if (CurrentScreen <> @ScreenSing) or (Cursor_HiddenByScreen) then
-  begin // hide cursor on singscreen
+  if (Ini.Mouse = 2) and
+     (Cursor_HiddenByScreen <> ((CurrentScreen = @ScreenSing) and (ScreenHideMode = cshDefault))) then
+  begin
+    Cursor_Visible := false;
+    Cursor_Fade := false;
+  end;
+
+  Cursor_HiddenByScreen := (CurrentScreen = @ScreenSing) and (ScreenHideMode = cshDefault);
+
+  if not Cursor_HiddenByScreen then
+  begin
     if (Ini.Mouse = 0) and (Ini.FullScreen = 0) then
       // show sdl (os) cursor in window mode even when mouse support is off
       Cursor := 1
     else if (Ini.Mouse = 1) then
       // show sdl (os) cursor when hardware cursor is selected
       Cursor := 1;
-
-    if (Ini.Mouse <> 2) then
-      Cursor_HiddenByScreen := false;
-  end
-  else if (Ini.Mouse <> 2) then
-    Cursor_HiddenByScreen := true;
-
+  end;
 
   SDL_ShowCursor(Cursor);
-
-  if (Ini.Mouse = 2) then
-  begin
-    if Cursor_HiddenByScreen then
-    begin
-      // show software cursor
-      Cursor_HiddenByScreen := false;
-      Cursor_Visible := false;
-      Cursor_Fade := false;
-    end
-    else if (CurrentScreen = @ScreenSing) then
-    begin
-      // hide software cursor in singscreen
-      Cursor_HiddenByScreen := true;
-      Cursor_Visible := false;
-      Cursor_Fade := false;
-    end;
-  end;
 end;
 
 { called by MoveCursor and OnMouseButton to update last move and start fade in }

--- a/src/screens/UScreenPopup.pas
+++ b/src/screens/UScreenPopup.pas
@@ -2173,7 +2173,7 @@ begin
      Display.Cursor_HiddenByScreen then
   begin
     CursorForcedVisible := true;
-    Display.SetCursor;
+    Display.SetCursor(cshIgnoreSingScreen);
   end;
 end;
 
@@ -2185,10 +2185,7 @@ begin
   CursorForcedVisible := false;
 
   if (Display <> nil) and (Display.CurrentScreen = @ScreenSing) then
-  begin
-    Display.Cursor_HiddenByScreen := false;
     Display.SetCursor;
-  end;
 end;
 
 procedure TScreenPopupHelp.ClosePopup;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -1385,7 +1385,7 @@ begin
           fShowWebCam:=false;
         end;
   Background.OnFinish;
-  Display.SetCursor;
+  Display.SetCursor(cshIgnoreSingScreen);
 end;
 
 function TScreenSingController.Draw: boolean;


### PR DESCRIPTION
As reported in #1344, there were some cursor state toggling bugs in the game in the context of medleys.

With this PR we
- set singing-screen cursor hiding based on the current screen state instead of toggling the previous state
- add an explicit cursor screen-hide mode for cases where the current screen is still `ScreenSing` but the cursor should follow normal visibility rules
- keep the singing help popup cursor override working without manually mutating `Cursor_HiddenByScreen`

Fixes #1344.


Bugs beyond #1344:
- starting the game in full screen mode and switching to windowed mode --> mouse cursor remains invisible
- starting the game in windowed mode and switching to full-screen mode --> mouse cursor remains visible

I fixed these two cases as well as a second commit