### PR TITLE
Respect START/END for preview fallback

### DIFF
--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -217,6 +217,7 @@ type
     destructor  Destroy; override;
     function    LoadSong(DuetChange: boolean): boolean;
     function    Analyse(const ReadCustomTags: Boolean = false; DuetChange: boolean = false; RapToFreestyle: boolean = false; OutOfBoundsToFreestyle: boolean = false; AudioLength: real = 0; ForceLoadNotes: boolean = false): boolean;
+    procedure   GetPreviewRange(AudioLength: real; out PreviewStartPos, PreviewEndPos: real);
     procedure   SetMedleyMode();
     procedure   Clear();
     function    MD5SongFile(SongFileR: TTextFileStream): string;
@@ -1503,6 +1504,52 @@ begin
     Result := FileLineNo
   else
     Result := -1;
+end;
+
+procedure TSong.GetPreviewRange(AudioLength: real; out PreviewStartPos, PreviewEndPos: real);
+var
+  EffectiveAudioStart:  real;
+  EffectiveAudioEnd:    real;
+  EffectiveAudioLength: real;
+  PreviewOffset:        real;
+begin
+  if (AudioLength <= 0.0) then
+  begin
+    PreviewStartPos := 0.0;
+    PreviewEndPos := 0.0;
+    Exit;
+  end;
+
+  EffectiveAudioStart := EnsureRange(Start, 0.0, AudioLength);
+  if (Finish > 0) then
+    EffectiveAudioEnd := EnsureRange(Finish / 1000.0, 0.0, AudioLength)
+  else
+    EffectiveAudioEnd := AudioLength;
+
+  if (EffectiveAudioEnd <= EffectiveAudioStart) then
+  begin
+    EffectiveAudioStart := 0.0;
+    EffectiveAudioEnd := AudioLength;
+  end;
+
+  PreviewEndPos := EffectiveAudioEnd;
+
+  // PreviewStart is an absolute position in the audio file, but it still
+  // needs to fall inside the part selected by START and END.
+  if ((PreviewStart > 0.0) or HasPreview) and
+     (PreviewStart >= EffectiveAudioStart) and
+     (PreviewStart < EffectiveAudioEnd) then
+  begin
+    PreviewStartPos := PreviewStart;
+    Exit;
+  end;
+
+  EffectiveAudioLength := EffectiveAudioEnd - EffectiveAudioStart;
+  PreviewOffset := EffectiveAudioLength / 4.0;
+  if (PreviewOffset > 120.0) then
+    PreviewOffset := 60.0;
+
+  PreviewStartPos := EffectiveAudioStart + PreviewOffset;
 end;
 
 function TSong.GetMD5: string;

--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -103,6 +103,7 @@ type
 
       BarTime:            cardinal;
       FinishScreenDraw:   boolean;
+      PreviewEnd:         real;
 
       aPlayerScoreScreenTextures: array[1..UIni.IMaxPlayerCount] of TPlayerScoreScreenTexture;
       aPlayerScoreScreenDatas:    array[1..UIni.IMaxPlayerCount] of TPlayerScoreScreenData;
@@ -1140,6 +1141,7 @@ begin
     Log.LogWarn('No Entry for Help-ID ' + ID, 'ScreenScore');
 
   FinishScreenDraw := false;
