### PR TITLE
Use PortAudio playback on macOS

### DIFF
--- a/src/switches.inc
+++ b/src/switches.inc
@@ -83,8 +83,11 @@
   {$DEFINE UseBASSPlayback}
   {$DEFINE UseBASSInput}
 {$ELSEIF Defined(HavePortaudio)}
-  {$DEFINE UseSDLPlayback}
-  {.$DEFINE UsePortaudioPlayback}
+  {$IFDEF DARWIN}
+    {$DEFINE UsePortaudioPlayback}
+  {$ELSE}
+    {$DEFINE UseSDLPlayback}
+  {$ENDIF}
   {$DEFINE UsePortaudioInput}
   {$IFDEF HavePortmixer}
     {$DEFINE UsePortmixer}


### PR DESCRIPTION
## Summary

This PR changes only macOS builds!
It uses PortAudio for both playback and microphone input on macOS when PortAudio is available. Other platforms continue using their existing playback backend.

This is a macOS-scoped successor to #576, addressing the valid concern that its original change affected every Unix platform.

## Motivation

Current macOS builds combine SDL playback with PortAudio input. Reports in #573 and #576 indicate that this mixed-backend configuration can cause crackling or stuttering with bidirectional USB audio interfaces.

The original reporter tested these combinations:

- PortAudio playback + PortAudio input: working
- SDL playback + SDL input: working
- SDL playback + PortAudio input: crackling/stuttering

Now, I thought maybe this is outdated. But turns out @bohning can still verify this behavior on current builds and current macs with a Behringer Flow 8 when the interface is used simultaneously for input and output.

## Testing requested

I don't have a mac. We need to compare a current master build with this PR's macOS artifact using the same input/output configuration.

Related: #573, #576