### PR TITLE
let the key K (karaoke mode) toggle through 2 or 3 states depending on user configured vocals volume

### DIFF
--- a/src/base/UIni.pas
+++ b/src/base/UIni.pas
@@ -186,6 +186,7 @@ type
 
       AudioVolume:    integer;
       VocalsVolume:   integer;
+      LastPartialVocalsVolume: integer;
       SfxVolume:      integer;
       BackgroundMusicVolume: integer;
 
@@ -1631,6 +1632,7 @@ begin
 
   AudioVolume  := ReadVolumePercent('Sound', 'AudioVolume', 100);
   VocalsVolume := ReadVolumePercent('Sound', 'VocalsVolume', 100);
+  LastPartialVocalsVolume := ReadVolumePercent('Sound', 'LastPartialVocalsVolume', 0);
   SfxVolume    := ReadVolumePercent('Sound', 'SfxVolume', 100);
   PreviewVolume := ReadVolumePercent('Sound', 'PreviewVolume', 30);
   BackgroundMusicVolume := ReadVolumePercent('Sound', 'BackgroundMusicVolume', 40);
@@ -1951,6 +1953,7 @@ begin
     // Volume Settings
     IniFile.WriteInteger('Sound', 'AudioVolume', AudioVolume);
     IniFile.WriteInteger('Sound', 'VocalsVolume', VocalsVolume);
+    IniFile.WriteInteger('Sound', 'LastPartialVocalsVolume', LastPartialVocalsVolume);
     IniFile.WriteInteger('Sound', 'SfxVolume', SfxVolume);
     IniFile.WriteInteger('Sound', 'BackgroundMusicVolume', BackgroundMusicVolume);
     IniFile.WriteInteger('Sound', 'PreviewVolume', PreviewVolume);

--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -669,7 +669,8 @@ function  AudioInput(): IAudioInput;
 function  AudioDecoders(): TInterfaceList;
 
 procedure SetAudioVolumePercent(Value: integer);
-procedure SetVocalsVolumePercent(Value: integer);
+procedure SetVocalsVolumePercent(Value: integer; UpdatePartialVolume: boolean = false);
+procedure ToggleVocalsVolume;
 procedure SetSfxVolumePercent(Value: integer);
 procedure SetPreviewVolumePercent(Value: integer);
 procedure SetBackgroundMusicVolumePercent(Value: integer);
@@ -818,7 +819,7 @@ begin
     Playback.SetVolume(Clamped / 100);
 end;
 
-procedure SetVocalsVolumePercent(Value: integer);
+procedure SetVocalsVolumePercent(Value: integer; UpdatePartialVolume: boolean);
 var
   Clamped: integer;
   Playback: IAudioPlayback;
@@ -831,9 +832,35 @@ begin
     Clamped := Value;
 
   Ini.VocalsVolume := Clamped;
+  if UpdatePartialVolume then
+    Ini.LastPartialVocalsVolume := Clamped;
+
   Playback := AudioPlayback();
   if assigned(Playback) then
     Playback.SetVocalsBalance(Clamped / 100);
+end;
+
+procedure ToggleVocalsVolume;
+var
+  TargetPercent: integer;
+  VolumeChanged: boolean;
+begin
+  if Ini.VocalsVolume >= 100 then
+  begin
+    TargetPercent := Ini.LastPartialVocalsVolume;
+    if (TargetPercent <= 0) or (TargetPercent >= 100) then
+      TargetPercent := 0;
+  end
+  else if Ini.VocalsVolume > 0 then
+    TargetPercent := 0
+  else
+    TargetPercent := 100;
+
+  VolumeChanged := Ini.VocalsVolume <> TargetPercent;
+  SetVocalsVolumePercent(TargetPercent, false);
+
+  if VolumeChanged then
+    Ini.Save;
 end;
 
 procedure SetSfxVolumePercent(Value: integer);

--- a/src/media/UAudioPlaybackBase.pas
+++ b/src/media/UAudioPlaybackBase.pas
@@ -351,24 +351,8 @@ begin
 end;
 
 procedure TAudioPlaybackBase.ToggleKaraoke;
-var
-  TargetPercent: integer;
-  VolumeChanged: boolean;
 begin
-  if not assigned(KaraokeMusicStream) then
-    Exit;
-
-  if FVocalsShare > 0.5 then
-    TargetPercent := 0
-  else
-    TargetPercent := 100;
-
-  VolumeChanged := Ini.VocalsVolume <> TargetPercent;
-  Ini.VocalsVolume := TargetPercent;
-  SetVocalsBalance(TargetPercent / 100);
-
-  if VolumeChanged then
-    Ini.Save;
+  ToggleVocalsVolume;
 end;
 
 procedure TAudioPlaybackBase.Stop;

