### PR TITLE
Keep the GLSL version header in GL2 vertex shaders

### DIFF
--- a/src/base/URenderer_OpenGL.pas
+++ b/src/base/URenderer_OpenGL.pas
@@ -1858,7 +1858,7 @@ procedure TRenderer_OpenGL2.GetShaderSource(out MainVertex, MainFragment, TextFr
   function GetVertexShader(const ShaderSource: string): string;
   begin
     Result := GLSL_LEGACY_HEADER + ShaderSource;
-    Result := StringReplace(ShaderSource, '[VTX_IN]', 'attribute', [rfReplaceAll]);
+    Result := StringReplace(Result, '[VTX_IN]', 'attribute', [rfReplaceAll]);
     Result := StringReplace(Result, '[VTX_OUT]', 'varying', [rfReplaceAll]);
   end;
   function GetFragmentShader(const ShaderSource: string): string;


### PR DESCRIPTION
`GetVertexShader` first prepended `#version 110`, then performed its first replacement against the original `ShaderSource` instead of `Result`. That deterministically discarded the header from both GL2 vertex shaders. This PR corrects it to `Result`.