### PR TITLE
Refactor File Search Paths

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -285,9 +285,6 @@ install-data:
 	        RECURSIVE_DST_DIR="$(DESTDIR)$(INSTALL_DATADIR)/visuals" \
 	        install-data-recursive ; \
 	fi
-	$(MAKE) RECURSIVE_SRC_DIR="$(USDX_GAME_DIR)/webs" \
-            RECURSIVE_DST_DIR="$(DESTDIR)$(INSTALL_DATADIR)/themes" \
-            install-data-recursive
 	$(INSTALL_DATA) "LICENSE" "$(DESTDIR)$(INSTALL_DATADIR)/LICENSE"
 
 .PHONY: install-data-recursive
@@ -325,7 +322,6 @@ uninstall-data:
 	$(RM_REC) "$(DESTDIR)$(INSTALL_DATADIR)/sounds"
 	$(RM_REC) "$(DESTDIR)$(INSTALL_DATADIR)/themes"
 	$(RM_REC) "$(DESTDIR)$(INSTALL_DATADIR)/visuals"
-	$(RM_REC) "$(DESTDIR)$(INSTALL_DATADIR)/webs"
 	$(RM)     "$(DESTDIR)$(INSTALL_DATADIR)/LICENSE"
 	-rmdir "$(DESTDIR)$(INSTALL_DATADIR)"
 

--- a/game/visuals/projectM/config.inp
+++ b/game/visuals/projectM/config.inp
@@ -21,4 +21,4 @@ Hard Cut Sensitivity = 10
 ; Custom Shape Aspect Correction
 Aspect Correction = true
 
-Preset Path = visuals/projectM/presets
+Preset Path = presets

--- a/src/base/UAvatars.pas
+++ b/src/base/UAvatars.pas
@@ -56,14 +56,32 @@ type
 var
   Avatars: TAvatarManager;
   AvatarsList: array of IPath;
+  AvatarsMD5: array of UTF8String;
   NoAvatarTexture: array[1..UIni.IMaxPlayerCount] of TTexture;
   AvatarPlayerTextures: array[1..UIni.IMaxPlayerCount] of TTexture;
 
 implementation
 
 uses
+  md5,
+  sysutils,
   UFilesystem,
   UPathUtils;
+
+function AvatarExists(Hash: string): boolean;
+var
+  I: integer;
+begin
+  Result := false;
+  for I := Low(AvatarsMD5) to High(AvatarsMD5) do
+  begin
+    if (AvatarsMD5[I] = Hash) then
+    begin
+      Result := true;
+      Exit;
+    end;
+  end;
+end;
 
 constructor TAvatar.Create(const Filename: IPath);
 begin
@@ -76,36 +94,39 @@ begin
 end;
 
 constructor TAvatarManager.Create();
+const
+  Extensions: array[0..3] of string = ('.jpg', '.jpeg', '.png', '.webp');
 var
-  Len: Integer;
-  IterJPG, IterPNG: IFileIterator;
+  I, J, Len: Integer;
+  Iter: IFileIterator;
   FileInfo: TFileInfo;
+  AvatarPath: IPath;
+  Hash: string;
 begin
   // first position for no-avatar
   SetLength(AvatarsList, 1);
 
-  // jpg
-  IterJPG := FileSystem.FileFind(AvatarsPath.Append('*.jpg'), 0);
-  while (IterJPG.HasNext) do
+  // Find avatars
+  for I := 0 to AvatarsPaths.Count - 1 do
   begin
-    Len := Length(AvatarsList);
-    SetLength(AvatarsList, Len + 1);
-
-    FileInfo := IterJPG.Next;
-
-    AvatarsList[High(AvatarsList)] := AvatarsPath.Append(FileInfo.Name);
-  end;
-
-  // png
-  IterPNG := FileSystem.FileFind(AvatarsPath.Append('*.png'), 0);
-  while (IterPNG.HasNext) do
-  begin
-    Len := Length(AvatarsList);
-    SetLength(AvatarsList, Len + 1);
-
-    FileInfo := IterPNG.Next;
-
-    AvatarsList[High(AvatarsList)] := AvatarsPath.Append(FileInfo.Name);
+    for J := Low(Extensions) to High(Extensions) do
+    begin
+      Iter := FileSystem.FileFind(IPath(AvatarsPaths[I]).Append('*' + Extensions[J]), 0);
+      while (Iter.HasNext) do
+      begin
+        FileInfo := Iter.Next;
+        AvatarPath := IPath(AvatarsPaths[I]).Append(FileInfo.Name);
+        Hash := UpperCase(MD5Print(MD5File(AvatarPath.ToNative)));
+        if (not AvatarExists(Hash)) then
+        begin
+          Len := Length(AvatarsList);
+          SetLength(AvatarsList, Len + 1);
+          SetLength(AvatarsMD5, Len + 1);
+          AvatarsList[Len] := AvatarPath;
+          AvatarsMD5[Len] := Hash;
+        end;
+      end;
+    end;
   end;
 end;
 

--- a/src/base/UDLLManager.pas
+++ b/src/base/UDLLManager.pas
@@ -42,7 +42,7 @@ uses
 type
   TDLLMan = class
     private
-      hLibW:     THandle;
+      hLibW:     {$IFDEF MSWINDOWS}THandle{$ELSE}TLibHandle{$ENDIF};
 
       P_SendScore:       fModi_SendScore;
       P_EncryptScore:    fModi_EncryptScore;
@@ -51,9 +51,11 @@ type
       P_DownloadScore:   fModi_DownloadScore;
       P_VerifySong:      fModi_VerifySong;
 
+      function WebsiteExists(Name: string): boolean;
+
     public
       Websites: array of TWebsiteInfo;
-      WebsitePaths: array of IPath;
+      DLLPaths: array of IPath;
       SelectedW: ^TWebsiteInfo;
 
       constructor Create;
@@ -104,31 +106,51 @@ begin
   inherited;
 
   SetLength(Websites, 0);
-  SetLength(WebsitePaths, Length(Websites));
+  SetLength(DLLPaths, Length(Websites));
   GetWebsiteList;
+end;
+
+function TDLLMan.WebsiteExists(Name: string): boolean;
+var
+  I: integer;
+begin
+  Result := false;
+  for I := Low(DLLPaths) to High(DLLPaths) do
+  begin
+    if (DLLPaths[I].GetName().ToUTF8() = Name) then
+    begin
+      Result := true;
+      Break;
+    end;
+  end;
 end;
 
 procedure TDLLMan.GetWebsiteList;
 var
   Iter: IFileIterator;
   FileInfo: TFileInfo;
+  I: integer;
 begin
-  Iter := FileSystem.FileFind(WebsitePath.Append('*' + DLLExt), 0);
-  while (Iter.HasNext) do
+  for I := 0 to WebsitePaths.Count - 1 do
   begin
-    SetLength(Websites, Length(Websites)+1);
-    SetLength(WebsitePaths, Length(Websites));
-
-    FileInfo := Iter.Next;
-
-    if LoadWebsiteInfo(FileInfo.Name, High(Websites)) and (Websites[High(Websites)].Name <> '') then // loaded succesful
+    Iter := FileSystem.FileFind(IPath(WebsitePaths[I]).Append('*' + DLLExt), 0);
+    while (Iter.HasNext) do
     begin
