### PR TITLE
Freestyle-Rap Changes 3: Put freestyle-to-rap songs in highscore

### DIFF
--- a/game/languages/English.ini
+++ b/game/languages/English.ini
@@ -1163,7 +1163,7 @@ J = Open search menu
 P = Open playlist menu
 O = Toggle fixed order for current playlist (playlist view)
 R = Jump to random song
-T = Interpret rap notes as freestyle (toggle on/off)
+T = Cycle note handling (normal / rap as freestyle / freestyle as rap)
 E = Load editor for selected song
 W = Web matching
 ;-------------------------------------------------------;
@@ -1242,7 +1242,7 @@ J = Open search menu
 P = Open playlist menu
 O = Toggle fixed order for current playlist (playlist view)
 R = Jump to random song
-T = Interpret rap notes as freestyle (toggle on/off)
+T = Cycle note handling (normal / rap as freestyle / freestyle as rap)
 W = Web matching
 ;-------------------------------------------------------;
 ;SEC_020  Playback
@@ -1281,7 +1281,7 @@ J = Open search menu
 P = Open playlist menu
 O = Toggle fixed order for current playlist (playlist view)
 R = Jump to random song
-T = Interpret rap notes as freestyle (toggle on/off)
+T = Cycle note handling (normal / rap as freestyle / freestyle as rap)
 W = Web matching
 ;-------------------------------------------------------;
 ;SEC_020  Playback

--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -115,7 +115,8 @@ type
     FMD5Cached  : boolean;
 
     function DecodeFilename(Filename: RawByteString): IPath;
-    procedure ParseNote(Track: integer; TypeP: char; StartP, DurationP, NoteP: integer; LyricS: UTF8String; RapToFreestyle: boolean);
+    procedure ParseNote(Track: integer; TypeP: char; StartP, DurationP, NoteP: integer;
+      LyricS: UTF8String; RapToFreestyle, FreestyleToRap: boolean);
     procedure NewSentence(LineNumberP: integer; Param1, Param2: integer);
     procedure FindRefrain(); // tries to find a refrain for the medley mode and preview start
 
@@ -128,7 +129,9 @@ type
     function ReadTXTHeader(SongFile: TTextFileStream; ReadCustomTags: Boolean): boolean;
 
     function GetFolderCategory(const aFileName: IPath): UTF8String;
-    function LoadOpenedSong(SongFile: TTextFileStream; FileNamePath: IPath; DuetChange: boolean; RapToFreestyle: boolean; OutOfBoundsToFreestyle: boolean; AudioLength: real): boolean;
+    function LoadOpenedSong(SongFile: TTextFileStream; FileNamePath: IPath;
+      DuetChange, RapToFreestyle, FreestyleToRap, OutOfBoundsToFreestyle: boolean;
+      AudioLength: real): boolean;
     function GetMD5: string;
     procedure SetMD5(const Value: string);
   public
@@ -189,6 +192,8 @@ type
     DuetNames:  array of UTF8String; // duet singers name
 
     hasRap: boolean;
+    hasFreestyle: boolean;
+    NoteTypesLoaded: boolean;
 
     CustomTags: array of TCustomHeaderTag;
 
@@ -216,7 +221,10 @@ type
     constructor Create(const aFileName : IPath); overload;
     destructor  Destroy; override;
     function    LoadSong(DuetChange: boolean): boolean;
-    function    Analyse(const ReadCustomTags: Boolean = false; DuetChange: boolean = false; RapToFreestyle: boolean = false; OutOfBoundsToFreestyle: boolean = false; AudioLength: real = 0; ForceLoadNotes: boolean = false): boolean;
+    function    Analyse(const ReadCustomTags: Boolean = false; DuetChange: boolean = false;
+      RapToFreestyle: boolean = false; FreestyleToRap: boolean = false;
+      OutOfBoundsToFreestyle: boolean = false; AudioLength: real = 0;
+      ForceLoadNotes: boolean = false): boolean;
     procedure   SetMedleyMode();
     procedure   Clear();
     function    MD5SongFile(SongFileR: TTextFileStream): string;
@@ -617,11 +625,13 @@ begin
   end;
 
   CurrentSong := self;
-  Result := LoadOpenedSong(SongFile, FileNamePath, DuetChange, false, false, 0);
+  Result := LoadOpenedSong(SongFile, FileNamePath, DuetChange, false, false, false, 0);
   SongFile.Free;
 end;
 
