### PR TITLE
Fix triangle vertex buffer size (#1296 regression)

### DIFF
--- a/src/base/URenderer_OpenGL.pas
+++ b/src/base/URenderer_OpenGL.pas
@@ -654,7 +654,8 @@ end;
 function TRenderer_OpenGLBase.GetArrayBuffer(var Bytes: GLuint): PGLfloat;
 begin
   glBindBuffer(GL_ARRAY_BUFFER, VBO);
-  Bytes := Max(QUAD_STRIDE_BYTES, Bytes + Bytes mod QUAD_STRIDE_BYTES);
+  Bytes := QUAD_STRIDE_BYTES *
+    Max(1, (Bytes + QUAD_STRIDE_BYTES - 1) div QUAD_STRIDE_BYTES);
   if (GLuint(VBOCursor) * SizeOf(GLfloat) + Bytes >= VBO_SIZE) then
   begin
     glBufferData(GL_ARRAY_BUFFER, VBO_SIZE, nil, GL_STREAM_DRAW);
@@ -1076,7 +1077,7 @@ begin
   end;
 
   // Map VBO to system memory
-  Bytes := VERTEX_STRIDE_BYTES * NumTriangles;
+  Bytes := VERTEX_STRIDE_BYTES * 3 * NumTriangles;
   Buffer := GetArrayBuffer(Bytes);
 
   // Fill in VBO mapped memory with vertex information


### PR DESCRIPTION
**Problem**
This is maybe the most straight-forward bug introduced in #1296: One renderer vertex is 9 floats = 36 bytes. A triangle therefore needs 27 floats = 108 bytes, but `DrawTriangles` requested only `36 * NumTriangles` bytes and then wrote `108 * NumTriangles`. With two triangles the old allocator returns 144 bytes and the loop writes 216 bytes: a deterministic 72-byte CPU-side overflow. Four triangles request 144 bytes and write 432 bytes.

**Fix**
Request `TRIANGLE_STRIDE * SizeOf(GLfloat) * NumTriangles`, rounded up to the renderer's 144-byte quad boundary.

**Reproduce/verify**
Call `DrawTriangles` with two triangles under range checking or instrument the requested/written byte counts. Expected before: 144 requested versus 216 written. Expected after: 288 requested versus 216 written. Tested on Windows 11.