-      WebsitePaths[High(WebsitePaths)] := FileInfo.Name;
-    end
-    else // error loading
-    begin
-      SetLength(Websites, Length(Websites)-1);
-      SetLength(WebsitePaths, Length(Websites));
+      FileInfo := Iter.Next;
+      if (not WebsiteExists(FileInfo.Name.ToUTF8())) then
+      begin
+        SetLength(Websites, Length(Websites)+1);
+        SetLength(DLLPaths, Length(Websites));
+        if LoadWebsiteInfo(IPath(WebsitePaths[I]).Append(FileInfo.Name), High(Websites)) and (Websites[High(Websites)].Name <> '') then // loaded succesful
+        begin
+          DLLPaths[High(DLLPaths)] := IPath(WebsitePaths[I]).Append(FileInfo.Name);
+        end
+        else // error loading
+        begin
+          SetLength(Websites, Length(Websites)-1);
+          SetLength(DLLPaths, Length(Websites));
+        end;
+      end;
     end;
   end;
 end;
@@ -140,7 +162,7 @@ end;
 
 function TDLLMan.LoadWebsiteInfo(const Filename: IPath; No: cardinal): boolean;
 var
-  hLibg: THandle;
+  hLibg: {$IFDEF MSWINDOWS}THandle{$ELSE}TLibHandle{$ENDIF};
   Info: pModi_WebsiteInfo;
 begin
   Result := true;
@@ -149,7 +171,8 @@ begin
   ClearWebsiteInfo(No);
 
   // load libary
-  hLibg := LoadLibrary(PAnsiChar(WebsitePath.Append(Filename).ToNative));
+  hLibg := LoadLibrary(PAnsiChar(Filename.ToNative));
+
   // if loaded
   if (hLibg <> 0) then
   begin
@@ -164,19 +187,19 @@ begin
       Result := true;
     end
     else
-      Log.LogError('Could not load website "' + Filename.ToNative + '": Info procedure not found');
+      Log.LogError('Could not load website "' + Filename.GetName().ToNative + '": Info procedure not found');
 
     FreeLibrary (hLibg);
   end
   else
-    Log.LogError('Could not load website "' + Filename.ToNative + '": Library not loaded');
+    Log.LogError('Could not load website "' + Filename.GetName().ToNative + '": Library not loaded');
 end;
 
 function TDLLMan.LoadWebsite(No: cardinal): boolean;
 begin
   Result := true;
   // load libary
-  hLibW := LoadLibrary(PChar(WebsitePath.Append(WebsitePaths[No]).ToNative));
+  hLibW := LoadLibrary(PChar(DLLPaths[No].ToNative));
   // if loaded
   if (hLibW <> 0) then
   begin
@@ -195,11 +218,11 @@ begin
     end
     else
     begin
-      Log.LogError('Could not load website "' + WebsitePaths[No].ToNative + '": Basic Procedures not found');
+      Log.LogError('Could not load website "' + DLLPaths[No].GetName().ToNative + '": Basic Procedures not found');
     end;
   end
   else
-    Log.LogError('Could not load website "' + WebsitePaths[No].ToNative + '": Library not loaded');
+    Log.LogError('Could not load website "' + DLLPaths[No].GetName().ToNative + '": Library not loaded');
 end;
 
 procedure TDLLMan.UnLoadWebsite;

--- a/src/base/UIni.pas
+++ b/src/base/UIni.pas
@@ -1506,14 +1506,11 @@ var
 begin
   LoadFontFamilyNames;
   ILyricsFont := FontFamilyNames;
-  GamePath := Platform.GetGameUserPath;
-
-  Log.LogStatus( 'GamePath : ' +GamePath.ToNative , '' );
 
   if (Params.ConfigFile.IsSet) then
     FileName := Params.ConfigFile
   else
-    FileName := GamePath.Append('config.ini');
+    FileName := Platform.GetGameUserPath().Append('config.ini');
 
   Log.LogStatus('Using config : ' + FileName.ToNative, 'Ini');
   IniFile := TMemIniFile.Create(FileName.ToNative);
@@ -1577,9 +1574,9 @@ begin
   DataBase.AddWebsite;
 
   // Webs Scores Path
-  WebScoresPath := Path(IniFile.ReadString('Directories', 'WebScoresDir', WebsitePath.ToNative));
+  WebScoresPath := Path(IniFile.ReadString('Directories', 'WebScoresDir', IPath(WebsitePaths[0]).ToNative));
   if not(DirectoryExists(WebScoresPath.ToNative)) then
-    WebScoresPath :=  WebsitePath;
+    WebScoresPath :=  WebsitePaths[0] as IPath;
 
   // ShowWebScore
   if (Length(DllMan.Websites) > 0) then

--- a/src/base/UPathUtils.pas
+++ b/src/base/UPathUtils.pas
@@ -40,24 +40,27 @@ uses
 
 var
   // Absolute Paths
-  GamePath:         IPath;
   SoundPath:        IPath;
   SongPaths:        IInterfaceList;
   LogPath:          IPath;
-  ThemePath:        IPath;
-  SkinsPath:        IPath;
+  ThemePaths:       IInterfaceList;
   ScreenshotsPath:  IPath;
   CoverPaths:       IInterfaceList;
   LanguagesPath:    IPath;
-  PluginPath:       IPath;
-  FontPath:         IPath;
+  PluginPaths:      IInterfaceList;
+  FontPaths:        IInterfaceList;
   ResourcesPath:    IPath;
   PlaylistPath:     IPath;
-  WebsitePath:      IPath;
+  WebsitePaths:     IInterfaceList;
   WebScoresPath:    IPath;
-  AvatarsPath:      IPath;
+  AvatarsPaths:     IInterfaceList;
+  {$IFDEF UseProjectM}
+  VisualsPaths:     IInterfaceList;
+  {$ENDIF}
 
 function FindPath(out PathResult: IPath; const RequestedPath: IPath; NeedsWritePermission: boolean): boolean;
+function FindPaths(out PathList: IInterfaceList; const Prefixes: IInterfaceList; Suffix: string): boolean;
+
 procedure InitializePaths;
 procedure AddSongPath(const Path: IPath; CreateMissing: boolean = true);
 
@@ -79,10 +82,7 @@ begin
     PathList := TInterfaceList.Create;
 
   if Path.Equals(PATH_NONE) then
-  begin
-    Log.LogWarn('Path "'+ Path.ToNative +'" not available', 'UPathUtils.AddSpecialPath');
     Exit;
-  end;
 
   if CreateMissing then
   begin
@@ -169,12 +169,21 @@ begin
   Result := true;
 end;
 
+function FindPaths(out PathList: IInterfaceList; const Prefixes: IInterfaceList; Suffix: string): boolean;
+var
+  I: integer;
+begin
+  for I := 0 to Prefixes.Count - 1 do
+    AddSpecialPath(PathList, IPath(Prefixes[I]).Append(Suffix), true);
+end;
+
 (**
  * Function sets all absolute paths e.g. song path and makes sure the directorys exist
  *)
 procedure InitializePaths;
 var
   SharedPath, UserPath: IPath;
+  ModifiableAssetPaths: IInterfaceList;
 begin
   // Log directory (must be writable)
   if (not FindPath(LogPath, Platform.GetLogPath, true)) then
@@ -185,16 +194,19 @@ begin
 
   SharedPath := Platform.GetGameSharedPath;
   UserPath := Platform.GetGameUserPath;
+  ModifiableAssetPaths := Platform.GetModifiableAssetPaths;
 
   FindPath(SoundPath,     SharedPath.Append('sounds'),    false);