-function TSong.LoadOpenedSong(SongFile: TTextFileStream; FileNamePath: IPath; DuetChange: boolean; RapToFreestyle: boolean; OutOfBoundsToFreestyle: boolean; AudioLength: real): boolean;
+function TSong.LoadOpenedSong(SongFile: TTextFileStream; FileNamePath: IPath;
+  DuetChange, RapToFreestyle, FreestyleToRap, OutOfBoundsToFreestyle: boolean;
+  AudioLength: real): boolean;
 var
   CurLine:      RawByteString;
   LinePos:      integer;
@@ -634,6 +644,7 @@ var
   Param2:       integer;
   Param3:       integer;
   ParamLyric:   UTF8String;
+  ConvertFreestyleNote: boolean;
 
   NotesFound:   boolean;
 
@@ -669,6 +680,9 @@ begin
   Mult              := 1; // accuracy of measurement of note
   Rel[0]            := 0;
   Rel[1]            := 0;
+  hasRap            := false;
+  hasFreestyle      := false;
+  NoteTypesLoaded   := false;
 
   try
     SongFile.Position := 0;
@@ -777,11 +791,14 @@ begin
         end
         else if (Param0 in [':', '*', 'F', 'R', 'G']) then
         begin
-          // sets the rap icon if the song has rap notes
-          if(Param0 in ['R', 'G']) then
-          begin
-            Self.hasRap := true;
-          end;
+          // Remember the note types from the file before applying temporary
+          // singing-mode conversions.
+          if Param0 in ['R', 'G'] then
+            Self.hasRap := true
+          else if Param0 = 'F' then
+            Self.hasFreestyle := true;
+          ConvertFreestyleNote := FreestyleToRap and (Param0 = 'F');
+
           // read notes
           Param1 := ParseLyricIntParam(CurLine, LinePos);
           Param2 := ParseLyricIntParam(CurLine, LinePos);
@@ -797,12 +814,14 @@ begin
               'TSong.LoadSong');
             //Log.LogError('Found zero-length note at "'+Param0+' '+IntToStr(Param1)+' '+IntToStr(Param2)+' '+IntToStr(Param3)+ParamLyric+'" -> Note ignored!')
             Param0 := 'F';
+            ConvertFreestyleNote := false;
           end;
 
           if (OutOfBoundsToFreestyle and (((Self.Start > 0) and (GetTimeFromBeat(Param1, Self) < Self.Start)) or ((AudioLength > 0) and (GetTimeFromBeat(Param1 + Param3, Self) >= AudioLength)))) then
           begin
             // convert to freestyle note
             Param0 := 'F';
+            ConvertFreestyleNote := false;
             Log.LogWarn(
               Format('Note at "%s %d %d %d %s" is before audio start (%.2f < %.2f) or after audio end (%.2f >= %.2f) -> converted to freestyle note',
               [Param0, Param1, Param2, Param3, ParamLyric, GetTimeFromBeat(Param1, Self), Self.Start, GetTimeFromBeat(Param1 + Param3, Self), AudioLength]),
@@ -818,7 +837,9 @@ begin
             FileNamePath.ToNative+' Line:'+IntToStr(FileLineNo));
             Break;
           end;
-          ParseNote(CurrentTrack, Param0, (Param1+Rel[CurrentTrack]) * Mult, Param2 * Mult, Param3, ParamLyric, RapToFreestyle);
+          ParseNote(CurrentTrack, Param0, (Param1+Rel[CurrentTrack]) * Mult,
+            Param2 * Mult, Param3, ParamLyric, RapToFreestyle,
+            ConvertFreestyleNote);
         end // if
 
         else
@@ -890,6 +911,7 @@ begin
     NextTrack: ;
   end;
 
+  NoteTypesLoaded := true;
   Result := true;
 end;
 
@@ -1541,7 +1563,8 @@ begin
   FMD5Cached := Value <> '';
 end;
 
-procedure TSong.ParseNote(Track: integer; TypeP: char; StartP, DurationP, NoteP: integer; LyricS: UTF8String; RapToFreestyle: boolean);
+procedure TSong.ParseNote(Track: integer; TypeP: char; StartP, DurationP, NoteP: integer;
+  LyricS: UTF8String; RapToFreestyle, FreestyleToRap: boolean);
 begin
 
   with Tracks[Track].Lines[Tracks[Track].High] do
@@ -1561,7 +1584,13 @@ begin
 
     // back to the normal system with normal, golden and now freestyle notes
     case TypeP of
-      'F':  Notes[HighNote].NoteType := ntFreestyle;
+      'F':
+        begin
+          if FreestyleToRap then
+            Notes[HighNote].NoteType := ntRap
+          else
+            Notes[HighNote].NoteType := ntFreestyle;
+        end;
       ':':  Notes[HighNote].NoteType := ntNormal;
       '*':  Notes[HighNote].NoteType := ntGolden;
       'R':
