### PR TITLE
Support ProjectM on MacOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,8 @@ jobs:
       SDL2_SHA: 5f5993c530f084535c65a6879e9b26ad441169b3e25d789d83287040a9ca5165
       SDL2_IMAGE_VERSION: 2.8.12
       SDL2_IMAGE_SHA: 393f5efb50536ec13ca4f4affb69cc9966d3c3f969e6c5e701faddf9f9785381
+      PROJECTM_VERSION: 4.1.7
+      PROJECTM_SHA: 16e4610b4d58981f7a2351faa58d507d3f40163a7b26ba81e19aec928c66641f
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -139,10 +141,35 @@ jobs:
             -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
             -DSDL2_DIR=$GITHUB_WORKSPACE/sdl2/lib/cmake/SDL2
           cmake --build SDL2_image-$SDL2_IMAGE_VERSION/build --target install --parallel
+      - name: Cache ProjectM
+        id: cache-projectm
+        uses: actions/cache@v6
+        with:
+          path: ${{github.workspace}}/projectm
+          key: projectm-${{matrix.os}}-${{env.PROJECTM_VERSION}}
+      - name: Build ProjectM
+        if: steps.cache-projectm.outputs.cache-hit != 'true'
+        run: |
+          curl -L -O https://github.com/projectM-visualizer/projectm/releases/download/v$PROJECTM_VERSION/libprojectM-$PROJECTM_VERSION.tar.gz
+          echo "$PROJECTM_SHA libprojectM-$PROJECTM_VERSION.tar.gz" | sha256sum -c -
+          tar -xf libprojectM-$PROJECTM_VERSION.tar.gz
+          cmake -S libprojectM-$PROJECTM_VERSION \
+            -B libprojectM-$PROJECTM_VERSION/build \
+            -DENABLE_PLAYLIST=OFF \
+            -DBUILD_SHARED_LIBS=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/projectm \
+            -DCMAKE_INSTALL_NAME_DIR=$GITHUB_WORKSPACE/projectm/lib \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
+          cmake --build libprojectM-$PROJECTM_VERSION/build --target install --parallel
       - name: Generate Build Scripts
         run: ./autogen.sh
       - name: Configure Project
-        run: PKG_CONFIG_PATH=$GITHUB_WORKSPACE/sdl2/lib/pkgconfig ./configure --with-opencv-cxx-api
+        run: |
+          PKG_CONFIG_PATH=$GITHUB_WORKSPACE/sdl2/lib/pkgconfig \
+          libprojectM_VERSION=$PROJECTM_VERSION \
+          LIBS=-L$GITHUB_WORKSPACE/projectm/lib \
+          ./configure --with-opencv-cxx-api --with-libprojectM=nocheck
       - name: Build
         run: make macos-dmg
       - name: Rename DMG

--- a/configure.ac
+++ b/configure.ac
@@ -344,9 +344,6 @@ libprojectM_PKG="projectM-4 >= 4.0"
 PKG_HAVE([libprojectM], [$libprojectM_PKG], no)
 AC_SUBST_DEFINE(HAVE_PROJECTM, $libprojectM_HAVE)
 PKG_VERSION([libprojectM], [$libprojectM_PKG])
-# get projectM include-dir
-PKG_VALUE([libprojectM], [INCLUDEDIR], [variable=includedir], [$libprojectM_PKG], 
-          [C-Header include-dir (e.g. /usr/include)])
 
 opencv_core_standalone=no
 opencv_imgproc_standalone=no

--- a/src/lib/projectM/projectM.pas
+++ b/src/lib/projectM/projectM.pas
@@ -13,6 +13,10 @@ interface
 uses
   ctypes;
 
+{$IFDEF DARWIN}
+  {$linklib projectM-4}
+{$ENDIF}
+
 const
   projectM__lib = 'projectM-4';
 


### PR DESCRIPTION
This PR adds support for ProjectM on macOS. Mac is the only platform for which we currently don't provide fully featured builds.

Homebrew currently ships ProjectM 3.x, so I added the build commands within the Actions script, with caching enabled for performance.

The `libprojectM_INCLUDEDIR` variable was removed because we don't use the C++ interface anymore since we updated to 4.x.

Tested and verified working on macOS 26.5 Tahoe.