-  FindPath(ThemePath,     SharedPath.Append('themes'),    false);
-  FindPath(SkinsPath,     SharedPath.Append('themes'),    false);
+  FindPaths(ThemePaths, ModifiableAssetPaths, 'themes');
   FindPath(LanguagesPath, SharedPath.Append('languages'), false);
-  FindPath(PluginPath,    SharedPath.Append('plugins'),   false);
-  FindPath(FontPath,      SharedPath.Append('fonts'),     false);
+  FindPaths(PluginPaths, ModifiableAssetPaths, 'plugins');
+  FindPaths(FontPaths, ModifiableAssetPaths, 'fonts');
   FindPath(ResourcesPath, SharedPath.Append('resources'), false);
-  FindPath(WebsitePath,   SharedPath.Append('webs'), false);
-  FindPath(AvatarsPath, SharedPath.Append('avatars'), false);
+  FindPaths(WebsitePaths, Platform.GetWebsitePaths, 'webs');
+  FindPaths(AvatarsPaths, ModifiableAssetPaths, 'avatars');
+  {$IFDEF UseProjectM}
+  FindPaths(VisualsPaths, ModifiableAssetPaths, Path('visuals').Append('projectM').ToUTF8());
+  {$ENDIF}
 
   // Playlists are not shared as we need one directory to write too
   FindPath(PlaylistPath, UserPath.Append('playlists'), true);

--- a/src/base/UPlatform.pas
+++ b/src/base/UPlatform.pas
@@ -54,6 +54,8 @@ type
     function GetMusicPath:      IPath; virtual; abstract;
     function GetGameSharedPath: IPath; virtual; abstract;
     function GetGameUserPath:   IPath; virtual; abstract;
+    function GetModifiableAssetPaths: IInterfaceList; virtual; abstract;
+    function GetWebsitePaths: IInterfaceList; virtual; abstract;
   end;
 
   function Platform(): TPlatform;

--- a/src/base/UPlatformLinux.pas
+++ b/src/base/UPlatformLinux.pas
@@ -52,6 +52,8 @@ type
       function GetLogPath        : IPath; override;
       function GetGameSharedPath : IPath; override;
       function GetGameUserPath   : IPath; override;
+      function GetModifiableAssetPaths: IInterfaceList; override;
+      function GetWebsitePaths: IInterfaceList; override;
   end;
 
 implementation
@@ -158,6 +160,29 @@ begin
   // GetUserDir() is another function that returns a user path.
   // It uses env-var HOME or a fallback to a temp-dir.
   //Result := GetUserDir();
+end;
+
+function TPlatformLinux.GetModifiableAssetPaths: IInterfaceList;
+begin
+  Result := TInterfaceList.Create;
+  if UseLocalDirs then
+  begin
+    Result.Add(GetExecutionDir());
+    Result.Add(GetHomeDir().Append('.ultrastardx'));
+  end
+  else
+  begin
+    Result.Add(GetHomeDir().Append('.ultrastardx'));
+    Result.Add(Path(INSTALL_DATADIR));
+  end;
+end;
+
+function TPlatformLinux.GetWebsitePaths: IInterfaceList;
+begin
+  Result := TInterfaceList.Create;
+  if UseLocalDirs then
+    Result.Add(GetExecutionDir());
+  Result.Add(GetHomeDir().Append('.ultrastardx'));
 end;
 
 end.

--- a/src/base/UPlatformMacOS.pas
+++ b/src/base/UPlatformMacOS.pas
@@ -42,81 +42,20 @@ uses
   UConfig;
 
 type
-  {**
-   * @abstract(Provides macOS specific details.)
-   * @lastmod(August 1, 2008)
-   * The UPlatformMacOS unit takes care of setting paths to resource folders.
-   *
-   * (Note for non-Maccies: "folder" is the Mac name for directory.)
-   *
-   * Note on the resource folders:
-   *  1. Installation of an application on the mac works as follows: Extract and
-   *     copy an application and if you don't like or need the application
-   *     anymore you move the folder to the trash - and you're done.
-   *  2. The use of folders in the user's home directory is against Apple's
-   *     guidelines and strange to an average user.
-   *  3. Even worse is using /usr/local/... since all lowercase folders in / are
-   *     not visible to an average user in the Finder, at least not without some
-   *     "tricks".
-   *
-   * The best way would be to store everything within the application bundle.
-   * However, this requires USDX to offer the handling of the resources. Until
-   * this is implemented, the second best solution is as follows:
-   *
-   * According to Apple guidelines handling of resources and folders should follow
-   * these lines:
-   *
-   * Acceptable places for files are folders named UltraStarDeluxe either in
-   *   /Library/Application Support/
-   * or
-   *   ~/Library/Application Support/
-   *
-   * So
-   * GetGameSharedPath could return
-   *   /Library/Application Support/UltraStarDeluxe_[USDX_VERSION]/.
-   * GetGameUserPath could return
-   *   ~/Library/Application Support/UltraStarDeluxe_[USDX_VERSION]/.
-   *
-   * Right now, only $HOME/Library/Application Support/UltraStarDeluxe_[USDX_VERSION]
-   * is used. So every user needs the complete set of files and folders.
-   * Future versions may also use shared resources in
-   * /Library/Application Support/UltraStarDeluxe_[USDX_VERSION]. However, this is
-   * not treated yet in the code outside this unit.
-   *
-   * USDX checks, whether GetGameUserPath exists. If not, USDX creates it.
-   * The existence of needed files is then checked and if a file is missing
-   * it is copied to there from within the folder Contents in the Application
-   * bundle, which contains the default files. USDX should not delete files or
-   * folders in Application Support/UltraStarDeluxe_[USDX_VERSION] automatically or without
-   * user confirmation.
-   *
-   * The log and benchmark files are stored in
-   * $HOME/Library/Log/UltraStar Deluxe/
-   *
-   * Music should go into ~/Music/UltraStar Deluxe/
-   *
-   * ~/Library/Application Support/UltraStarDeluxe_[USDX_VERSION]/songs is also used.
-   * The idea is to remove this at some time.
-   *
-   *}
   TPlatformMacOS = class(TPlatform)
     private
-      {**
-       * GetBundlePath returns the path to the application bundle
-       * UltraStarDeluxe.app.
-       *}
-      function GetBundlePath: IPath;
+      IsBundle: boolean;
+      IsLocal: boolean;
+      BundleDir: IPath;
+      ExecutionDir: IPath;
+
+      procedure DetectExecutionType();
 
       {**
        * GetApplicationSupportPath returns the path to
        * $HOME/Library/Application Support/UltraStarDeluxe_[USDX_VERSION].
        *}
       function GetApplicationSupportPath: IPath;
-
-      {**
-       * see the description of @link(Init).
-       *}
-      procedure CreateUserFolders();
 
       {**
        * GetHomeDir returns the path to $HOME.
@@ -157,6 +96,9 @@ type
        * This is where a user can add themes, ....
        *}
       function  GetGameUserPath:   IPath; override;
+
+      function GetModifiableAssetPaths: IInterfaceList; override;
+      function GetWebsitePaths: IInterfaceList; override;
   end;
 
 implementation
@@ -165,213 +107,99 @@ uses
   SysUtils,
   MacOSAll;
 
-type
-  TLogSwitch = (On, Off);
 const
-  LogSwitch: TLogSwitch = Off;
+  {$I paths.inc}
 
 procedure TPlatformMacOS.Init;
 begin
-  CreateUserFolders();
+  inherited;
+  DetectExecutionType();
 end;
 
-procedure TPlatformMacOS.CreateUserFolders();
+procedure TPlatformMacOS.DetectExecutionType();
 var