--- a/src/media/UMedia_dummy.pas
+++ b/src/media/UMedia_dummy.pas
@@ -219,6 +219,7 @@ end;
 
 procedure TAudio_Dummy.ToggleKaraoke;
 begin
+  ToggleVocalsVolume;
 end;
 
 procedure TAudio_Dummy.Pause;

--- a/src/screens/UScreenOptionsSound.pas
+++ b/src/screens/UScreenOptionsSound.pas
@@ -51,7 +51,7 @@ type
     SfxVolumeSelectId: integer;
     PreviewVolumeSelectId: integer;
     function AddVolumeSlider(const Text: UTF8String; var Data: integer): integer;
-    procedure ApplyRealtimeSoundSettings;
+    procedure ApplyRealtimeSoundSettings(UpdatePartialVocalsVolume: boolean = false);
     function IsVolumeSlider(SelectId: integer): boolean;
     function CurrentVolumeSelectId: integer;
     function StepVolumeSlider(Delta: integer): boolean;
@@ -115,8 +115,12 @@ type
 
 function TScreenOptionsSound.ParseInput(PressedKey: cardinal;
   CharCode: UCS4Char; PressedDown: boolean): boolean;
+var
+  PrevVocalsVolume: integer;
 begin
   Result := true;
+  PrevVocalsVolume := Ini.VocalsVolume;
+
   if (PressedDown) then
   begin // Key Down
     case PressedKey of
@@ -138,6 +142,13 @@ begin
       SDLK_TAB:
       begin
         ScreenPopupHelp.ShowPopup();
+      end;
+      SDLK_K:
+      begin
+        ToggleVocalsVolume;
+        AudioPlayback.PlaySound(SoundLib.Option);
+        SyncVolumeSlidersFromIni;
+        Exit;
       end;
       SDLK_RETURN:
       begin
@@ -182,14 +193,17 @@ begin
     end;
   end;
 
-  ApplyRealtimeSoundSettings;
+  ApplyRealtimeSoundSettings(Ini.VocalsVolume <> PrevVocalsVolume);
   SyncVolumeSlidersFromIni;
 end;
 
 function TScreenOptionsSound.ParseMouse(MouseButton: integer; BtnDown: boolean; X, Y: integer): boolean;
+var
+  PrevVocalsVolume: integer;
 begin
+  PrevVocalsVolume := Ini.VocalsVolume;
   Result := inherited ParseMouse(MouseButton, BtnDown, X, Y);
-  ApplyRealtimeSoundSettings;
+  ApplyRealtimeSoundSettings(Ini.VocalsVolume <> PrevVocalsVolume);
   SyncVolumeSlidersFromIni;
 end;
 
@@ -332,13 +346,13 @@ begin
   Result := true;
 end;
 
-procedure TScreenOptionsSound.ApplyRealtimeSoundSettings;
+procedure TScreenOptionsSound.ApplyRealtimeSoundSettings(UpdatePartialVocalsVolume: boolean);
 var
   MusicOptionValue: integer;
 begin
   SetAudioVolumePercent(Ini.AudioVolume);
 
-  SetVocalsVolumePercent(Ini.VocalsVolume);
+  SetVocalsVolumePercent(Ini.VocalsVolume, UpdatePartialVocalsVolume);
 
   SetSfxVolumePercent(Ini.SfxVolume);
 

--- a/src/screens/UScreenPopup.pas
+++ b/src/screens/UScreenPopup.pas
@@ -1602,7 +1602,10 @@ begin
       SDLK_K:
         begin
           ApplyVolumeChanges(PrevAudio, PrevVocals, PrevSfx, PrevPreview);
-          ShowPopup(ResumeSingAfterPopup);
+          ToggleVocalsVolume;
+          SyncVolumeSliders;
+          if ScreenOptionsSound <> nil then
+            ScreenOptionsSound.SyncVolumeSlidersFromIni;
           Exit;
         end;
 
@@ -1944,7 +1947,7 @@ begin
 
   if VolumeVocalsIndex <> PrevVocals then
   begin
-    SetVocalsVolumePercent(EnsureRange(VolumeVocalsIndex, 0, 100));
+    SetVocalsVolumePercent(EnsureRange(VolumeVocalsIndex, 0, 100), true);
     VolumeChanged := true;
   end;
 


### PR DESCRIPTION
Hopefully addresses #1360.

This PR:
- persists the user-selected vocals slider value as `LastPartialVocalsVolume`
- keeps `K` toggle vocals between `100%` and `0%` by default
- if the save partial volume is not 0 or 100, it uses a 3-step cycle, `100% -> saved partial volume -> 0% -> 100%`
- makes sure `K` also works from the TAB popup and Sound Options screen, with visible slider updates
- applies the toggle at the settings level even when no karaoke/instrumental stream is active


