### PR TITLE
Fix sourceforge-caused regression: failed Windows dependency download leads to incomplete exe execution and a 6h CI timeout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,11 @@ jobs:
   build_windows:
     name: Build for Windows
     runs-on: windows-2022
+    env:
+      FPC_VERSION: 3.2.2
+      FPC_SHA256: 8C255390544B051388B577EB61C6191A04883264AFE0E3369B3600A56DAF7BDE
+      NSIS_VERSION: 3.05
+      NSIS_SHA256: 1A3CC9401667547B9B9327A177B13485F7C59C2303D4B6183E7BC9E6C8D6BFDB
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -24,6 +29,7 @@ jobs:
         with:
           msystem: MSYS
           update: false
+          cache: true
           install: >-
             autoconf-wrapper
             automake-wrapper
@@ -32,22 +38,31 @@ jobs:
             pkgconf
             mingw-w64-x86_64-gcc
             mingw-w64-x86_64-tools
+      - name: Cache FPC and NSIS
+        id: cache-fpc-nsis
+        uses: actions/cache@v6
+        with:
+          path: |
+            C:\FPC\${{ env.FPC_VERSION }}
+            C:\Program Files (x86)\NSIS
+          key: windows-fpc-nsis-v1-${{ runner.arch }}-fpc-${{ env.FPC_VERSION }}-nsis-${{ env.NSIS_VERSION }}
       - name: Install Dependencies
+        if: steps.cache-fpc-nsis.outputs.cache-hit != 'true'
         timeout-minutes: 10
         run: |
-          curl.exe --fail --location --retry 3 --retry-all-errors --connect-timeout 30 --max-time 300 --output fpc-installer.exe "https://downloads.freepascal.org/fpc/dist/3.2.2/i386-win32/fpc-3.2.2.win32.and.win64.exe"
+          curl.exe --fail --location --retry 3 --retry-all-errors --connect-timeout 30 --max-time 300 --output fpc-installer.exe "https://downloads.freepascal.org/fpc/dist/$($env:FPC_VERSION)/i386-win32/fpc-$($env:FPC_VERSION).win32.and.win64.exe"
           if ($LASTEXITCODE -ne 0) { throw "Failed to download the FPC installer (curl exit code $LASTEXITCODE)" }
-          curl.exe --fail --location --retry 3 --retry-all-errors --connect-timeout 30 --max-time 120 --output nsis-3.05-setup.exe "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.05/nsis-3.05-setup.exe"
+          curl.exe --fail --location --retry 3 --retry-all-errors --connect-timeout 30 --max-time 120 --output nsis-installer.exe "https://downloads.sourceforge.net/project/nsis/NSIS%203/$($env:NSIS_VERSION)/nsis-$($env:NSIS_VERSION)-setup.exe"
           if ($LASTEXITCODE -ne 0) { throw "Failed to download the NSIS installer (curl exit code $LASTEXITCODE)" }
 
           $fpcHash = (Get-FileHash -Algorithm SHA256 fpc-installer.exe).Hash
-          if ($fpcHash -ne "8C255390544B051388B577EB61C6191A04883264AFE0E3369B3600A56DAF7BDE") { throw "Unexpected FPC installer hash: $fpcHash" }
-          $nsisHash = (Get-FileHash -Algorithm SHA256 nsis-3.05-setup.exe).Hash
-          if ($nsisHash -ne "1A3CC9401667547B9B9327A177B13485F7C59C2303D4B6183E7BC9E6C8D6BFDB") { throw "Unexpected NSIS installer hash: $nsisHash" }
+          if ($fpcHash -ne $env:FPC_SHA256) { throw "Unexpected FPC installer hash: $fpcHash" }
+          $nsisHash = (Get-FileHash -Algorithm SHA256 nsis-installer.exe).Hash
+          if ($nsisHash -ne $env:NSIS_SHA256) { throw "Unexpected NSIS installer hash: $nsisHash" }
 
           $fpcInstaller = Start-Process -FilePath ".\fpc-installer.exe" -ArgumentList "/TYPE=full /VERYSILENT /SP- /SUPPRESSMSGBOXES /NORESTART" -Wait -PassThru
           if ($fpcInstaller.ExitCode -ne 0) { throw "FPC installer failed with exit code $($fpcInstaller.ExitCode)" }
