### PR TITLE
Reset Note Texture Colors

### DIFF
--- a/src/base/UDraw.pas
+++ b/src/base/UDraw.pas
@@ -756,6 +756,10 @@ begin
             Y := Rec.Top;
             W := Rec.Right - Rec.Left;
             H := Rec.Bottom - Rec.Top;
+            ColR := 1;
+            ColG := 1;
+            ColB := 1;
+            Alpha := 1;
           end;
           Renderer.DrawTexture(Texture);
 
@@ -783,6 +787,10 @@ begin
             Y := Rec.Top;
             W := Rec.Right - Rec.Left;
             H := Rec.Bottom - Rec.Top;
+            ColR := 1;
+            ColG := 1;
+            ColB := 1;
+            Alpha := 1;
             TexX1 := 0;
             TexY1 := 0;
             TexX2 := round((Rec.Right-Rec.Left)/32);
@@ -804,6 +812,10 @@ begin
             Y := Rec.Top;
             W := Rec.Right - Rec.Left;
             H := Rec.Bottom - Rec.Top;
+            ColR := 1;
+            ColG := 1;
+            ColB := 1;
+            Alpha := 1;
           end;
           Renderer.DrawTexture(Texture);
 


### PR DESCRIPTION
This fixes a minor regression introduced in #1296 where the color of the sung note textures can be wrong on the sing screen in an edge case (see screenshot). To reproduce:
1. Open a song in the editor
2. Go to a line where the last note in the line is a golden note
3. Exit the editor and immediately play the song in regular sing mode.

The editor and sing screen share the same note textures. The editor changes the color of the note textures when displaying golden notes, but the sing screen doesn't. This new code resets the color of the texture so it's not affected by the changes the editor makes to it.

<img width="1280" height="720" alt="screen" src="https://github.com/user-attachments/assets/4ffd145a-6891-4d24-a9cf-818b93d77b56" />
