### PR TITLE
Remove the legacy avatar cache db

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,7 +38,7 @@ Have fun and enjoy working on a game that easily can hit 5.000 downloads in a we
 - **projectM** is used for visualisation.
 - **ffmpeg** is used for most video and audio stuff. On Windows, the bass library is used for playing mp3 files because of licensing issues of mp3 codecs.
 - **OpenCV** videoio is used for getting images from the webcam.
-- **sqlite** is used for creating and accessing databases to store song scores, already scanned songs, avatar image caches and so on. Remember that changing database setup will require adding an automatic upgrade script or resetting the database file for all users and loosing ist content.
+- **sqlite** is used for creating and accessing databases to store song scores and already scanned songs. Remember that changing database setup will require adding an automatic upgrade script or resetting the database file for all users and loosing ist content.
 
 
 ### Where the game starts...:

--- a/src/base/UAvatars.pas
+++ b/src/base/UAvatars.pas
@@ -34,65 +34,27 @@ interface
 {$I switches.inc}
 
 uses
-  sdl2,
-  SQLite3,
-  SQLiteTable3,
-  SysUtils,
-  Classes,
-  UImage,
   UIni,
   URenderer,
   UPath;
 
 type
-  ECoverDBException = class(Exception)
-  end;
-
   TAvatar = class
     private
-      ID: int64;
       Filename: IPath;
     public
-      constructor Create(ID: int64; Filename: IPath);
-      function GetPreviewTexture(): TTexture;
+      constructor Create(const Filename: IPath);
       function GetTexture(): TTexture;
   end;
 
-  TAvatarThumbnailInfo = record
-    AvatarWidth: integer;         // Original width of avatar
-    AvatarHeight: integer;        // Original height of avatar
-    PixelFormat: TImagePixelFmt; // Pixel-format of avatar thumbnail
-  end;
-
-  TAvatarDatabase = class
-    private
-      DB: TSQLiteDatabase;
-
-      procedure InitAvatarDatabase();
-      function CreateAvatarThumbnail(const Filename: IPath; var Info: TAvatarThumbnailInfo): PSDL_Surface;
-      function LoadAvatar(AvatarID: int64): TTexture;
-      procedure DeleteAvatar(AvatarID: int64);
-      function FindAvatarIntern(const Filename: IPath): int64;
-      procedure Open();
-      function GetVersion(): integer;
-      procedure SetVersion(Version: integer);
+  TAvatarManager = class
     public
       constructor Create();
-      destructor Destroy; override;
       function AddAvatar(const Filename: IPath): TAvatar;
-      function FindAvatar(const Filename: IPath): TAvatar;
-      function AvatarExists(const Filename: IPath): boolean;
-      function GetMaxAvatarSize(): integer;
-      procedure SetMaxAvatarSize(Size: integer);
-      procedure LoadAvatars();
-  end;
-
-  TBlobWrapper = class(TCustomMemoryStream)
-     function Write(const Buffer; Count: Integer): Integer; override;
   end;
 
 var
-  Avatars: TAvatarDatabase;
+  Avatars: TAvatarManager;
   AvatarsList: array of IPath;
   NoAvatarTexture: array[1..UIni.IMaxPlayerCount] of TTexture;
   AvatarPlayerTextures: array[1..UIni.IMaxPlayerCount] of TTexture;
@@ -100,54 +62,12 @@ var
 implementation
 
 uses
-  UMain,
-  ULog,
-  UPathUtils,
-  UPlatform,
   UFilesystem,
-  Math,
-  DateUtils;
+  UPathUtils;
 
-const
-  AVATARDB_FILENAME: UTF8String = 'avatar.db';
-  AVATARDB_VERSION = 01; // 0.1
-  AVATAR_TBL = 'Avatar';
-  AVATAR_THUMBNAIL_TBL = 'AvatarThumbnail';
-  AVATAR_IDX = 'Avatar_Filename_IDX';
-
-// Note: DateUtils.DateTimeToUnix() will throw an exception in FPC
-function DateTimeToUnixTime(time: TDateTime): int64;
+constructor TAvatar.Create(const Filename: IPath);
 begin
