### PR TITLE
Freestyle-Rap Changes 1: Reduce rap note score weight

### DIFF
--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -74,12 +74,13 @@ type
   end;
 
 const
-  // ScoreFactor defines how a notehit of a specified notetype is
-  // measured in comparison to the other types
-  // 0 means this notetype is not rated at all
-  // 2 means a hit of this notetype will be rated w/ twice as much
-  // points as a hit of a notetype w/ ScoreFactor 1
-  ScoreFactor:         array[TNoteType] of integer = (0, 1, 2, 1, 2);
+  // ScoreFactor defines how a note hit of a specified note type is
+  // weighted in comparison to the other types. The common scale of four
+  // keeps the values integral while allowing rap notes to be worth 25%
+  // of pitched notes. Golden notes retain their double-value bonus.
+  //
+  // Freestyle, Normal, Golden, Rap, RapGolden
+  ScoreFactor:         array[TNoteType] of integer = (0, 4, 8, 1, 2);
 
 type
   (**


### PR DESCRIPTION
Currently, rap notes are scored the same as regular notes:

- Normal note: 100%
- Golden note: 200%
- Rap note: 100%
- Golden rap note: 200%
- Freestyle note: 0%

Rap notes accept any valid detected pitch and are therefore easier to hit than pitch-sensitive notes. Reducing their relative weight prevents long rap sections from disproportionately determining the result of mixed songs.

This PR changes the weights to:

- Normal note: 100%
- Golden note: 200%
- Rap note: 25%
- Golden rap note: 50%
- Freestyle note: 0%

For a song with just rap notes, everything stays as is. For a song without rap notes, everything stays as is. Just for songs with both, this scales down the rap part. The maximum score of 10000 remains unchanged, it just shifts the points towards normal and golden notes.