### PR TITLE
Fix crash after returning from fixed playlists

### DIFF
--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -2117,6 +2117,7 @@ end;
 procedure TScreenSong.SyncCoversToSongs();
 var
   B: integer;
+  CoverFile: IPath;
 begin
   if (Length(Button) = 0) or (Length(CatSongs.Song) = 0) then
     Exit;
@@ -2127,6 +2128,19 @@ begin
       Break;
 
     UnloadCover(B);
+
+    // Refresh creates new category songs without initialized cover textures.
+    if not Assigned(CatSongs.Song[B].CoverTex) then
+    begin
+      CoverFile := CatSongs.Song[B].Path.Append(CatSongs.Song[B].Cover);
+      if not CoverFile.IsFile() then
+        CatSongs.Song[B].Cover := PATH_NONE;
+
+      if CatSongs.Song[B].Cover.IsUnset then
+        CoverFile := Skin.GetTextureFileName('SongCover');
+
+      CatSongs.Song[B].CoverTex := Renderer.CreateEmptyTexture(CoverFile);
+    end;
 
     Button[B].Texture.Free();
     Button[B].Texture := CatSongs.Song[B].CoverTex.Clone();


### PR DESCRIPTION
Fixes #1391.

When returning from a fixed-order playlist with song tabs enabled, restoring the original song order refreshes the categories. The newly created category entries do not have a cover texture yet, but `SyncCoversToSongs` tries to clone it anyway, causing the crash.

So we need to initialize missing category cover textures before syncing them to the song buttons.

The crash can be reproduced with `Tabs=On` by opening a fixed-order playlist, singing a song, and returning from the score screen. The same flow no longer crashes with this change.