-  Result := Round((time - UnixDateDelta) * SecsPerDay);
-end;
-
-// Note: DateUtils.UnixToDateTime() will throw an exception in FPC
-function UnixTimeToDateTime(timestamp: int64): TDateTime;
-begin
-  Result := timestamp / SecsPerDay + UnixDateDelta;
-end;
-
-
-{ TBlobWrapper }
-
-function TBlobWrapper.Write(const Buffer; Count: Integer): Integer;
-begin
-  SetPointer(Pointer(Buffer), Count);
-  Result := Count;
-end;
-
-
-{ TCover }
-
-constructor TAvatar.Create(ID: int64; Filename: IPath);
-begin
-  Self.ID := ID;
   Self.Filename := Filename;
-end;
-
-function TAvatar.GetPreviewTexture(): TTexture;
-begin
-  Result := Avatars.LoadAvatar(ID);
 end;
 
 function TAvatar.GetTexture(): TTexture;
@@ -155,308 +75,9 @@ begin
   Result := Renderer.LoadTexture(Filename);
 end;
 
-
-{ TAvatarDatabase }
-
-constructor TAvatarDatabase.Create();
-begin
-  inherited;
-
-  Open();
-  LoadAvatars();
-  InitAvatarDatabase();
-end;
-
-destructor TAvatarDatabase.Destroy;
-begin
-  DB.Free;
-  inherited;
-end;
-
-function TAvatarDatabase.GetVersion(): integer;
-begin
-  Result := DB.GetTableValue('PRAGMA user_version');
-end;
-
-procedure TAvatarDatabase.SetVersion(Version: integer);
-begin
-  DB.ExecSQL(Format('PRAGMA user_version = %d', [Version]));
-end;
-
-function TAvatarDatabase.GetMaxAvatarSize(): integer;
-begin
-  Result := ITextureSizeVals[Ini.TextureSize];
-end;
-
-procedure TAvatarDatabase.SetMaxAvatarSize(Size: integer);
+constructor TAvatarManager.Create();
 var
