### PR TITLE
Fix Regression: Songs without #VERSION header are missing in the game

### DIFF
--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -447,6 +447,7 @@ begin
   Self.Path     := aFileName.GetPath;
   Self.FileName := aFileName.GetName;
   Self.Folder   := GetFolderCategory(aFileName);
+  Self.FormatVersion := TVersion.Create();
 
   (*
   if (aFileName.IsFile) then


### PR DESCRIPTION
A recent cleanup part of #1364 removed the parser fallback under the assumption that `FormatVersion` was initialized by the constructor. However, songs discovered from files use a different constructor, leaving `FormatVersion` nil.

This PR restores the previous behavior of treating songs without a `#VERSION` header as legacy format `0.3.0`.

Fixes #1415.

I have many songs without a `#VERSION` header, even just starting the game with #1364 or on current master reveals the bug.