### PR TITLE
Use the PCM buffer format for projectM conversion (#1296 regression)

### DIFF
--- a/src/media/UVisualizer.pas
+++ b/src/media/UVisualizer.pas
@@ -345,7 +345,7 @@ end;
 
 constructor TVideo_ProjectM.Create(ProjectM: TVideoPlayback_ProjectM);
 var
-  SrcFormat: TAudioFormatInfo;
+  PlaybackFormat, SrcFormat: TAudioFormatInfo;
 begin
   inherited Create;
   self.ProjectM := ProjectM;
@@ -355,17 +355,28 @@ begin
   // The ProjectM documentation recommends that all audio samples be provided in 32 bit float format. They do
   // accept 16 bit signed integer, but will just convert it to 32 bit float interally. We will do the
   // conversion instead, because with FFmpeg we will likely get faster results due to the assembly optimization
-  SrcFormat := AudioPlayback.GetFormatInfo();
-  if (SrcFormat <> nil) then
+  PlaybackFormat := AudioPlayback.GetFormatInfo();
+  if (PlaybackFormat <> nil) then
   begin
-    DstFormat := TAudioFormatInfo.Create(Min(SrcFormat.Channels, 2), SrcFormat.SampleRate, asfFloat);
-    AudioConverter := TAudioConverter_SWResample.Create;
-    AudioConverter.Init(SrcFormat, DstFormat);
-    SetLength(fAudioData, AudioConverter.GetOutputBufferSize(SizeOf(TPCMData)) div SizeOf(single));
-    if (DstFormat.Channels = 1) then
-      Channels := PROJECTM_MONO
-    else
-      Channels := PROJECTM_STEREO;
+    // GetPCMData always returns interleaved signed 16-bit stereo frames,
+    // independently of the source file's native format.
+    SrcFormat := TAudioFormatInfo.Create(2, PlaybackFormat.SampleRate, asfS16);
+    try
+      DstFormat := TAudioFormatInfo.Create(2, PlaybackFormat.SampleRate, asfFloat);
+      AudioConverter := TAudioConverter_SWResample.Create;
+      if (AudioConverter.Init(SrcFormat, DstFormat)) then
+      begin
+        SetLength(fAudioData, AudioConverter.GetOutputBufferSize(SizeOf(TPCMData)) div SizeOf(single));
+        Channels := PROJECTM_STEREO;
+      end
+      else
+      begin
+        FreeAndNil(AudioConverter);
+        FreeAndNil(DstFormat);
+      end;
+    finally
+      SrcFormat.Free;
+    end;
   end;
 end;
 
@@ -514,6 +525,7 @@ procedure TVideo_ProjectM.GetFrame(Time: Extended);
 var
   nSamples: cardinal;
   nBytes: integer;
+  ConvertedBytes: integer;
   Data: TPCMData;
 begin
   if (fState <> pmPlay) then
@@ -529,11 +541,11 @@ begin
     if (nSamples = 0) then
       nSamples := GetRandomPCMData(Data);
     nBytes := nSamples * SizeOf(TPCMStereoSample);
-    AudioConverter.Convert(PByteArray(@Data[0]), PByteArray(fAudioData), nBytes);
+    ConvertedBytes := AudioConverter.Convert(PByteArray(@Data[0]), PByteArray(fAudioData), nBytes);
 
     // send audio-data to projectM
-    if (nSamples > 0) then
-      ProjectM.AddAudioSamples(PSingle(fAudioData), nSamples, Channels);
+    if (ConvertedBytes > 0) then
+      ProjectM.AddAudioSamples(PSingle(fAudioData), ConvertedBytes div DstFormat.FrameSize, Channels);
   end;
 
   // let projectM render a frame


### PR DESCRIPTION
**Problem**
This is also something that changed with #1296: `TPCMData` is locally declared as 512 frames of two `SmallInt` samples, so `GetPCMData` supplies interleaved signed-16-bit stereo regardless of the source file's native channel count (YouTube sometimes gives you 4 channel or 5.1 channel audio files!). The old converter was initialized with `AudioPlayback.GetFormatInfo`, which describes the source file instead. For a six-channel source, 2048 input bytes are interpreted as only about 170 source frames, but `projectm_pcm_add_float` is still told to read as many as 512 stereo float frames from the smaller converted buffer. That can read beyond `fAudioData`; mono input is also interpreted with the wrong layout.

**Fix**

Describe the converter input as stereo S16, keep only the playback sample rate, require successful converter initialization, size the output buffer from that format, and pass projectM the number of frames actually returned by conversion. The projectM API's audio entry points are documented in its [public audio header](https://github.com/projectM-visualizer/projectm/blob/master/src/api/include/projectM-4/audio.h).

**Reproduce/verify**

Enable projectM and play a mono and then a 5.1/7.1 source while running with range/heap checking or an address sanitizer. Before the fix the converter layout/count is wrong wrt. `TPCMData`; after it both sides are stereo and the submitted frame count is derived from converted bytes. Tested on Windows 11.