-  I: integer;
-begin
-  // search for first valid avatar-size > Size
-  for I := 0 to Length(ITextureSizeVals)-1 do
-  begin
-    if (Size <= ITextureSizeVals[I]) then
-    begin
-      Ini.TextureSize := I;
-      Exit;
-    end;
-  end;
-
-  // fall-back to highest size
-  Ini.TextureSize := High(ITextureSizeVals);
-end;
-
-procedure TAvatarDatabase.Open();
-var
-  Version: integer;
-  Filename: IPath;
-begin
-  Filename := Platform.GetGameUserPath().Append(AVATARDB_FILENAME);
-
-  DB := TSQLiteDatabase.Create(Filename.ToUTF8());
-  Version := GetVersion();
-
-  // check version, if version is too old/new, delete database file
-  if ((Version <> 0) and (Version <> AVATARDB_VERSION)) then
-  begin
-    Log.LogInfo('Outdated avatar-database file found', 'TAvatarDatabase.Open');
-    // close and delete outdated file
-    DB.Free;
-    if (not Filename.DeleteFile()) then
-      raise ECoverDBException.Create('Could not delete ' + Filename.ToNative);
-    // reopen
-    DB := TSQLiteDatabase.Create(Filename.ToUTF8());
-    Version := 0;
-  end;
-
-  // set version number after creation
-  if (Version = 0) then
-    SetVersion(AVATARDB_VERSION);
-
-  // speed-up disk-writing. The default FULL-synchronous mode is too slow.
-  // With this option disk-writing is approx. 4 times faster but the database
-  // might be corrupted if the OS crashes, although this is very unlikely.
-  DB.ExecSQL('PRAGMA synchronous = OFF;');
-
-  // the next line rather gives a slow-down instead of a speed-up, so we do not use it
-  //DB.ExecSQL('PRAGMA temp_store = MEMORY;');
-end;
-
-procedure TAvatarDatabase.InitAvatarDatabase();
-begin
-  DB.ExecSQL('CREATE TABLE IF NOT EXISTS ['+AVATAR_TBL+'] (' +
-               '[ID] INTEGER  NOT NULL PRIMARY KEY AUTOINCREMENT, ' +
-               '[Filename] TEXT  UNIQUE NOT NULL, ' +
-               '[Date] INTEGER  NOT NULL, ' +
-               '[Width] INTEGER  NOT NULL, ' +
-               '[Height] INTEGER  NOT NULL ' +
-             ')');
-
-  DB.ExecSQL('CREATE INDEX IF NOT EXISTS ['+AVATAR_IDX+'] ON ['+AVATAR_TBL+'](' +
-               '[Filename]  ASC' +
-             ')');
-
-  DB.ExecSQL('CREATE TABLE IF NOT EXISTS ['+AVATAR_THUMBNAIL_TBL+'] (' +
-               '[ID] INTEGER  NOT NULL PRIMARY KEY, ' +
-               '[Format] INTEGER  NOT NULL, ' +
-               '[Width] INTEGER  NOT NULL, ' +
-               '[Height] INTEGER  NOT NULL, ' +
-               '[Data] BLOB  NULL' +
-             ')');
-end;
-
-function TAvatarDatabase.FindAvatarIntern(const Filename: IPath): int64;
-begin
-  Result := DB.GetTableValue('SELECT [ID] FROM ['+AVATAR_TBL+'] ' +
-                             'WHERE [Filename] = ?',
-                             [Filename.ToUTF8]);
-end;
-
-function TAvatarDatabase.FindAvatar(const Filename: IPath): TAvatar;
-var
-  AvatarID: int64;
-begin
-  Result := nil;
-  try
-    AvatarID := FindAvatarIntern(Filename);
-    if (AvatarID > 0) then
-      Result := TAvatar.Create(AvatarID, Filename);
-  except on E: Exception do
-    Log.LogError(E.Message, 'TAvatarDatabase.FindAvatar');
-  end;
-end;
-
-function TAvatarDatabase.AvatarExists(const Filename: IPath): boolean;
-begin
-  Result := false;
-  try
-    Result := (FindAvatarIntern(Filename) > 0);
-  except on E: Exception do
-    Log.LogError(E.Message, 'TAvatarDatabase.CoverExists');
-  end;
-end;
-
-function TAvatarDatabase.AddAvatar(const Filename: IPath): TAvatar;
-var
-  AvatarID: int64;
-  Thumbnail: PSDL_Surface;
-  AvatarData: TBlobWrapper;
-  FileDate: TDateTime;
-  Info: TAvatarThumbnailInfo;
-begin
-  Result := nil;
-
-  //if (not FileExists(Filename)) then
-  //  Exit;
-
-  // TODO: replace '\' with '/' in filename
-  FileDate := Now(); //FileDateToDateTime(FileAge(Filename));
-
-  Thumbnail := CreateAvatarThumbnail(Filename, Info);
-  if (Thumbnail = nil) then
-    Exit;
-  SDL_LockSurface(Thumbnail);
-  if not assigned(Thumbnail^.pixels) then
-  begin
-    Log.LogError('Failed to lock surface', 'TAvatarDatabase.AddAvatar');
-    SDL_FreeSurface(Thumbnail);
-    Exit;
-  end;
-
-  AvatarData := TBlobWrapper.Create;
-  AvatarData.Write(Thumbnail^.pixels, Thumbnail^.h * Thumbnail^.pitch);
-
-  try
-    // Note: use a transaction to speed-up file-writing.
-    // Without data written by the first INSERT might be moved at the second INSERT.
-    DB.BeginTransaction();
-
-    // add general cover info
-    DB.ExecSQL('INSERT INTO ['+AVATAR_TBL+'] ' +
-               '([Filename], [Date], [Width], [Height]) VALUES' +
-               '(?, ?, ?, ?)',
-               [Filename.ToUTF8, DateTimeToUnixTime(FileDate),
-                Info.AvatarWidth, Info.AvatarHeight]);
-
-    // get auto-generated avatar ID
-    AvatarID := DB.GetLastInsertRowID();
-
-    // add thumbnail info
-    DB.ExecSQL('INSERT INTO ['+AVATAR_THUMBNAIL_TBL+'] ' +
-               '([ID], [Format], [Width], [Height], [Data]) VALUES' +
-               '(?, ?, ?, ?, ?)',
-               [AvatarID, Ord(Info.PixelFormat),
-                Thumbnail^.w, Thumbnail^.h, AvatarData]);
-
-    Result := TAvatar.Create(AvatarID, Filename);
-  except on E: Exception do
-    Log.LogError(E.Message, 'TAvatarDatabase.AddAvatar');
-  end;
-
-  DB.Commit();
-  AvatarData.Free;
-  SDL_FreeSurface(Thumbnail);
-end;
-
-function TAvatarDatabase.LoadAvatar(AvatarID: int64): TTexture;
-var
-  Width, Height: integer;
-  PixelFmt: TImagePixelFmt;
-  Data: PChar;
-  DataSize: integer;
-  Filename: IPath;
-  Table: TSQLiteUniTable;
-begin
-  Result := nil;
-  Table := nil;
-
-  try
-    Table := DB.GetUniTable(Format(
-      'SELECT C.[Filename], T.[Format], T.[Width], T.[Height], T.[Data] ' +
-      'FROM ['+AVATAR_TBL+'] C ' +
-        'INNER JOIN ['+AVATAR_THUMBNAIL_TBL+'] T ' +
-        'USING(ID) ' +
-      'WHERE [ID] = %d', [AvatarID]));
-
-    Filename := Path(Table.FieldAsString(0));
-    PixelFmt := TImagePixelFmt(Table.FieldAsInteger(1));
-    Width    := Table.FieldAsInteger(2);
-    Height   := Table.FieldAsInteger(3);
-
-    Data := Table.FieldAsBlobPtr(4, DataSize);
-    if (Data <> nil) and
-       (PixelFmt = ipfRGB) then
-      Result := Renderer.CreateTexture(Data, Filename, Width, Height, TEXTURE_TYPE_PLAIN)
-    else
-      Result := Renderer.CreateEmptyTexture(PATH_NONE);
-  except on E: Exception do
-    Log.LogError(E.Message, 'TAvatarDatabase.LoadAvatar');
-  end;
-
-  Table.Free;
-end;
-
-procedure TAvatarDatabase.DeleteAvatar(AvatarID: int64);
-begin
-  DB.ExecSQL(Format('DELETE FROM ['+AVATAR_TBL+'] WHERE [ID] = %d', [AvatarID]));
-  DB.ExecSQL(Format('DELETE FROM ['+AVATAR_THUMBNAIL_TBL+'] WHERE [ID] = %d', [AvatarID]));
-end;
-
-(**
- * Returns a pointer to an array of bytes containing the texture data in the
- * requested size
- *)
-function TAvatarDatabase.CreateAvatarThumbnail(const Filename: IPath; var Info: TAvatarThumbnailInfo): PSDL_Surface;
-var
-  //TargetAspect, SourceAspect: double;
-  //TargetWidth, TargetHeight: integer;
-  Thumbnail: PSDL_Surface;
-  MaxSize: integer;
-begin
-  Result := nil;
-
-  MaxSize := GetMaxAvatarSize();
-
-  Thumbnail := LoadImage(Filename);
-  if (not assigned(Thumbnail)) then
-  begin
-    Log.LogError('Could not load avatar: "'+ Filename.ToNative +'"', 'TAvatarDatabase.AddAvatar');
-    Exit;
-  end;
-
-  // Convert pixel format as needed
-  AdjustPixelFormat(Thumbnail, TEXTURE_TYPE_PLAIN);
-
-  Info.AvatarWidth  := Thumbnail^.w;
-  Info.AvatarHeight := Thumbnail^.h;
-  Info.PixelFormat := ipfRGB;
-
-  (* TODO: keep aspect ratio
-  TargetAspect := Width / Height;
-  SourceAspect := TexSurface.w / TexSurface.h;
-
-  // Scale texture to covers dimensions (keep aspect)
-  if (SourceAspect >= TargetAspect) then
-  begin
-    TargetWidth := Width;
-    TargetHeight := Trunc(Width / SourceAspect);
-  end
-  else
-  begin
-    TargetHeight := Height;
-    TargetWidth := Trunc(Height * SourceAspect);
-  end;
-  *)
-
-  // TODO: do not scale if image is smaller
-  ScaleImage(Thumbnail, MaxSize, MaxSize);
-
-  Result := Thumbnail;
-end;
-
-procedure TAvatarDatabase.LoadAvatars;
-var
-  Len:  Integer;
+  Len: Integer;
   IterJPG, IterPNG: IFileIterator;
   FileInfo: TFileInfo;
 begin
