### PR TITLE
Initialize players before song score lookup

### DIFF
--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -2954,6 +2954,15 @@ begin
   if Ini.Players <= 3 then PlayersPlay := Ini.Players + 1;
   if Ini.Players  = 4 then PlayersPlay := 6;
 
+  // The player-selection screen normally initializes Player. When players are
+  // selected after the song, however, the song screen is shown first.
+  SetLength(Player, PlayersPlay);
+  for I := 0 to PlayersPlay - 1 do
+  begin
+    Player[I].Name := Ini.Name[I];
+    Player[I].Level := Ini.PlayerLevel[I];
+  end;
+
   //Cat Mod etc
   if (Ini.TabsAtStartup = 1) and (CatSongs.CatNumShow = -1) then
   begin


### PR DESCRIPTION
**Problem**: High scores are initially only displayed for difficulty "Easy" when **On Song Click** is set to **Select Players**.

Commit da4138909 changed the song score lookup from `Ini.PlayerLevel[0]` to `Player[0].Level`.

When players are selected after choosing a song, the song-selection screen opens before the player-selection screen has initialized the global `Player` array. Consequently, the score lookup uses the zero-initialized difficulty.

After selecting players or singing once, `Player` is initialized and the scores appear normally.

As a fix, this PR initializes the active players, names, and difficulty levels from the saved configuration when the song-selection screen opens.

Tested on Windows 11 but I don't see any platform specifics here.