-  RelativePath: IPath;
-  // BaseDir contains the path to the folder, where a search is performed.
-  // It is set to the entries in @link(DirectoryList) one after the other.
-  BaseDir: IPath;
-  // OldBaseDir contains the path to the folder, where the search started.
-  // It is used to return to it, when the search is completed in all folders.
-  OldBaseDir: IPath;
-  Iter:       IFileIterator;
-  FileInfo:   TFileInfo;
-  CurPath:    IPath;
-  // These two lists contain all folder and file names found
-  // within the folder @link(BaseDir).
-  DirectoryList, FileList: IInterfaceList;
-  // DirectoryIsFinished contains the index of the folder in @link(DirectoryList),
-  // which is the last one completely searched. Later folders are still to be
-  // searched for additional files and folders.
-  DirectoryIsFinished: longint;
-  I: longint;
-  // These three are for creating directories, due to possible symlinks
-  CreatedDirectory: boolean;
-  FileAttrs:        integer;
-  DirectoryPath:    IPath;
-  UserPath:         IPath;
-  SrcFile, TgtFile: IPath;
-  mainBundle:       CFBundleRef;
-  resourcesURL:     CFURLRef;
-  bundlePath:       AnsiString;
-  bundleName:       AnsiString;
-  success:          boolean;
-  Position:         integer;
-const
-  PATH_MAX = 500;
-
+  LanguageDir: IPath;
 begin
-  // Get the current folder and save it in OldBaseDir for returning to it, when finished.
-  OldBaseDir := FileSystem.GetCurrentDir();
-  if LogSwitch = On then
-    writeln('Old base directory: ' + OldBaseDir.ToNative);
-
-  // Try to get bundle path - UltraStarDeluxe.app/Contents contains all the default files and folders.
-  bundleName := 'UltraStarDeluxe.app';
-  mainBundle := CFBundleGetMainBundle();
-  resourcesURL := CFBundleCopyResourcesDirectoryURL(mainBundle);
-  SetLength(bundlePath, PATH_MAX);
-  success := CFURLGetFileSystemRepresentation(resourcesURL, TRUE, PChar(bundlePath), PATH_MAX);
-  if resourcesURL <> nil then
-    CFRelease(resourcesURL);
-
-  if success then
-  begin
-    if LogSwitch = On then
-      writeln('BundlePath: ', bundlePath);
-    Position := pos(bundleName, bundlePath);
-    success := Position > 0;  // Only consider it a success if we found the bundle marker
-
-    if success then
-    begin
-      setlength(bundlePath, Position + Length(bundleName) - 1);
-      success := DirectoryExists(bundlePath);  // Verify the path exists
-
-      if success then
-      begin
-        chdir(bundlePath);
-        BaseDir := FileSystem.GetCurrentDir();
-        BaseDir := BaseDir.Append('Contents');
-
-        if LogSwitch = On then
-          writeln('Running from app bundle');
-      end;
-    end;
-  end;
-
-  // Fallback: Use executable directory
-  if not success then
-  begin
-    writeln('Warning: Not running from app bundle, using executable directory');
-    BaseDir := GetExecutionDir();
-    if LogSwitch = On then
-      writeln('Using base directory: ' + BaseDir.ToNative);
-  end;
-
-  FileSystem.SetCurrentDir(BaseDir);
-
-  // Right now, only $HOME/Library/Application Support/UltraStarDeluxe_[USDX_VERSION] is used.
-  UserPath := GetGameUserPath();
-  if LogSwitch = On then
-    writeln('User path: ' + UserPath.ToNative);
-
-  DirectoryIsFinished := 0;
-  // replace with IInterfaceList
-  DirectoryList := TInterfaceList.Create();
-  FileList := TInterfaceList.Create();
-  DirectoryList.Add(Path('.'));
-
-  // create the folder and file lists
-  repeat
-    RelativePath := (DirectoryList[DirectoryIsFinished] as IPath);
-    FileSystem.SetCurrentDir(BaseDir.Append(RelativePath));
-    Iter := FileSystem.FileFind(Path('*'), faAnyFile);
-    while (Iter.HasNext) do
-    begin
-      FileInfo := Iter.Next;
-      CurPath := FileInfo.Name;
-      if LogSwitch = On then
-        writeln('Current path: ' + CurPath.ToNative);
-      if CurPath.IsDirectory() then
-      begin
-        if (not CurPath.Equals('.')) and
-	   (not CurPath.Equals('..')) and
-	   (not CurPath.Equals('MacOS')) then
-          DirectoryList.Add(RelativePath.Append(CurPath));
-      end
-      else
-        Filelist.Add(RelativePath.Append(CurPath));
-    end;
-    Inc(DirectoryIsFinished);
-  until (DirectoryIsFinished = DirectoryList.Count);
-
-  // create missing folders
-  UserPath.CreateDirectory(true); // should not be necessary since (UserPathName+'/.') is created.
-  for I := 0 to DirectoryList.Count-1 do
-  begin
-    CurPath          := DirectoryList[I] as IPath;
-    if LogSwitch = On then
-      writeln('Current path: ' + CurPath.ToNative);
-    DirectoryPath    := UserPath.Append(CurPath);
-    if LogSwitch = On then
-      writeln('Directory path: ' + DirectoryPath.ToNative);
-    CreatedDirectory := DirectoryPath.CreateDirectory();
-    FileAttrs        := DirectoryPath.GetAttr();
-    // Maybe analyse the target of the link with FpReadlink().
-    // Let's assume the symlink is pointing to an existing directory.
-    if (not CreatedDirectory) and (FileAttrs and faSymLink > 0) then
-      writeln('Failed to create the folder "' +
-              DirectoryPath.ToNative +
-              '" in PlatformMacOS.CreateUserFolders');
-  end;
-
-  // copy missing files
-  for I := 0 to Filelist.Count-1 do
-  begin
-    CurPath := Filelist[I] as IPath;
-    if LogSwitch = On then
-      writeln('Current path: ' + CurPath.ToNative);
-    SrcFile := BaseDir.Append(CurPath);
-    TgtFile := UserPath.Append(CurPath);
-    SrcFile.CopyFile(TgtFile, true);
-  end;
-
-  // go back to the initial folder
-  FileSystem.SetCurrentDir(OldBaseDir);
-end;
-
-function TPlatformMacOS.GetBundlePath: IPath;
-begin
-  // Mac applications are packaged in folders.
-  // Cutting the last two folders yields the application folder.
-  Result := GetExecutionDir().GetParent().GetParent();
-  if LogSwitch = On then
-    writeln('Bundle path: ' + Result.ToNative);
+  // we just check if the 'languages' folder exists in the
+  // directory of the executable. If so -> local execution.
+  ExecutionDir := GetExecutionDir();
+  LanguageDir := ExecutionDir.Append('languages');
+  IsLocal := LanguageDir.IsDirectory and not ExecutionDir.IsReadonly;
+  BundleDir := ExecutionDir.GetParent().GetParent();
+  if string(BundleDir.RemovePathDelim().ToUTF8()).EndsWith('.app') then
+    IsBundle := true
+  else
+    BundleDir := PATH_NONE;
 end;
 
 function TPlatformMacOS.GetHomeDir: IPath;
 begin
   Result := Path(GetEnvironmentVariable('HOME'));
-  if LogSwitch = On then
-    writeln('Home path: ' + Result.ToNative);
 end;
 
 function TPlatformMacOS.GetApplicationSupportPath: IPath;
 begin
 // append the version for conflict resolution