@@ -1571,7 +1600,13 @@ begin
           else
             Notes[HighNote].NoteType := ntRap;
         end;
-      'G':  Notes[HighNote].NoteType := ntRapGolden;
+      'G':
+        begin
+          if RapToFreestyle then
+            Notes[HighNote].NoteType := ntFreestyle
+          else
+            Notes[HighNote].NoteType := ntRapGolden;
+        end;
     end;
 
     //add this notes value ("notes length" * "notes scorefactor") to the current songs entire value
@@ -1897,6 +1932,9 @@ begin
   Medley.Source := msNone;
 
   isDuet := false;
+  hasRap := false;
+  hasFreestyle := false;
+  NoteTypesLoaded := false;
 
   SetLength(DuetNames, 2);
   DuetNames[0] := 'P1';
@@ -1905,7 +1943,10 @@ begin
   Relative := false;
 end;
 
-function TSong.Analyse(const ReadCustomTags: Boolean; DuetChange: boolean; RapToFreestyle: boolean; OutOfBoundsToFreestyle: boolean; AudioLength: real; ForceLoadNotes: boolean): boolean;
+function TSong.Analyse(const ReadCustomTags: Boolean; DuetChange: boolean;
+  RapToFreestyle: boolean; FreestyleToRap: boolean;
+  OutOfBoundsToFreestyle: boolean; AudioLength: real;
+  ForceLoadNotes: boolean): boolean;
 var
   SongFile: TTextFileStream;
   FileNamePath: IPath;
@@ -1938,7 +1979,8 @@ begin
     begin
       //Load Song for Medley Tags
       CurrentSong := Self;
-      NotesLoaded := LoadOpenedSong(SongFile, FileNamePath, DuetChange, RapToFreestyle, OutOfBoundsToFreestyle, AudioLength);
+      NotesLoaded := LoadOpenedSong(SongFile, FileNamePath, DuetChange,
+        RapToFreestyle, FreestyleToRap, OutOfBoundsToFreestyle, AudioLength);
       Result := Result and NotesLoaded;
     end;
 

--- a/src/base/USongs.pas
+++ b/src/base/USongs.pas
@@ -448,7 +448,7 @@ var
 begin
   Song := TSong.Create(FilePath);
 
-  if Song.Analyse(false, false, false, false, 0, Params.CheckSongs) then
+  if Song.Analyse(false, false, false, false, false, 0, Params.CheckSongs) then
     SongList.Add(Song)
   else
   begin

--- a/src/screens/UScreenEditSub.pas
+++ b/src/screens/UScreenEditSub.pas
@@ -5428,7 +5428,7 @@ begin
 
   try
     // reread header with custom tags
-    Error := not CurrentSong.Analyse(true, false, false, false, 0, true);
+    Error := not CurrentSong.Analyse(true, false, false, false, false, 0, true);
 
     // with the duet/medley code, TSong.Analyse is already loading the song
     //if not Error then

--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -378,7 +378,7 @@ begin
           if (FinishScreenDraw = true) then
           begin
             if (CurrentSong.isDuet) or (ScreenSong.RapToFreestyle) or
-              (ScreenSong.FreestyleToRap) or (ScreenSong.Mode = smMedley) then
+              (ScreenSong.Mode = smMedley) then
               FadeTo(@ScreenSong)
             else
               FadeTo(@ScreenTop5);
@@ -403,7 +403,7 @@ begin
            begin
 
              if (CurrentSong.isDuet) or (ScreenSong.RapToFreestyle) or
-               (ScreenSong.FreestyleToRap) or (ScreenSong.Mode = smMedley) then
+               (ScreenSong.Mode = smMedley) then
                FadeTo(@ScreenSong)
              else
                FadeTo(@ScreenTop5);

--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -377,7 +377,8 @@ begin
         begin
           if (FinishScreenDraw = true) then
           begin
-            if (CurrentSong.isDuet) or (ScreenSong.RapToFreestyle) or (ScreenSong.Mode = smMedley) then
+            if (CurrentSong.isDuet) or (ScreenSong.RapToFreestyle) or
+              (ScreenSong.FreestyleToRap) or (ScreenSong.Mode = smMedley) then
               FadeTo(@ScreenSong)
             else
               FadeTo(@ScreenTop5);
@@ -401,7 +402,8 @@ begin
            if (FinishScreenDraw = true) then
            begin
 
