### PR TITLE
Release projectM handle when initialization fails (#1296 regression)

### DIFF
--- a/src/media/UVisualizer.pas
+++ b/src/media/UVisualizer.pas
@@ -206,7 +206,11 @@ begin
     ProjectMPath := Platform.GetGameSharedPath.Append(ProjectMPath);
 
   if (not SetParameters(ProjectMPath.Append('config.inp'))) then
+  begin
+    projectm_destroy(Handle);
+    Handle := nil;
     Exit;
+  end;
   Randomize;
   PresetOrder := RandomPermute(Length(Presets));
   PresetIdx := 0;


### PR DESCRIPTION
**Problem**
With #1296 a lot of projectm-related code changed. After `projectm_create` succeeds, `SetParameters` can fail. The old early exit retained the native handle even though initialization returned false.

**Fix**

Destroy the handle and set it to `nil` on that failure path. No successful path changes.

**Reproduce/verify**
Point projectM at an invalid/missing configuration, then observe create/destroy calls with a debugger, or leak checker, or just add debug statements in there ;) The leak is gone with the fix. Tested on Windos 11.