### PR TITLE
Fix uninitialized avatar load result (#1296 regression)

### DIFF
--- a/src/base/UAvatars.pas
+++ b/src/base/UAvatars.pas
@@ -367,6 +367,7 @@ var
   Filename: IPath;
   Table: TSQLiteUniTable;
 begin
+  Result := nil;
   Table := nil;
 
   try


### PR DESCRIPTION
**Problem**
Since #1296 was merged, `TAvatarDatabase.LoadAvatar` assigns its class-valued `Result` only inside a `try` block. If the database query or a field conversion raises first, the exception is logged and the function returns without an explicit result. A class variable is a reference; declaring it does not construct an object. See the [Free Pascal class-instantiation documentation](https://www.freepascal.org/docs-html/ref/refse38.html).

**Fix**

Initialize `Result := nil` before entering the failure-prone block. This is a one-line change and preserves every successful return path.

**Reproduce/verify**

Make the avatar query fail (for example, temporarily request a missing/corrupt thumbnail row) and call `LoadAvatar`. Before the fix the returned reference is not defined by the function; after it the failure contract is deterministically `nil`. Tested on Windows 11.