-  Result := GetHomeDir.Append('Library/Application Support/UltraStarDeluxe' + USDX_VERSION, pdAppend);
+  Result := GetHomeDir.Append('Library/Application Support/UltraStar Deluxe', pdAppend);
 end;
 
 function TPlatformMacOS.GetLogPath: IPath;
 begin
-  Result := GetHomeDir.Append('Library/Logs/UltraStar Deluxe', pdAppend);
+  if (IsLocal) then
+    Result := Path(ExecutionDir.ToNative())
+  else
+    Result := GetHomeDir.Append('Library/Logs/UltraStar Deluxe', pdAppend)
 end;
 
 function TPlatformMacOS.GetMusicPath: IPath;
 begin
   Result := GetHomeDir.Append('Music/UltraStar Deluxe', pdAppend);
-  if LogSwitch = On then
-    writeln('Music path: ' + Result.ToNative);
 end;
 
 function TPlatformMacOS.GetGameSharedPath: IPath;
 begin
-  Result := GetApplicationSupportPath;
+  if (IsBundle) then
+    Result := BundleDir.Append('Contents')
+  else if (IsLocal) then
+    Result := Path(ExecutionDir.ToNative())
+  else
+    Result := Path(INSTALL_DATADIR);
 end;
 
 function TPlatformMacOS.GetGameUserPath: IPath;
 begin
-  Result := GetApplicationSupportPath;
+  if (IsLocal) then
+    Result := Path(ExecutionDir.ToNative())
+  else
+    Result := GetApplicationSupportPath;
+end;
+
+function TPlatformMacOS.GetModifiableAssetPaths: IInterfaceList;
+begin
+  Result := TInterfaceList.Create;
+  if (IsLocal) then
+  begin
+    Result.Add(Path(ExecutionDir.ToNative()));
+    Result.Add(GetApplicationSupportPath());
+  end
+  else if (IsBundle) then
+  begin
+    Result.Add(GetApplicationSupportPath());
+    Result.Add(BundleDir.Append('Contents'));
+  end
+  else
+  begin
+    Result.Add(GetApplicationSupportPath());
+    Result.Add(Path(INSTALL_DATADIR));
+  end;
+end;
+
+function TPlatformMacOS.GetWebsitePaths: IInterfaceList;
+begin
+  Result := TInterfaceList.Create;
+  if (IsLocal) then
+    Result.Add(Path(ExecutionDir.ToNative()));
+  Result.Add(GetApplicationSupportPath());
 end;
 
 end.

--- a/src/base/UPlatformWindows.pas
+++ b/src/base/UPlatformWindows.pas
@@ -56,6 +56,8 @@ type
       function GetLogPath: IPath; override;
       function GetGameSharedPath: IPath; override;
       function GetGameUserPath: IPath; override;
+      function GetModifiableAssetPaths: IInterfaceList; override;
+      function GetWebsitePaths: IInterfaceList; override;
   end;
 
   function GetConsoleWindow: THandle; stdcall; external kernel32 name 'GetConsoleWindow';
@@ -207,6 +209,19 @@ begin
     Result := GetExecutionDir()
   else
     Result := GetSpecialPath(CSIDL_APPDATA).Append('ultrastardx', pdAppend);
+end;
+
+function TPlatformWindows.GetModifiableAssetPaths: IInterfaceList;
+begin
+  Result := TInterfaceList.Create;
+  if (UseLocalDirs) then
+    Result.Add(GetExecutionDir());
+  Result.Add(GetSpecialPath(CSIDL_APPDATA).Append('ultrastardx', pdAppend));
+end;
+
+function TPlatformWindows.GetWebsitePaths: IInterfaceList;
+begin
+  Result := GetModifiableAssetPaths();
 end;
 
 function HasConsole: Boolean;

--- a/src/base/USkins.pas
+++ b/src/base/USkins.pas
@@ -68,6 +68,7 @@ type
     function GetDefaultColor(SkinNo: integer): integer;
 
     procedure GetSkinsByTheme(Theme: string; out Skins: TUTF8StringDynArray);
+    function SkinExists(Name, Theme: string): boolean;
 
     procedure onThemeChange;
   end;
@@ -100,13 +101,17 @@ procedure TSkin.LoadList;
 var
   Iter: IFileIterator;
   DirInfo: TFileInfo;
+  I: integer;
 begin
-  Iter := FileSystem.FileFind(SkinsPath.Append('*'), faDirectory);
-  while Iter.HasNext do
+  for I := 0 to ThemePaths.Count - 1 do
   begin
-    DirInfo := Iter.Next();
-    if (not DirInfo.Name.Equals('.')) and (not DirInfo.Name.Equals('..')) then
-      ParseDir(SkinsPath.Append(DirInfo.Name, pdAppend));
+    Iter := FileSystem.FileFind(IPath(ThemePaths[I]).Append('*'), faDirectory);
+    while Iter.HasNext do
+    begin
+      DirInfo := Iter.Next();
+      if (not DirInfo.Name.Equals('.')) and (not DirInfo.Name.Equals('..')) then
+        ParseDir(IPath(ThemePaths[I]).Append(DirInfo.Name, pdAppend));
+    end;
   end;
 end;
 
@@ -127,19 +132,23 @@ procedure TSkin.LoadHeader(FileName: IPath);
 var
   SkinIni: TMemIniFile;
   S:       integer;
+  Theme, Name: string;
 begin
   SkinIni := TMemIniFile.Create(FileName.ToNative);
+  Theme    := SkinIni.ReadString('Skin', 'Theme', '');
+  Name     := SkinIni.ReadString('Skin', 'Name', '');
+  if (not SkinExists(Name, Theme)) then
+  begin
+    S := Length(Skin);
+    SetLength(Skin, S+1);
 
-  S := Length(Skin);
-  SetLength(Skin, S+1);
-  
-  Skin[S].Path     := FileName.GetPath;
-  Skin[S].FileName := FileName.GetName;
-  Skin[S].Theme    := SkinIni.ReadString('Skin', 'Theme', '');
-  Skin[S].Name     := SkinIni.ReadString('Skin', 'Name', '');
-  Skin[S].Creator  := SkinIni.ReadString('Skin', 'Creator', '');
-  Skin[S].DefaultColor := Max(0, GetArrayIndex(IColor, SkinIni.ReadString('Skin', 'Color', ''), true));
-
+    Skin[S].Path     := FileName.GetPath;
+    Skin[S].FileName := FileName.GetName;
+    Skin[S].Theme    := Theme;
+    Skin[S].Name     := Name;
+    Skin[S].Creator  := SkinIni.ReadString('Skin', 'Creator', '');
+    Skin[S].DefaultColor := Max(0, GetArrayIndex(IColor, SkinIni.ReadString('Skin', 'Color', ''), true));
+  end;
   SkinIni.Free;
 end;
 
@@ -237,6 +246,21 @@ begin
         Break;
       end;
     end;
+end;
+
+function TSkin.SkinExists(Name, Theme: string): boolean;
+var
+  I: integer;
+begin
+  Result := false;
+  for I := Low(Skin) to High(Skin) do
+  begin
+    if ((Name = Skin[I].Name) and (Theme = Skin[I].Theme)) then
+    begin
+      Result := true;
+      Exit;
+    end;
+  end;
 end;
 
 procedure TSkin.onThemeChange;

--- a/src/base/UText.pas
+++ b/src/base/UText.pas
@@ -107,10 +107,12 @@ const
 {**
  * Returns either Filename if it is absolute or a path relative to FontPath.
  *}