-             if (CurrentSong.isDuet) or (ScreenSong.RapToFreestyle) or (ScreenSong.Mode = smMedley) then
+             if (CurrentSong.isDuet) or (ScreenSong.RapToFreestyle) or
+               (ScreenSong.FreestyleToRap) or (ScreenSong.Mode = smMedley) then
                FadeTo(@ScreenSong)
              else
                FadeTo(@ScreenTop5);

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -4465,7 +4465,7 @@ procedure TScreenSong.SongScore;
 begin
 
   if (CatSongs.Song[Interaction].isDuet) or (RapToFreestyle) or
-    (FreestyleToRap) or ((Mode <> smNormal) or (Ini.ShowScores = 0) or
+    ((Mode <> smNormal) or (Ini.ShowScores = 0) or
     (CatSongs.Song[Interaction].Edition = '') or ((Ini.ShowScores = 1) and
     ((Text[TextMaxScore2].Text = '0') and (Text[TextMaxScoreLocal].Text = '0')))) then
   begin

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -112,6 +112,7 @@ type
       RapIcon:     cardinal;
       RapToFreestyleIcon: cardinal;
       RapToFreestyle: boolean;
+      FreestyleToRap: boolean;
 
       TextCat:   integer;
       StaticCat: integer;
@@ -304,6 +305,7 @@ type
 
       //Medley
       function  EnsureMedleyData(SongIndex: integer; MinSource: TMedleySource): boolean;
+      function  EnsureNoteTypeData(SongIndex: integer): boolean;
       procedure StartMedley(NumSongs: integer; MinSource: TMedleySource);
       function  getVisibleMedleyArr(MinSource: TMedleySource): TVisArr;
 
@@ -363,13 +365,39 @@ begin
   begin
     PreviousSong := CurrentSong;
     try
-      CatSongs.Song[SongIndex].Analyse(false, false, false, false, 0, true);
+      CatSongs.Song[SongIndex].Analyse(false, false, false, false, false, 0, true);
     finally
       CurrentSong := PreviousSong;
     end;
   end;
 
   Result := CatSongs.Song[SongIndex].Medley.Source >= MinSource;
+end;
+
+function TScreenSong.EnsureNoteTypeData(SongIndex: integer): boolean;
+var
+  PreviousSong: TSong;
+begin
+  Result := false;
+
+  if (SongIndex < 0) or (SongIndex > High(CatSongs.Song)) then
+    Exit;
+
+  if CatSongs.Song[SongIndex].Main then
+    Exit;
+
+  if not CatSongs.Song[SongIndex].NoteTypesLoaded then
+  begin
+    PreviousSong := CurrentSong;
+    try
+      CatSongs.Song[SongIndex].Analyse(false, false, false, false,
+        false, 0, true);
+    finally
+      CurrentSong := PreviousSong;
+    end;
+  end;
+
+  Result := CatSongs.Song[SongIndex].NoteTypesLoaded;
 end;
 
 function TScreenSong.FreeListMode: boolean;
@@ -1079,8 +1107,25 @@ begin
         end;
 
       SDLK_T:
-        if CatSongs.Song[Interaction].hasRap then
-          RapToFreestyle := not RapToFreestyle;
+        if EnsureNoteTypeData(Interaction) then
+        begin
+          // Cycle through the three temporary note-handling modes:
+          // unchanged -> rap as freestyle -> freestyle as rap -> unchanged.
+          if RapToFreestyle then
+          begin
+            RapToFreestyle := false;
+            FreestyleToRap := true;
+          end
+          else if FreestyleToRap then
+          begin
+            FreestyleToRap := false;
+          end
+          else
+            RapToFreestyle := true;
+
+          SetScrollRefresh;
+          SongScore;
+        end;
 
       SDLK_W:
         begin
@@ -2128,6 +2173,7 @@ procedure TScreenSong.OnSongDeSelect;
 begin
   DuetChange := false;
   RapToFreestyle := false;
+  FreestyleToRap := false;
 
   CoverTime := 10;
   //UnloadCover(Interaction);
@@ -2205,7 +2251,9 @@ begin
       Statics[DuetIcon].Visible := CatSongs.Song[Interaction].isDuet;
 
       //Set Visibility of Rap Icons
-      Statics[RapIcon].Visible := CatSongs.Song[Interaction].hasRap and not RapToFreestyle;
+      Statics[RapIcon].Visible :=
+        (CatSongs.Song[Interaction].hasRap and not RapToFreestyle) or
+        (CatSongs.Song[Interaction].hasFreestyle and FreestyleToRap);
       Statics[RapToFreestyleIcon].Visible := CatSongs.Song[Interaction].hasRap and RapToFreestyle;
 
       // Set texts
@@ -2818,7 +2866,9 @@ begin
 
     //Set Visibility of Rap Icons
     Statics[ListRapIcon[I]].Texture.Alpha := Alpha;
-    Statics[ListRapIcon[I]].Visible := CatSongs.Song[SongID[I]].hasRap and not RapToFreestyle;
+    Statics[ListRapIcon[I]].Visible :=
+      (CatSongs.Song[SongID[I]].hasRap and not RapToFreestyle) or
+      (CatSongs.Song[SongID[I]].hasFreestyle and FreestyleToRap);
 
     Statics[ListRapToFreestyleIcon[I]].Texture.Alpha := Alpha;
     Statics[ListRapToFreestyleIcon[I]].Visible := CatSongs.Song[SongID[I]].hasRap and RapToFreestyle;
@@ -3014,6 +3064,7 @@ var
 begin
   DuetChange := false;
   RapToFreestyle := false;
+  FreestyleToRap := false;
 
   isScrolling := true;
   CoverTime := 10;
@@ -4413,7 +4464,10 @@ procedure TScreenSong.SongScore;
   end;
 begin
 
-  if (CatSongs.Song[Interaction].isDuet) or (RapToFreestyle) or ((Mode <> smNormal) or (Ini.ShowScores = 0) or (CatSongs.Song[Interaction].Edition = '') or ((Ini.ShowScores = 1) and ((Text[TextMaxScore2].Text = '0') and (Text[TextMaxScoreLocal].Text = '0')))) then
+  if (CatSongs.Song[Interaction].isDuet) or (RapToFreestyle) or
+    (FreestyleToRap) or ((Mode <> smNormal) or (Ini.ShowScores = 0) or
+    (CatSongs.Song[Interaction].Edition = '') or ((Ini.ShowScores = 1) and
+    ((Text[TextMaxScore2].Text = '0') and (Text[TextMaxScoreLocal].Text = '0')))) then
   begin
     hide([
       TextScore, TextMaxScore, TextMediaScore,

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -1066,7 +1066,9 @@ begin
   success := false;
   // FIXME: bad style, put the try-except into loadsong() and not here
   try
-    success := CurrentSong.Analyse(false, ScreenSong.DuetChange, ScreenSong.RapToFreestyle, true, AudioEnd, true); // and CurrentSong.LoadSong();
+    success := CurrentSong.Analyse(false, ScreenSong.DuetChange,
+      ScreenSong.RapToFreestyle, ScreenSong.FreestyleToRap, true,
+      AudioEnd, true); // and CurrentSong.LoadSong();
   except
     on E: EInOutError do Log.LogWarn(E.Message, 'TScreenSing.LoadNextSong');
   end;

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -841,7 +841,8 @@ begin
 
   LastLineSungToEnd := false;
   //the song was sung to the end?
-  if not (ScreenSing.SungToEnd) and not(CurrentSong.isDuet) and not(ScreenSong.RapToFreestyle) then
+  if not (ScreenSing.SungToEnd) and not(CurrentSong.isDuet) and
+    not(ScreenSong.RapToFreestyle) and not(ScreenSong.FreestyleToRap) then
   begin
     Line := ScreenSing.Lyrics.GetUpperLine();
     if Line.LastLine then

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -842,7 +842,7 @@ begin
   LastLineSungToEnd := false;
   //the song was sung to the end?
   if not (ScreenSing.SungToEnd) and not(CurrentSong.isDuet) and
-    not(ScreenSong.RapToFreestyle) and not(ScreenSong.FreestyleToRap) then
+    not(ScreenSong.RapToFreestyle) then
   begin
     Line := ScreenSing.Lyrics.GetUpperLine();
     if Line.LastLine then


### PR DESCRIPTION
## Motivation

Freestyle-to-rap asks players to perform freestyle sections (without checking the pitch) instead of skipping them. This gives players an incentive to perform on the freestyle parts and not just stay quiet during these.

The freestyle-to-rap conversion makes the scoring requirements rather stricter than easier: freestyle notes that previously did not require a performance must be performed as rap notes. Excluding the resulting score is therefore unnecessary - even more so as players explicitly choose to sing it in freestyle-to-rap mode.

## Context

This change originated from a Discord discussion with @complexlogic about scoring freestyle and rap sections and is part of a series of related PRs:

- #1369
- #1370
- this PR: #1385
- #1386

The timing might not be bad for changes around scoring as we just moved from 10s rounding to 1s rounding as a major (breaking) change in scoring.

## Changes

- Allow freestyle-to-rap performances to run through the normal high-score flow
- Show existing highscores while freestyle-to-rap is active
- Keep rap-to-freestyle performances excluded because that conversion removes the scoring requirement from rap notes