+  PreviewEnd := 0;
 
   {**
    * Turn backgroundmusic on
@@ -1355,6 +1357,12 @@ function TScreenScore.Draw: boolean;
 var
   PlayerCounter: integer;
 begin
+  if (PreviewEnd > 0) and (AudioPlayback.Position >= PreviewEnd) then
+  begin
+    AudioPlayback.Stop;
+    PreviewEnd := 0;
+  end;
+
 {
   player[0].ScoreInt       := 7000;
   player[0].ScoreLineInt   := 2000;
@@ -1782,6 +1790,7 @@ procedure TScreenSCore.StartPreview;
 var
   select:   integer;
   changed:  boolean;
+  PreviewPos: real;
   PreviewVolume: single;
 begin
   //When Music Preview is activated -> then change music
@@ -1812,13 +1821,12 @@ begin
     if changed then
     begin
       AudioPlayback.Close;
+      PreviewEnd := 0;
 
       if AudioPlayback.Open(CatSongs.Song[select].Path.Append(CatSongs.Song[select].Audio),nil) then
       begin
-        if (CatSongs.Song[select].PreviewStart > 0) then
-          AudioPlayback.Position := CatSongs.Song[select].PreviewStart
-        else
-          AudioPlayback.Position := (AudioPlayback.Length / 4);
+        CatSongs.Song[select].GetPreviewRange(AudioPlayback.Length, PreviewPos, PreviewEnd);
+        AudioPlayback.Position := PreviewPos;
 
         // set preview volume
         PreviewVolume := EnsureRange(Ini.PreviewVolume, 0, 100) / 100;

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -64,6 +64,7 @@ type
 
       PreviewOpened: Integer; // interaction of the Song that is loaded for preview music
                               // -1 if nothing is opened
+      PreviewEnd: real;
 
       isScrolling: boolean;   // true if song flow is about to move
 
@@ -1840,6 +1841,7 @@ begin
   Equalizer := Tms_Equalizer.Create(AudioPlayback, Theme.Song.Equalizer);
 
   PreviewOpened := -1;
+  PreviewEnd := 0;
   isScrolling := false;
 
   fCurrentVideo := nil;
@@ -3127,6 +3129,9 @@ begin
 
   FadeMessage();
 
+  if (PreviewEnd > 0) and (AudioPlayback.Position >= PreviewEnd) then
+    StopMusicPreview;
+
   if isScrolling then
   begin
     dx := SongTarget - SongCurrent;
@@ -3657,15 +3662,7 @@ begin
   begin
     PreviewOpened := Interaction;
 
-    // preview start is either calculated (by finding the chorus) or pre-set, use it
-    if ((Song.PreviewStart > 0.0) or Song.HasPreview) and InRange(Song.PreviewStart, 0.0, AudioPlayback.Length) then
-      PreviewPos := Song.PreviewStart
-    else
-    begin // otherwise, fallback to simple preview calculation
-      PreviewPos := AudioPlayback.Length / 4;
-      // fix for invalid music file lengths
-      if (PreviewPos > 120.0) then PreviewPos := 60.0;
-    end;
+    Song.GetPreviewRange(AudioPlayback.Length, PreviewPos, PreviewEnd);
 
     AudioPlayback.Position := PreviewPos;
   
@@ -3690,6 +3687,7 @@ procedure TScreenSong.StopMusicPreview();
 begin
   // Stop preview of previous song
   AudioPlayback.Stop;
+  PreviewEnd := 0;
 end;
 
 procedure TScreenSong.StartVideoPreview();


### PR DESCRIPTION
### Problem

Fallback previews ignore the effective audio range defined by `#START` and `#END`.

This produces different incorrect behavior depending on the screen:

- Song selection may preview an unrelated position in the full audio file.
- The score screen uses a separate fallback and may start somewhere else again.
- Preview playback can continue beyond `#END` into the next section of a shared audio file.

### Fix

Calculate one effective preview range for both song selection and the score screen:

- Keep an explicit or calculated preview position when it falls inside the effective range.
- Otherwise, choose a fallback position inside the `#START`/`#END` range.
- Use the same preview position on both screens.
- Stop preview playback at `#END`.


Fixes #1353.
Also fixes bugs 1 and 2 from #1397.

### Testing

Created two song entries using the same 100-second generated audio file with different `#START`/`#END` ranges:

[songs.zip](https://github.com/user-attachments/files/31119606/songs.zip)

- Current master previews both at 25 seconds.
- This PR previews the early range at 5 seconds and the late range at 65 seconds.
- Both previews stop at their configured `#END`.

For the file attached to #1397, both screens now use the range from 1071.000 to 1107.810 seconds, start at 1080.2025 seconds, and stop at 1107.810 seconds.