-function FindFontFile(const Filename: string): IPath;
+function FindFontFile(const IniPath: IPath; const Filename: string): IPath;
+var
+  I: integer;
+  FilePath: IPath;
 begin
-  Result := FontPath.Append(Filename);
-  // if path does not exist, try as an absolute path
+  Result := IniPath.Append(Filename);
   if (not Result.IsFile) then
     Result := Path(Filename);
 end;
@@ -123,11 +125,24 @@ procedure LoadFontFamilyNames;
 var
   FontNameIndex: integer;
   FontIni: TMemIniFile;
+  FontIniPath: IPath;
+  I: integer;
 begin
   CurrentFont.FontFamily := 0;
   CurrentFont.FontStyle := 0;
 
-  FontIni := TMemIniFile.Create(FontPath.Append('fonts.ini').ToNative);
+  FontIni := nil;
+  for I := 0 to FontPaths.Count - 1 do
+  begin
+    FontIniPath := IPath(FontPaths[I]).Append('fonts.ini');
+    if FontIniPath.IsFile then
+    begin
+      FontIni := TMemIniFile.Create(FontIniPath.ToNative);
+      break;
+    end;
+  end;
+  if (FontIni = nil) then
+    raise Exception.Create('Could not find fonts.ini file');
 
   // each section describes one font family
   FontSections := TStringList.Create;
@@ -155,6 +170,7 @@ procedure BuildFonts;
 var
   FontNameIndex, FontStyleIndex, FallbackIndex: integer;
   FontIni: TMemIniFile;
+  FontIniPath: IPath;
   FontFile: IPath;
   FontMaxResolution: Integer;
   FontPreCache: Integer;
@@ -162,8 +178,20 @@ var
   Embolden: single;
   OutlineFont: TFTScalableOutlineFont;
   SectionName: string;
+  I: integer;
 begin
-  FontIni := TMemIniFile.Create(FontPath.Append('fonts.ini').ToNative);
+  FontIni := nil;
+  for I := 0 to FontPaths.Count - 1 do
+  begin
+    FontIniPath := IPath(FontPaths[I]).Append('fonts.ini');
+    if FontIniPath.IsFile then
+    begin
+      FontIni := TMemIniFile.Create(FontIniPath.ToNative);
+      break;
+    end;
+  end;
+  if (FontIni = nil) then
+    raise Exception.Create('Could not find fonts.ini file');
 
   try
     for FontNameIndex := 0 to FontSections.Count-1 do
@@ -171,7 +199,7 @@ begin
       for FontStyleIndex := 0 to High(FONT_STYLES) do
       begin
         SectionName := FontSections[FontNameIndex];
-        FontFile := FindFontFile(FontIni.ReadString(SectionName, FONT_STYLES[FontStyleIndex] + 'File', ''));
+        FontFile := FindFontFile(FontIniPath.GetDir, FontIni.ReadString(SectionName, FONT_STYLES[FontStyleIndex] + 'File', ''));
         if (FontFile.Equals(PATH_NONE)) then
           Continue;
 
@@ -217,7 +245,7 @@ begin
 
         for FallbackIndex := 1 to 25 do
         begin
-          FontFile := FindFontFile(FontIni.ReadString(SectionName , FONT_STYLES[FontStyleIndex] + 'FallbackFile' + IntToStr(FallbackIndex), ''));
+          FontFile := FindFontFile(FontIniPath.GetDir, FontIni.ReadString(SectionName , FONT_STYLES[FontStyleIndex] + 'FallbackFile' + IntToStr(FallbackIndex), ''));
           if (FontFile.Equals(PATH_NONE)) then
             Continue;
           try

--- a/src/base/UThemes.pas
+++ b/src/base/UThemes.pas
@@ -1210,6 +1210,7 @@ type
     constructor Create;
 
     procedure LoadList;
+    function ThemeExists(Name: string): boolean;
 
     function LoadTheme(ThemeNum: integer; sColor: integer): boolean; // Load some theme settings from file
 
@@ -1384,17 +1385,20 @@ procedure TTheme.LoadHeader(FileName: IPath);
     Len: integer;
     Skins: TUTF8StringDynArray;
 begin
-  Entry.Filename := ThemePath.Append(FileName);
+  Entry.Filename := Path(FileName.ToNative());
   //read info from theme header
   Ini := TMemIniFile.Create(Entry.Filename.ToNative);
 
-  Entry.Name := Ini.ReadString('Theme', 'Name', FileName.SetExtension('').ToNative);
+  Entry.Name := Ini.ReadString('Theme', 'Name', FileName.GetName().SetExtension('').ToNative);
   Entry.BaseTheme := Ini.ReadString('Theme', 'BaseTheme', '');
   ThemeVersion := Trim(UpperCase(Ini.ReadString('Theme', 'US_Version', 'no version tag')));
   Entry.Creator := Ini.ReadString('Theme', 'Creator', 'Unknown');
   SkinName := Ini.ReadString('Theme', 'DefaultSkin', FileName.SetExtension('').ToNative);
 
   Ini.Free;
+
+  if (ThemeExists(Entry.Name)) then
+    Exit;
 
   // don't load theme with wrong version tag
   if ThemeVersion <> 'USD 110' then
@@ -1434,15 +1438,35 @@ procedure TTheme.LoadList;
   var
     Iter: IFileIterator;
     FileInfo: TFileInfo;
+    I: integer;
+    ThemePath: IPath;
 begin
-  Log.LogStatus('Searching for Theme : ' + ThemePath.ToNative + '*.ini', 'Theme.LoadList');
-
-  Iter := FileSystem.FileFind(ThemePath.Append('*.ini'), 0);
-  while (Iter.HasNext) do
+  for I := 0 to ThemePaths.Count - 1 do
   begin
-    FileInfo := Iter.Next;
-    Log.LogStatus('Found Theme: ' + FileInfo.Name.ToNative, 'Theme.LoadList');
-    LoadHeader(Fileinfo.Name);
+    ThemePath := IPath(ThemePaths[I]);
+    Log.LogStatus('Searching for Theme : ' + ThemePath.ToNative + '*.ini', 'Theme.LoadList');
+    Iter := FileSystem.FileFind(ThemePath.Append('*.ini'), 0);
+    while (Iter.HasNext) do
+    begin
+      FileInfo := Iter.Next;
+      Log.LogStatus('Found Theme: ' + FileInfo.Name.ToNative, 'Theme.LoadList');
+      LoadHeader(ThemePath.Append(Fileinfo.Name));
+    end;
+  end;
+end;
+
+function TTheme.ThemeExists(Name: string): boolean;
+var
+  I: integer;
+begin
+  Result := false;
+  for I := Low(Themes) to High(Themes) do
+  begin
+    if (Themes[I].Name = Name) then
+    begin
+      Result := true;
+      Exit;
+    end;
   end;
 end;
 

--- a/src/config.inc.in
+++ b/src/config.inc.in
@@ -54,7 +54,6 @@
 
 {$@DEFINE_HAVE_PROJECTM@ HaveProjectM}
 {$IF Defined(HaveProjectM) and Defined(IncludeConstants)}
-  ProjectM_DataDir = 'visuals/projectM';
   PROJECTM_VERSION_MAJOR   = @libprojectM_VERSION_MAJOR@;
   PROJECTM_VERSION_MINOR   = @libprojectM_VERSION_MINOR@;
   PROJECTM_VERSION_RELEASE = @libprojectM_VERSION_RELEASE@;

