### PR TITLE
Round VBO allocations up to quad boundaries

### DIFF
--- a/src/base/URenderer_OpenGL.pas
+++ b/src/base/URenderer_OpenGL.pas
@@ -654,7 +654,8 @@ end;
 function TRenderer_OpenGLBase.GetArrayBuffer(var Bytes: GLuint): PGLfloat;
 begin
   glBindBuffer(GL_ARRAY_BUFFER, VBO);
-  Bytes := Max(QUAD_STRIDE_BYTES, Bytes + Bytes mod QUAD_STRIDE_BYTES);
+  Bytes := QUAD_STRIDE_BYTES *
+    Max(1, (Bytes + QUAD_STRIDE_BYTES - 1) div QUAD_STRIDE_BYTES);
   if (GLuint(VBOCursor) * SizeOf(GLfloat) + Bytes >= VBO_SIZE) then
   begin
     glBufferData(GL_ARRAY_BUFFER, VBO_SIZE, nil, GL_STREAM_DRAW);


### PR DESCRIPTION
**Problem**

The old formula adds the remainder instead of the amount missing from the 144-byte boundary. For a 25-point line strip, 200 bytes becomes 256, which is still not divisible by 144. The cursor advances only `256 div 144 = 1` block (144 bytes), so the next unsynchronized mapping overlaps 112 bytes of the mapped range and 56 bytes of vertex data still used by the preceding draw.

**Fix**

Use integer division + ceiling to allocate `144 * max(1, ceil(Bytes / 144))`. The 200-byte example becomes 288 and advances two complete blocks.

**Reproduce/verify**

Debugger + set a breakpoint on two consecutive 25-point `DrawLineStrip` calls. Before: you can read the mapped length 256 in the debugger, next offset 144. After: mapped length 288, next offset 288. The earlier 40-byte example is not a failure because the existing `Max` raises it to one full 144-byte block. Again, not sure the code is using any of this currently but the computation might fail otherwise in the future.