### PR TITLE
Fix potential video texture corruption

### DIFF
--- a/src/media/UVideo.pas
+++ b/src/media/UVideo.pas
@@ -587,7 +587,7 @@ begin
     end;
   end;
   FreeAndNil(fFrameTex);
-  fFrameTex := Renderer.CreateTexture(nil, PATH_NONE, fTexWidth, fTexHeight, VIDEO_TEXTURE_TYP);
+  fFrameTex := Renderer.CreateTexture(nil, PATH_NONE, fTexWidth, fTexHeight, VIDEO_TEXTURE_TYP, false);
 
   // allocate space for decoded frame and rgb frame
   fAVFrame := av_frame_alloc();


### PR DESCRIPTION
#1213 enabled mipmaps by default for generated textures.

The video texture is created before any frame data is available and updated for every decoded frame. These updates only replace the base mip level, leaving the generated lower levels stale or undefined.

Depending on the OpenGL driver and video scaling, these levels may be sampled and cause video corruption.

### Fix

Keep the dynamically updated video texture on linear sampling without mipmaps, as already done for webcam frames.

Static resource textures continue to use mipmaps.

I can not reproduce the bug. Things look fine with and without this on my system.