--- a/src/lua/ULuaCore.pas
+++ b/src/lua/ULuaCore.pas
@@ -64,6 +64,7 @@ type
     private
       iId:        integer;
       Filename:   IPath;
+      pBaseName:  IPath;
       State:      Plua_State; //< all functions of this plugin are called with this Lua state
       bPaused:    boolean;    //< If true no lua functions from this state are called
       ErrorCount: integer;    //< counts the errors that occured during function calls of this plugin
@@ -88,6 +89,7 @@ type
       property CountErrors: integer read ErrorCount;
 
       property LuaState:    Plua_State read State;
+      property BaseName: IPath read pBaseName;
 
       procedure Load;
 
@@ -133,6 +135,7 @@ type
       Modules: array of TLuaModule; //< modules that has been registered, has to be proctected because fucntions of this unit need to get access
 
       function GetModuleIdByName(Name: string): integer; // returns id of given module, or -1 if module is not found
+      function PluginExists(const Plugin: UTF8String): boolean;
     public
       constructor Create;
       destructor Destroy; override;
@@ -241,15 +244,33 @@ begin
   inherited;
 end;
 
+function TLuaCore.PluginExists(const Plugin: UTF8String): boolean;
+var
+  I: integer;
+begin
+  Result := false;
+  for I := Low(Plugins) to High(Plugins) do
+  begin
+    if (Plugins[I].BaseName.ToUTF8() = Plugin) then
+    begin
+      Result := true;
+      Exit;
+    end;
+  end;
+end;
+
 { calls BrowseDir with plugin dir and LoadingFinished eventchain }
 procedure TLuaCore.LoadPlugins;
+var
+  I: integer;
 begin
   // we have to create event here, because in create it can
   // not be registered, because LuaCore is no assigned
   if (not Assigned(eLoadingFinished)) then
     eLoadingFinished := THookableEvent.Create('Usdx.LoadingFinished');
 
-  BrowseDir(PluginPath);
+  for I := 0 to PluginPaths.Count - 1 do
+    BrowseDir(IPath(PluginPaths[I]));
   eLoadingFinished.CallHookChain(false);
 end;
 
@@ -288,9 +309,11 @@ end;
 { tries to load filename with lua and creates the default
   usdx lua environment for the plugins state }
 procedure TLuaCore.LoadPlugin(Filename: IPath);
-  var
-    Len: integer;  
+var
+  I, Len: integer;
 begin
+  if (PluginExists(Filename.GetName().ToUTF8())) then
+    Exit;
   Len := Length(Plugins);
   SetLength(Plugins, Len + 1);
   Plugins[Len] := TLuaPlugin.Create(Filename, Len);
@@ -665,6 +688,7 @@ begin
   inherited Create;
   Self.iId := Id;
   Self.Filename := Filename;
+  Self.pBaseName := Filename.GetName;
 
   // set some default attributes
   Self.bPaused    := false;

--- a/src/media/UVisualizer.pas
+++ b/src/media/UVisualizer.pas
@@ -55,6 +55,7 @@ uses
   UMain,
   UConfig,
   UPath,
+  UPathUtils,
   UPlatform,
   URenderer,
   URenderer_OpenGL,
@@ -175,7 +176,8 @@ end;
 
 function TVideoPlayback_ProjectM.Init(): boolean;
 var
-  ProjectMPath: IPath;
+  ProjectMConfigPath: IPath;
+  I: integer;
 begin
   Result := false;
   if (fInitialized) then
@@ -201,16 +203,21 @@ begin
     Exit;
   end;
 
-  ProjectMPath := Path(ProjectM_DataDir, pdAppend);
-  if not ProjectMPath.IsAbsolute then
-    ProjectMPath := Platform.GetGameSharedPath.Append(ProjectMPath);
-
-  if (not SetParameters(ProjectMPath.Append('config.inp'))) then
+  for I := 0 to VisualsPaths.Count - 1 do
   begin
-    projectm_destroy(Handle);
-    Handle := nil;
-    Exit;
+    ProjectMConfigPath := IPath(VisualsPaths[I]).Append('config.inp');
+    if (ProjectMConfigPath.IsFile) then
+    begin
+      if (not SetParameters(ProjectMConfigPath)) then
+      begin
+        projectm_destroy(Handle);
+        Handle := nil;
+        Exit;
+      end;
+      Break;
+    end;
   end;
+
   Randomize;
   PresetOrder := RandomPermute(Length(Presets));
   PresetIdx := 0;
@@ -235,7 +242,7 @@ begin
   IniFile := TIniFile.Create(ConfigPath.ToNative, [ifoWriteStringBoolean, ifoStripComments]);
   PresetPath := Path(IniFile.ReadString('ProjectM', 'Preset Path', ''));
   if not PresetPath.IsAbsolute then
-    PresetPath := Platform.GetGameSharedPath.Append(PresetPath);
+    PresetPath := ConfigPath.GetDir().Append(PresetPath);
   if ((PresetPath.ToUTF8() = '') or (not PresetPath.Exists())) then
   begin
     Log.LogError('Invalid ProjectM Preset Path', 'TVideoPlayback_ProjectM.SetParameters');

--- a/src/screens/UScreenEditConvert.pas
+++ b/src/screens/UScreenEditConvert.pas
@@ -193,7 +193,8 @@ uses
   UTextEncoding,
   UUnicodeUtils,
   SysUtils,
-  UText;
+  UText,
+  UPlatform;
 
 const
   // MIDI/KAR lyrics are specified to be ASCII only.
@@ -258,7 +259,7 @@ begin
           begin
             IsFileOpen := true;
             AudioPlayback.PlaySound(SoundLib.Start);
-            ScreenOpen.Filename := GamePath.Append('file.mid');
+            ScreenOpen.Filename := Platform.GetGameUserPath().Append('file.mid');
             ScreenOpen.BackScreen := @ScreenEditConvert;
             FadeTo(@ScreenOpen);
           end

--- a/src/screens/UScreenName.pas
+++ b/src/screens/UScreenName.pas
@@ -85,7 +85,7 @@ type
       APlayerColor: array of integer;
 
       PlayerAvatarButton: array of integer;
-      PlayerAvatarButtonMD5: array of UTF8String;
+
     public
       Goto_SingScreen: boolean; //If true then next Screen in SingScreen
       
@@ -374,7 +374,7 @@ begin
             Player[I-1].Name := PlayerNames[I-1];
             Player[I-1].Level := PlayerLevel[I-1];
 
-            Ini.PlayerAvatar[I-1] := PlayerAvatarButtonMD5[PlayerAvatars[I-1]];
+            Ini.PlayerAvatar[I-1] := AvatarsMD5[PlayerAvatars[I-1]];
 
             if (PlayerAvatars[I-1] = 0) then
             begin
@@ -537,12 +537,9 @@ procedure TScreenName.GenerateAvatars();
 var
   I: integer;
   Avatar: TAvatar;
-  AvatarFile: IPath;
-  Hash: string;
 begin
 
   SetLength(PlayerAvatarButton, Length(AvatarsList) + 1);
-  SetLength(PlayerAvatarButtonMD5, Length(AvatarsList) + 1);
 
   // 1st no-avatar dummy
   for I := 1 to UIni.IMaxPlayerCount do
@@ -564,13 +561,8 @@ begin
     // create avatar
     PlayerAvatarButton[I] := AddButton(Theme.Name.PlayerAvatar);
 
-    AvatarFile := AvatarsList[I];
-
-    Hash := MD5Print(MD5File(AvatarFile.ToNative));
-    PlayerAvatarButtonMD5[I] := UpperCase(Hash);
-
     // load avatar directly from its file
