### PR TITLE
Fix video sync after changing backgrounds

### DIFF
--- a/src/screens/UScreenJukebox.pas
+++ b/src/screens/UScreenJukebox.pas
@@ -1396,7 +1396,7 @@ begin
             fShowVisualization := false;
             fCurrentVideo := fVideoClip;
             if (Assigned(fCurrentVideo)) then
-               fCurrentVideo.Position := CurrentSong.VideoGAP + CurrentSong.Start + AudioPlayback.Position;
+               fCurrentVideo.Position := CurrentSong.VideoGAP + AudioPlayback.Position;
             Log.LogStatus('finished switching to video', 'UScreenSing.ParseInput');
           end
           else
@@ -2910,4 +2910,3 @@ begin
 end;
 
 end.
-

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -315,7 +315,7 @@ begin
           if (Assigned(fCurrentVideo)) then
           begin
             fCurrentVideo.SetAspectCorrection(BackgroundAspectCorrection);
-            fCurrentVideo.Position := CurrentSong.VideoGAP + CurrentSong.Start + AudioPlayback.Position;
+            fCurrentVideo.Position := CurrentSong.VideoGAP + AudioPlayback.Position;
           end;
           Log.LogStatus('finished switching to video', 'UScreenSing.ParseInput');
         end


### PR DESCRIPTION
### Problem

Cycling through the available backgrounds with `V` can desynchronize the video for songs using `#START`.

When switching back to the video, USDX adds `#START` to the current audio position even though **the current audio position already includes it**. This seeks the video too far forward.

The same issue exists in the jukebox background cycling path.

### Fix

Seek the video using only the current absolute audio position plus `#VIDEOGAP`.

This keeps the video synchronized when switching back to it in both the singing and jukebox screens.

Fixes bug 3 from #1397.

### Testing

Tested with a song using `#START`, a video, and a background image:

- Start the song.
- Cycle with `V` until the video is shown again.
- The video remains at the current audio position instead of adding `#START` a second time.