### PR TITLE
Fix playlist selection after singing

### DIFF
--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -79,6 +79,8 @@ type
       LastChangeSoundTime: integer;
       LastScrollStopTime: integer;
 
+      SongReturnPending: boolean; // song selection is pending a return from singing
+
       RandomSongOrder: CardinalArray;
       NextRandomSongIdx: cardinal;
       RandomSearchOrder: CardinalArray;
@@ -287,6 +289,7 @@ type
 
       //procedures for Menu
       procedure StartSong;
+      procedure MarkSongStarted;
       procedure OpenEditor;
       procedure DoJoker(Team: integer; SDL_ModState: Word);
       procedure SelectPlayers;
@@ -1955,6 +1958,8 @@ begin
   LastChangeSoundTime := 0;
   LastScrollStopTime := 0;
 
+  SongReturnPending := false;
+
   NextRandomSongIdx := High(cardinal);
   NextRandomSearchIdx := High(cardinal);
 
@@ -3010,17 +3015,42 @@ end;
 
 procedure TScreenSong.OnShowFinish;
 var
-  NextSongID: Integer;
+  PlaylistItem, TargetSongID, NextSongID: Integer;
+  PlaylistReloaded, PlaylistReapplied: Boolean;
 begin
   DuetChange := false;
   RapToFreestyle := false;
 
   isScrolling := true;
   CoverTime := 10;
+  PlaylistReapplied := false;
 
   if (PlaylistMan.CurPlayList <> -1) then
   begin
-    if PlaylistMan.ReloadPlayList(PlaylistMan.CurPlayList) then
+    PlaylistReloaded := PlaylistMan.ReloadPlayList(PlaylistMan.CurPlayList);
+
+    if SongReturnPending then // restore playlist selection after singing
+    begin
+      TargetSongID := CatSongs.Selected;
+
+      if Assigned(ScreenSing) and ScreenSing.SungToEnd then
+      begin
+        if PlaylistMan.Playlists[PlaylistMan.CurPlayList].FixedOrder then // continues with the next playlist item
+        begin
+          PlaylistItem := PlaylistMan.GetIndexbySongID(CatSongs.Selected);
+          if (PlaylistItem <> -1) and
+             (Length(PlaylistMan.Playlists[PlaylistMan.CurPlayList].Items) > 0) then
+            TargetSongID := PlaylistMan.Playlists[PlaylistMan.CurPlayList]
+              .Items[(PlaylistItem + 1) mod Length(PlaylistMan.Playlists[PlaylistMan.CurPlayList].Items)].SongID;
+        end
+        else
+          TargetSongID := -1; // let SetPlayList select a random song
+      end;
+
+      PlaylistMan.SetPlayList(PlaylistMan.CurPlayList, TargetSongID);
+      PlaylistReapplied := true;
+    end
+    else if PlaylistReloaded then
     begin
       NextSongID := SongIndex;
       if (NextSongID = -1) then
@@ -3029,16 +3059,21 @@ begin
         NextSongID := Interaction;
 
       PlaylistMan.SetPlayList(PlaylistMan.CurPlayList, NextSongID);
+      PlaylistReapplied := true;
     end;
   end;
+
+  SongReturnPending := false;
 
   FilterDuetsInPartyMode; // in party mode
 
   if (Mode = smPartyClassic) then
     SelectRandomSong;
 
-  SetScrollRefresh;
   FixSelected;
+  if PlaylistReapplied then
+    SetScroll; // update row position before refresh
+  SetScrollRefresh;
   //if (Mode = smPartyTournament) then
   //  PartyTime := SDL_GetTicks();
 
@@ -4140,6 +4175,11 @@ begin
   StopMusicPreview();
 
   FadeTo(@ScreenSing);
+end;
+
+procedure TScreenSong.MarkSongStarted;
+begin
+  SongReturnPending := (Mode = smNormal); // only normal mode returns to song selection
 end;
 
 procedure TScreenSong.SelectPlayers;

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -728,6 +728,7 @@ begin
   if (ScreenSong.Mode = smMedley) then
     CatSongs.Selected := PlaylistMedley.Song[PlaylistMedley.CurrentMedleySong-1];
 
+  ScreenSong.MarkSongStarted;
   CurrentSong := CatSongs.Song[CatSongs.Selected];
 
   {for I := 0 to High(screenSingViewRef.StaticDuet) do


### PR DESCRIPTION
### Problem

After completing a song from a playlist, the selected entry does not change.

The intended playlist behavior is:

- Fixed-order playlist: select the next entry after completing a song.
- Non-fixed playlist: select a random entry after completing a song.
- Cancelled song: retain the current entry.

### Fix

Track whether the song screen is being entered after actually starting a song, then reapply the active playlist with the appropriate target:

- Advance to the next entry for completed fixed-order songs.
- Select a random entry for completed non-fixed songs.
- Keep the current entry when singing is cancelled.
- Realign the viewport before refreshing the selected row.
- Apply this only in normal mode, not medleys or party mode.

This addresses the remaining playlist-return behavior reported in #1270. The list-view mouse hitboxes and tag refresh are handled separately by #1273.

### Testing

Reproduced on current master with list view and a fixed-order playlist:

- Complete entry 3 and return from the score screen.
- Current master **keeps entry 3 selected**.
- **This PR selects entry 4**.