-          & .\nsis-3.05-setup.exe /S
+          & .\nsis-installer.exe /S
           if ($LASTEXITCODE -ne 0) { throw "NSIS installer failed with exit code $LASTEXITCODE" }
       - name: Download prebuilt DLLs
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,11 +33,22 @@ jobs:
             mingw-w64-x86_64-gcc
             mingw-w64-x86_64-tools
       - name: Install Dependencies
+        timeout-minutes: 10
         run: |
-          curl.exe -L --max-time 60 -o fpc-installer.exe "https://sourceforge.net/projects/freepascal/files/Win32/3.2.2/fpc-3.2.2.win32.and.win64.exe/download"
-          curl.exe -L --max-time 60 -o nsis-3.05-setup.exe "https://sourceforge.net/projects/nsis/files/NSIS%203/3.05/nsis-3.05-setup.exe/download"
-          Start-Process -FilePath ".\\fpc-installer.exe" -ArgumentList "/TYPE=full /VERYSILENT /SP- /SUPPRESSMSGBOXES /NORESTART" -Wait
-          ./nsis-3.05-setup.exe /S
+          curl.exe --fail --location --retry 3 --retry-all-errors --connect-timeout 30 --max-time 300 --output fpc-installer.exe "https://downloads.freepascal.org/fpc/dist/3.2.2/i386-win32/fpc-3.2.2.win32.and.win64.exe"
+          if ($LASTEXITCODE -ne 0) { throw "Failed to download the FPC installer (curl exit code $LASTEXITCODE)" }
+          curl.exe --fail --location --retry 3 --retry-all-errors --connect-timeout 30 --max-time 120 --output nsis-3.05-setup.exe "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.05/nsis-3.05-setup.exe"
+          if ($LASTEXITCODE -ne 0) { throw "Failed to download the NSIS installer (curl exit code $LASTEXITCODE)" }
+
+          $fpcHash = (Get-FileHash -Algorithm SHA256 fpc-installer.exe).Hash
+          if ($fpcHash -ne "8C255390544B051388B577EB61C6191A04883264AFE0E3369B3600A56DAF7BDE") { throw "Unexpected FPC installer hash: $fpcHash" }
+          $nsisHash = (Get-FileHash -Algorithm SHA256 nsis-3.05-setup.exe).Hash
+          if ($nsisHash -ne "1A3CC9401667547B9B9327A177B13485F7C59C2303D4B6183E7BC9E6C8D6BFDB") { throw "Unexpected NSIS installer hash: $nsisHash" }
+
+          $fpcInstaller = Start-Process -FilePath ".\fpc-installer.exe" -ArgumentList "/TYPE=full /VERYSILENT /SP- /SUPPRESSMSGBOXES /NORESTART" -Wait -PassThru
+          if ($fpcInstaller.ExitCode -ne 0) { throw "FPC installer failed with exit code $($fpcInstaller.ExitCode)" }
+          & .\nsis-3.05-setup.exe /S
+          if ($LASTEXITCODE -ne 0) { throw "NSIS installer failed with exit code $LASTEXITCODE" }
       - name: Download prebuilt DLLs
         run: |
           python dldlls.py


### PR DESCRIPTION
The Windows CI job recently started to fail again... This time with the FPC download timing out, then launching the truncated installer(!) and waiting until GitHub’s six-hour job timeout(!) to stop executing that broken .exe.

This PR changes the CI job such that we:

- download FPC from the official direct download host,
- retry failed downloads and checks curl exit codes,
- verify the FPC and NSIS SHA-256 checksums before execution,
- check both installer exit codes,
- limit the dependency installation step to 10 minutes - that should be more than enough!

This prevents incomplete installers from being executed and ensures download or installation failures terminate promptly and even retry the download if something went wrong there, so we have a higher chance that the job completes.

If the retries all fail we cannot do anything but fail the CI job.