-    Avatar := Avatars.AddAvatar(AvatarFile);
+    Avatar := Avatars.AddAvatar(AvatarsList[I]);
 
     if (Avatar <> nil) then
     begin
@@ -883,7 +875,7 @@ begin
   begin
     PlayerNames[I] := Ini.Name[I];
     PlayerLevel[I] := Ini.PlayerLevel[I];
-    PlayerAvatars[I] := GetArrayIndex(PlayerAvatarButtonMD5, Ini.PlayerAvatar[I]);
+    PlayerAvatars[I] := GetArrayIndex(AvatarsMD5, Ini.PlayerAvatar[I]);
     // if it is -1 then the current saved md5 does not exist anymore (file has changed or was deleted entirely)
     // setting it to 0 just resets it to the colorized default avatar
     if (PlayerAvatars[I] = -1) then


### PR DESCRIPTION
This PR significantly refactors the file search logic for the game assets. My reasons for doing this are two-fold.

The first is to implement the longstanding feature request of supporting custom themes and avatars that are stored in user directories (#715 #768 https://github.com/flathub/eu.usdx.UltraStarDeluxe/issues/8).

The second is to fix the very ugly hack used by the macOS version where the game copies all of the default game assets into a folder in the user's home directory upon startup. This user folder is unique to the particular release version being run, which means that every time you install a new release, you have to manually migrate your existing user data (config, scores, etc.) into the new folder. The behavior of the Mac version has been changed to be the same as the Linux version, with the appropriate folders substituted per Mac convention.

The code was refactored to support loading from multiple paths for certain assets which we expect that some users may  want to modify themselves. These include:
- Themes/Skins
- Avatars
- Fonts
- ProjectM config file and presets
- Lua plugins
- High Score plugins

The game will search for these assets in two directories, with logic added to detect duplicates. If the same asset exists in both directories, the first one will be used.

The only small breaking change in this PR is that in the Linux version, when running as installed, the game no longer looks for high score plugins in `/usr/share/ultrastardx/webs`. The reason is because binary files are not supposed to go into the `share` directory per Unix convention. The replacement is `~/.ultrastardx/webs` in the user's home directory.

Besides this, there are no breaking changes for existing installations. The new user asset directories are completely optional to use.

I prepared the following table to summarize the file search paths logic per platform and execution type:

|Asset Type|Windows|Mac|Linux|
|---|---------|-----|-----|
|Config file|`<EXECUTABLE_DIR>\config.ini`|If local build:`<EXECUTABLE_DIR>/config.ini`<br><br>If running from App bundle: `~/Library/Application Support/UltraStar Deluxe/config.ini`|If local build: `<EXECUTABLE_DIR>/config.ini`<br><br>If installed: `~/.ultrastardx/config.ini`|
|Score file|`<EXECUTABLE_DIR>\Ultrastar.db`|If local build: `<EXECUTABLE_DIR>/Ultrastar.db`<br><br>If running from App bundle: `~/Library/Application Support/UltraStar Deluxe/Ultrastar.db`|If local build: `<EXECUTABLE_DIR>/Ultrastar.db`<br><br>If installed: `~/.ultrastardx/Ultrastar.db`|
|Themes/Skins|1. `<EXECUTABLE_DIR>\themes`<br>2. `%APPDATA%\ultrastardx\themes`|If local build:<br> 1. `<EXECUTABLE_DIR>/themes`<br>2. `~/Library/Application Support/UltraStar Deluxe/themes`<br><br>If running from App bundle:<br>1. `~/Library/Application Support/UltraStar Deluxe/themes`<br>2. `<BUNDLE_DIR>/Contents/themes`|If local build:<br> 1. `<EXECUTABLE_DIR>/themes`<br>2. `~/.ultrastardx/themes`<br><br>If installed:<br>1. `~/.ultrastardx/themes`<br>2. `<INSTALL_PREFIX>/share/ultrastardx/themes`|
|Avatars|1. `<EXECUTABLE_DIR>\avatars`<br>2. `%APPDATA%\ultrastardx\avatars`|If local build:<br> 1. `<EXECUTABLE_DIR>/avatars`<br>2. `~/Library/Application Support/UltraStar Deluxe/avatars`<br><br>If running from App bundle:<br>1. `~/Library/Application Support/UltraStar Deluxe/avatars`<br>2. `<BUNDLE_DIR>/Contents/avatars`|If local build:<br> 1. `<EXECUTABLE_DIR>/avatars`<br>2. `~/.ultrastardx/avatars`<br><br>If installed:<br>1. `~/.ultrastardx/avatars`<br>2. `<INSTALL_PREFIX>/share/ultrastardx/avatars`|
|Fonts|1. `<EXECUTABLE_DIR>\fonts`<br>2. `%APPDATA%\ultrastardx\fonts`|If local build:<br> 1. `<EXECUTABLE_DIR>/fonts`<br>2. `~/Library/Application Support/UltraStar Deluxe/fonts`<br><br>If running from App bundle:<br>1. `~/Library/Application Support/UltraStar Deluxe/fonts`<br>2. `<BUNDLE_DIR>/Contents/fonts`|If local build:<br> 1. `<EXECUTABLE_DIR>/fonts`<br>2. `~/.ultrastardx/fonts`<br><br>If installed:<br>1. `~/.ultrastardx/fonts`<br>2. `<INSTALL_PREFIX>/share/ultrastardx/fonts`|
|ProjectM|1. `<EXECUTABLE_DIR>\visuals`<br>2. `%APPDATA%\ultrastardx\visuals`|If local build:<br> 1. `<EXECUTABLE_DIR>/visuals`<br>2. `~/Library/Application Support/UltraStar Deluxe/visuals`<br><br>If running from App bundle:<br>1. `~/Library/Application Support/UltraStar Deluxe/visuals`<br>2. `<BUNDLE_DIR>/Contents/visuals`|If local build:<br> 1. `<EXECUTABLE_DIR>/visuals`<br>2. `~/.ultrastardx/visuals`<br><br>If installed:<br>1. `~/.ultrastardx/visuals`<br>2. `<INSTALL_PREFIX>/share/ultrastardx/visuals`|
|Lua Plugins|1. `<EXECUTABLE_DIR>\plugins`<br>2. `%APPDATA%\ultrastardx\plugins`|If local build:<br> 1. `<EXECUTABLE_DIR>/plugins`<br>2. `~/Library/Application Support/UltraStar Deluxe/plugins`<br><br>If running from App bundle:<br>1. `~/Library/Application Support/UltraStar Deluxe/plugins`<br>2. `<BUNDLE_DIR>/Contents/plugins`|If local build:<br> 1. `<EXECUTABLE_DIR>/plugins`<br>2. `~/.ultrastardx/plugins`<br><br>If installed:<br>1. `~/.ultrastardx/plugins`<br>2. `<INSTALL_PREFIX>/share/ultrastardx/plugins`|
|High Score Plugins|1. `<EXECUTABLE_DIR>\webs`<br>2. `%APPDATA%\ultrastardx\webs`|If local build:<br> 1. `<EXECUTABLE_DIR>/webs`<br>2. `~/Library/Application Support/UltraStar Deluxe/webs`<br><br>If running from App bundle: `~/Library/Application Support/UltraStar Deluxe/webs`<br><br>|If local build:<br> 1. `<EXECUTABLE_DIR>/webs`<br>2. `~/.ultrastardx/webs`<br><br>If installed: `~/.ultrastardx/webs`<br>|


Fixes #715
Fixes #768

