### PR TITLE
improve and unify audio and video preview scheduling

### DIFF
--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -77,14 +77,16 @@ type
 
       LastSelectMouse: integer;
       LastSelectTime: integer;
+      PreviewInteraction: integer;
       LastPreviewStartTime: integer;
       LastChangeSoundTime: integer;
-      LastScrollStopTime: integer;
+      PreviewSettledTime: integer;
 
       RandomSongOrder: CardinalArray;
       NextRandomSongIdx: cardinal;
       RandomSearchOrder: CardinalArray;
 
+      procedure SchedulePreview(SelectionSettled: boolean = false);
       procedure StartMusicPreview();
       procedure StartVideoPreview();
       function GetSongButtonMouseOverArea(ButtonIndex: integer): TMouseOverRect;
@@ -1975,9 +1977,10 @@ begin
 
   LastSelectMouse := 0;
   LastSelectTime := 0;
+  PreviewInteraction := -1;
   LastPreviewStartTime := 0;
   LastChangeSoundTime := 0;
-  LastScrollStopTime := 0;
+  PreviewSettledTime := 0;
 
   NextRandomSongIdx := High(cardinal);
   NextRandomSearchIdx := High(cardinal);
@@ -2139,6 +2142,8 @@ end;
 { called when song flows movement stops at a song }
 procedure TScreenSong.OnSongSelect;
 begin
+  SchedulePreview(true);
+
   // fade in detailed cover
   CoverTime := 0;
 
@@ -2159,6 +2164,9 @@ begin
   StopMusicPreview();
   StopVideoPreview();
   PreviewOpened := -1;
+  PreviewInteraction := -1;
+  LastPreviewStartTime := 0;
+  PreviewSettledTime := 0;
 
   //SetScrollRefresh;
 end;
@@ -2968,6 +2976,9 @@ begin
   PreviewOpened := -1;
   DuetChange := false;
   RapToFreestyle := false;
+  PreviewInteraction := -1;
+  LastPreviewStartTime := 0;
+  PreviewSettledTime := 0;
 
   // reset video playback engine
   fCurrentVideo := nil;
@@ -3129,6 +3140,9 @@ begin
 
   FadeMessage();
 
+  // Use the same preview scheduling for every way Interaction can change.
+  SchedulePreview;
+
   if (PreviewEnd > 0) and (AudioPlayback.Position >= PreviewEnd) then
     StopMusicPreview;
 
@@ -3146,18 +3160,28 @@ begin
     begin
       isScrolling := false;
       SongCurrent := SongTarget;
-      LastScrollStopTime := SDL_GetTicks;
       OnSongSelect;
     end;
   end;
 
-  // Check if we need to start preview after debounce period
-  if (not isScrolling) and (Ini.PreviewVolume <> 0) and
+  // Audio should react quickly, independently of the cover-scroll animation.
+  if (Ini.PreviewVolume <> 0) and
      (PreviewOpened <> Interaction) and  // No preview loaded for current song
-     (LastScrollStopTime > 0) and
-     (SDL_GetTicks - LastScrollStopTime >= PREVIEW_DEBOUNCE_MS) then
+     (LastPreviewStartTime > 0) and
+     (SDL_GetTicks - LastPreviewStartTime >= PREVIEW_DEBOUNCE_MS) then
   begin
+    LastPreviewStartTime := 0;
     StartMusicPreview;
+  end;
+
+  // Video opening may block the render thread, so wait until the screen
+  // transition and selection movement have finished.
+  if ShowFinish and (not isScrolling) and (Ini.PreviewVolume <> 0) and
+     (PreviewOpened = Interaction) and
+     (PreviewSettledTime > 0) and
+     (SDL_GetTicks - PreviewSettledTime >= PREVIEW_DEBOUNCE_MS) then
+  begin
+    PreviewSettledTime := 0;
     StartVideoPreview;
   end;
 
@@ -3632,6 +3656,19 @@ begin
   end;
 end;
 
+procedure TScreenSong.SchedulePreview(SelectionSettled: boolean);
+begin
+  if PreviewInteraction <> Interaction then
+  begin
+    PreviewInteraction := Interaction;
+    LastPreviewStartTime := SDL_GetTicks;
+    PreviewSettledTime := 0;
+  end;
+
+  if SelectionSettled then
+    PreviewSettledTime := SDL_GetTicks;
+end;
+
 procedure TScreenSong.StartMusicPreview();
 var
   Song: TSong;
@@ -3748,8 +3785,10 @@ begin
   StopMusicPreview();
   StopVideoPreview();
   PreviewOpened := -1;
-  StartMusicPreview();
-  StartVideoPreview();
+  PreviewInteraction := -1;
+  LastPreviewStartTime := 0;
+  PreviewSettledTime := 0;
+  SchedulePreview(not isScrolling);
 end;
 
 procedure TScreenSong.SkipTo(Target: cardinal; TargetInteraction: integer = -1; VS: integer = -1);


### PR DESCRIPTION
Preview startup previously used different timing paths depending on how the song selection changed. Mouse navigation could trigger synchronous video initialization during the cover animation, while returning to song selection could open the video during the screen transition.

This PR introduces shared preview scheduling for mouse, keyboard, playlist, and jump-to selection changes:
- Audio preview starts after a 150 ms debounce without waiting for selection animations.
- Video preview starts after the selection has settled and the screen transition has finished, followed by the same 150 ms debounce.
- Selecting another song cancels and restarts pending preview startup.
- Preview changes no longer open audio or video synchronously.

This should fix both the mouse slowdown reported in #1390 and the choppy screen transition reported in #1207. It also removes the keyboard's accidental roughly one-second wait before starting audio. The configured preview fade duration remains unchanged.

I cannot reproduce the original slowdown / choppiness from #1390 and #1207 locally, but locally the updated behavior looks fine.