@@ -465,7 +86,6 @@ begin
 
   // jpg
   IterJPG := FileSystem.FileFind(AvatarsPath.Append('*.jpg'), 0);
-
   while (IterJPG.HasNext) do
   begin
     Len := Length(AvatarsList);
@@ -476,10 +96,8 @@ begin
     AvatarsList[High(AvatarsList)] := AvatarsPath.Append(FileInfo.Name);
   end;
 
-
   // png
   IterPNG := FileSystem.FileFind(AvatarsPath.Append('*.png'), 0);
-
   while (IterPNG.HasNext) do
   begin
     Len := Length(AvatarsList);
@@ -489,7 +107,11 @@ begin
 
     AvatarsList[High(AvatarsList)] := AvatarsPath.Append(FileInfo.Name);
   end;
-  
+end;
+
+function TAvatarManager.AddAvatar(const Filename: IPath): TAvatar;
+begin
+  Result := TAvatar.Create(Filename);
 end;
 
 end.

--- a/src/base/UGraphic.pas
+++ b/src/base/UGraphic.pas
@@ -595,9 +595,9 @@ begin
   Log.LogStatus('Creating Category Covers Array', 'Initialization');
   CatCovers:= TCatCovers.Create;
 
-  // Avatars Cache
-  Log.LogStatus('Creating Avatars Cache', 'Initialization');
-  Avatars := TAvatarDatabase.Create;
+  // Avatars
+  Log.LogStatus('Loading Avatars', 'Initialization');
+  Avatars := TAvatarManager.Create;
 
   // Songs
   Log.LogStatus('Creating Song Array', 'Initialization');

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -569,10 +569,8 @@ begin
     Hash := MD5Print(MD5File(AvatarFile.ToNative));
     PlayerAvatarButtonMD5[I] := UpperCase(Hash);
 
-    // load avatar and cache its texture
-    Avatar := Avatars.FindAvatar(AvatarFile);
-    if (Avatar = nil) then
-      Avatar := Avatars.AddAvatar(AvatarFile);
+    // load avatar directly from its file
+    Avatar := Avatars.AddAvatar(AvatarFile);
 
     if (Avatar <> nil) then
     begin


### PR DESCRIPTION
This Pr removes the old SQLite-backed avatars database and thumbnail cache. Avatars are now loaded directly from the files in the avatars directory. It was pretty useless.

The installer still cleans up existing `avatar.db` files from older installations, along with the installed and AppData avatar directories when requested -- in symmetry to what we did for the covers db.